### PR TITLE
rework parsing of port number

### DIFF
--- a/groups/nts/ntsb/ntsb_resolver.t.cpp
+++ b/groups/nts/ntsb/ntsb_resolver.t.cpp
@@ -3177,20 +3177,23 @@ NTSCFG_TEST_CASE(11)
         {
             bsl::vector<ntsa::Port> portList;
 
-            error = resolver.getPort(
-                &portList, bslstl::StringRef("70", 1), portOptions);
+            error = resolver.getPort(&portList,
+                                     bslstl::StringRef("70", 1),
+                                     portOptions);
             NTSCFG_TEST_EQ(error, ntsa::Error());
             NTSCFG_TEST_EQ(portList.size(), 1);
             NTSCFG_TEST_EQ(portList[0], 7);
 
-            error = resolver.getPort(
-                &portList, bslstl::StringRef(" +70 "), portOptions);
+            error = resolver.getPort(&portList,
+                                     bslstl::StringRef(" +70 "),
+                                     portOptions);
             NTSCFG_TEST_EQ(error, ntsa::Error());
             NTSCFG_TEST_EQ(portList.size(), 1);
             NTSCFG_TEST_EQ(portList[0], 70);
 
-            error = resolver.getPort(
-                &portList, bslstl::StringRef("7000"), portOptions);
+            error = resolver.getPort(&portList,
+                                     bslstl::StringRef("7000"),
+                                     portOptions);
             NTSCFG_TEST_EQ(error, ntsa::Error());
             NTSCFG_TEST_EQ(portList.size(), 1);
             NTSCFG_TEST_EQ(portList[0], 7000);
@@ -3199,12 +3202,14 @@ NTSCFG_TEST_CASE(11)
         {
             bsl::vector<ntsa::Port> portList;
 
-            error = resolver.getPort(
-                &portList, bslstl::StringRef("7a"), portOptions);
+            error = resolver.getPort(&portList,
+                                     bslstl::StringRef("7a"),
+                                     portOptions);
             NTSCFG_TEST_EQ(error, ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED));
 
-            error = resolver.getPort(
-                &portList, bslstl::StringRef("70000", 5), portOptions);
+            error = resolver.getPort(&portList,
+                                     bslstl::StringRef("70000", 5),
+                                     portOptions);
             NTSCFG_TEST_EQ(error, ntsa::Error(ntsa::Error::e_INVALID));
 
             error = resolver.getPort(&portList,
@@ -3212,7 +3217,6 @@ NTSCFG_TEST_CASE(11)
                                      portOptions);
             NTSCFG_TEST_EQ(error, ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED));
         }
-
     }
     NTSCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }

--- a/groups/nts/ntsb/ntsb_resolver.t.cpp
+++ b/groups/nts/ntsb/ntsb_resolver.t.cpp
@@ -3171,10 +3171,10 @@ NTSCFG_TEST_CASE(11)
     {
         ntsa::Error error;
 
-        ntsb::Resolver resolver(&ta);
+        ntsb::Resolver    resolver(&ta);
+        ntsa::PortOptions portOptions;
 
         {
-            ntsa::PortOptions       portOptions;
             bsl::vector<ntsa::Port> portList;
 
             error = resolver.getPort(
@@ -3197,8 +3197,11 @@ NTSCFG_TEST_CASE(11)
         }
 
         {
-            ntsa::PortOptions       portOptions;
             bsl::vector<ntsa::Port> portList;
+
+            error = resolver.getPort(
+                &portList, bslstl::StringRef("7a"), portOptions);
+            NTSCFG_TEST_EQ(error, ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED));
 
             error = resolver.getPort(
                 &portList, bslstl::StringRef("70000", 5), portOptions);
@@ -3207,7 +3210,7 @@ NTSCFG_TEST_CASE(11)
             error = resolver.getPort(&portList,
                                      bslstl::StringRef("18446744073709551616"),
                                      portOptions);
-            NTSCFG_TEST_EQ(error, ntsa::Error(ntsa::Error::e_INVALID));
+            NTSCFG_TEST_EQ(error, ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED));
         }
 
     }

--- a/groups/nts/ntsb/ntsb_resolver.t.cpp
+++ b/groups/nts/ntsb/ntsb_resolver.t.cpp
@@ -3178,14 +3178,21 @@ NTSCFG_TEST_CASE(11)
             bsl::vector<ntsa::Port> portList;
 
             error = resolver.getPort(
-                &portList, bslstl::StringRef("7000", 4), portOptions);
+                &portList, bslstl::StringRef("70", 1), portOptions);
             NTSCFG_TEST_EQ(error, ntsa::Error());
-
             NTSCFG_TEST_EQ(portList.size(), 1);
+            NTSCFG_TEST_EQ(portList[0], 7);
 
-            NTSCFG_TEST_LOG_DEBUG << "Port = " << portList[0]
-                                  << NTSCFG_TEST_LOG_END;
+            error = resolver.getPort(
+                &portList, bslstl::StringRef(" +70 "), portOptions);
+            NTSCFG_TEST_EQ(error, ntsa::Error());
+            NTSCFG_TEST_EQ(portList.size(), 1);
+            NTSCFG_TEST_EQ(portList[0], 70);
 
+            error = resolver.getPort(
+                &portList, bslstl::StringRef("7000"), portOptions);
+            NTSCFG_TEST_EQ(error, ntsa::Error());
+            NTSCFG_TEST_EQ(portList.size(), 1);
             NTSCFG_TEST_EQ(portList[0], 7000);
         }
 
@@ -3195,6 +3202,11 @@ NTSCFG_TEST_CASE(11)
 
             error = resolver.getPort(
                 &portList, bslstl::StringRef("70000", 5), portOptions);
+            NTSCFG_TEST_EQ(error, ntsa::Error(ntsa::Error::e_INVALID));
+
+            error = resolver.getPort(&portList,
+                                     bslstl::StringRef("18446744073709551616"),
+                                     portOptions);
             NTSCFG_TEST_EQ(error, ntsa::Error(ntsa::Error::e_INVALID));
         }
 

--- a/groups/nts/ntsu/ntsu_resolverutil.cpp
+++ b/groups/nts/ntsu/ntsu_resolverutil.cpp
@@ -21,10 +21,10 @@ BSLS_IDENT_RCSID(ntsu_resolverutil_cpp, "$Id$ $CSID$")
 #include <ntsu_adapterutil.h>
 #include <ntsu_socketutil.h>
 
-#include <bdlma_bufferedsequentialallocator.h>
 #include <bdlb_chartype.h>
 #include <bdlb_numericparseutil.h>
 #include <bdlb_stringviewutil.h>
+#include <bdlma_bufferedsequentialallocator.h>
 
 #if defined(BSLS_PLATFORM_OS_UNIX)
 #include <arpa/inet.h>
@@ -147,15 +147,15 @@ ntsa::Error convertGetAddrInfoError(int rc)
 // 'source'. Return 'ntsa::Error::e_INVALID' if the 'source' doesn't contain
 // a sequence of characters forming a valid <USHORT> optionally surrounded by
 // whitespace characters and 'ntsa::Error::e_OK' otherwise.
-ntsa::Error parsePortNumber(ntsa::Port*      result,
-                            bsl::string_view source)
+ntsa::Error parsePortNumber(ntsa::Port* result, bsl::string_view source)
 {
     bsl::string_view s = bdlb::StringViewUtil::trim(source);
     bsl::string_view remainder;
 
     unsigned int value = 0;
     if (0 != bdlb::NumericParseUtil::parseUint(&value, &remainder, s) ||
-            !remainder.empty()) {
+        !remainder.empty())
+    {
         return ntsa::Error(ntsa::Error::e_INVALID);
     }
     if (value > USHRT_MAX) {


### PR DESCRIPTION
**Describe your changes**
Rework `parsePortNumber()` impl due to several bugs as demonstrated by additional test cases, specifically:
- whitespace after the number is now allowed
- overflow is detected properly now
- custom num parsing impl removed and ``bdlb::NumericParseUtil::parseUint()` used

**Testing performed**
`ntsb_resolver.t` is verified to build and run on Linux/Solaris
