### PR TITLE
Reject string literals containing port numbers out-of-range when resolving service names

### DIFF
--- a/groups/nts/ntsb/ntsb_resolver.t.cpp
+++ b/groups/nts/ntsb/ntsb_resolver.t.cpp
@@ -3161,6 +3161,47 @@ NTSCFG_TEST_CASE(10)
     NTSCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
 
+NTSCFG_TEST_CASE(11)
+{
+    // Concern: Test resolution of a service name expressed as a port number.
+    //
+    // Plan:
+
+    ntscfg::TestAllocator ta;
+    {
+        ntsa::Error error;
+
+        ntsb::Resolver resolver(&ta);
+
+        {
+            ntsa::PortOptions       portOptions;
+            bsl::vector<ntsa::Port> portList;
+
+            error = resolver.getPort(
+                &portList, bslstl::StringRef("7000", 4), portOptions);
+            NTSCFG_TEST_EQ(error, ntsa::Error());
+
+            NTSCFG_TEST_EQ(portList.size(), 1);
+
+            NTSCFG_TEST_LOG_DEBUG << "Port = " << portList[0]
+                                  << NTSCFG_TEST_LOG_END;
+
+            NTSCFG_TEST_EQ(portList[0], 7000);
+        }
+
+        {
+            ntsa::PortOptions       portOptions;
+            bsl::vector<ntsa::Port> portList;
+
+            error = resolver.getPort(
+                &portList, bslstl::StringRef("70000", 5), portOptions);
+            NTSCFG_TEST_EQ(error, ntsa::Error(ntsa::Error::e_INVALID));
+        }
+
+    }
+    NTSCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
 NTSCFG_TEST_DRIVER
 {
     NTSCFG_TEST_REGISTER(1);
@@ -3175,5 +3216,7 @@ NTSCFG_TEST_DRIVER
     NTSCFG_TEST_REGISTER(9);
 
     NTSCFG_TEST_REGISTER(10);
+
+    NTSCFG_TEST_REGISTER(11);
 }
 NTSCFG_TEST_DRIVER_END;


### PR DESCRIPTION
This PR fixes a bug in `ntsu_resolver` when resolving a service name to a port number. The implementation is intended to resolve a service name to a port number as found in "/etc/services", but also intended to resolve a service name containing stringified number, e.g. resolving the service name "80" should return `80`. The implementation calls [getaddrinfo](https://pubs.opengroup.org/onlinepubs/009604599/functions/getaddrinfo.html) to resolver/convert the service name to a port number. This function correctly converts a stringified port number <= `USHRT_MAX` but fails to return an error if the stringified port number > `USHRT_MAX` (i.e. the port number outside the valid TCP/UDP port range.) Both Linux and Windows successfully return a truncated integer. POSIX does not specify error handling for this case of input to `getaddrinfo`.

This PR fixes this bug by attempting to parse the service name as an integer, only calling `getaddrinfo` if the service name is neither a number nor an out-of-range number.