### PR TITLE
Return false from ntsa::IpAddress::parse() if an empty string is passed into the method, update test driver

### DIFF
--- a/groups/nts/ntsa/ntsa_ipaddress.cpp
+++ b/groups/nts/ntsa/ntsa_ipaddress.cpp
@@ -76,7 +76,7 @@ bool IpAddress::parse(const bslstl::StringRef& text)
     this->reset();
 
     if (text.empty()) {
-        return true;
+        return false;
     }
 
     bool valid;

--- a/groups/nts/ntsa/ntsa_ipaddress.h
+++ b/groups/nts/ntsa/ntsa_ipaddress.h
@@ -115,7 +115,9 @@ class IpAddress
 
     /// Set the value of this object from the value parsed from any of its
     /// textual representations. Return true if the 'text' is in a valid
-    /// format and was parsed successfully, otherwise return false.
+    /// format and was parsed successfully, otherwise return false. If false
+    /// is returned then the value of this object was set to its value upon
+    /// default construction.
     bool parse(const bslstl::StringRef& text);
 
     /// Select the "v4" address representation. Return a reference to the

--- a/groups/nts/ntsa/ntsa_ipaddress.t.cpp
+++ b/groups/nts/ntsa/ntsa_ipaddress.t.cpp
@@ -53,9 +53,43 @@ NTSCFG_TEST_CASE(2)
     NTSCFG_TEST_EQ(ipAddress.v6(), ntsa::Ipv6Address::loopback());
 }
 
+NTSCFG_TEST_CASE(3)
+{
+    ntsa::IpAddress ipAddress("123.45.67.89");
+
+    const bslstl::StringRef empty;
+    NTSCFG_TEST_FALSE(ipAddress.parse(empty));
+    NTSCFG_TEST_TRUE(ipAddress.isUndefined());
+}
+
+NTSCFG_TEST_CASE(4)
+{
+    ntsa::IpAddress ipAddress;
+
+    const bslstl::StringRef ipv4 = "22.44.66.88";
+    NTSCFG_TEST_TRUE(ipAddress.parse(ipv4));
+    NTSCFG_TEST_FALSE(ipAddress.isUndefined());
+    NTSCFG_TEST_TRUE(ipAddress.isV4());
+    NTSCFG_TEST_EQ(ipAddress.v4(), ntsa::Ipv4Address(ipv4));
+}
+
+NTSCFG_TEST_CASE(5)
+{
+    ntsa::IpAddress ipAddress;
+
+    const bslstl::StringRef ipv6 = "2001:db8:3333:4444:5555:6666:7777:8888";
+    NTSCFG_TEST_TRUE(ipAddress.parse(ipv6));
+    NTSCFG_TEST_FALSE(ipAddress.isUndefined());
+    NTSCFG_TEST_TRUE(ipAddress.isV6());
+    NTSCFG_TEST_EQ(ipAddress.v6(), ntsa::Ipv6Address(ipv6));
+}
+
 NTSCFG_TEST_DRIVER
 {
     NTSCFG_TEST_REGISTER(1);
     NTSCFG_TEST_REGISTER(2);
+    NTSCFG_TEST_REGISTER(3);
+    NTSCFG_TEST_REGISTER(4);
+    NTSCFG_TEST_REGISTER(5);
 }
 NTSCFG_TEST_DRIVER_END;


### PR DESCRIPTION
*Issue : #13*

**Describe your changes**
`bool ntsa::IpAddress::parse(const bslstl::StringRef& text)` now returns false if `text ` is an empty string. Also method contract was updated.

**Testing performed**
`ntsa_ipaddress.t` was extended with some new testcases.

**Additional context**
`ntsa::Error HostDatabase::load(const bsl::shared_ptr<ntcdns::File>& file)` got stuck if `ipAddressStringRef` appeared to be an empty string.
