### PR TITLE
Fix TC 17 in ntsu_socketutil.t

### DIFF
--- a/groups/nts/ntsu/ntsu_socketutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.t.cpp
@@ -5554,7 +5554,7 @@ NTSCFG_TEST_CASE(17)
         // validate RX timestamping functionality
         {
             error =
-                ntsu::SocketOptionUtil::setTimestampIncomingData(server, true);
+                ntsu::SocketOptionUtil::setTimestampIncomingData(client, true);
 #if defined(TIMESTAMPING_SUPPORTED)
             NTSCFG_TEST_OK(error);
 #else  //should faile on other platforms
@@ -5626,7 +5626,7 @@ NTSCFG_TEST_CASE(17)
             // now switch off the option and check that requested timestamp is not available
             {
                 error =
-                    ntsu::SocketOptionUtil::setTimestampIncomingData(server,
+                    ntsu::SocketOptionUtil::setTimestampIncomingData(client,
                                                                      false);
 #if defined(TIMESTAMPING_SUPPORTED)
                 NTSCFG_TEST_OK(error);


### PR DESCRIPTION
*Issue : #8 *

**Describe your changes**
There was a typo in TC 17 in part which verifies RX timestamping functionality for stream sockets. RX timestamping option was incorrectly applied to the sender socket instead of the receiver. 

**Testing performed**
ntsu_socketutil.t is passing now

**Additional context**
The issue was not seen previously because this check is present only if Linux kernel version on building machine is > 3.10. Also, in future this code will be updated (there will be no compile-time dependancy on Linux kernel version).
