### PR TITLE
Fix race in gaining/losing interest in socket writability

### DIFF
--- a/groups/ntc/ntcr/ntcr_datagramsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.cpp
@@ -1083,6 +1083,12 @@ ntsa::Error DatagramSocket::privateRelaxFlowControl(
         if (relaxSend) {
             if (context.enableSend()) {
                 if (d_shutdownState.canSend()) {
+                    ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
+                    if (reactorRef) {
+                        reactorRef->showWritable(self,
+                                                 ntca::ReactorEventOptions());
+                    }
+
                     if (d_session_sp) {
                         ntca::WriteQueueEvent event;
                         event.setType(
@@ -1099,12 +1105,6 @@ ntsa::Error DatagramSocket::privateRelaxFlowControl(
                             defer,
                             &d_mutex);
                     }
-
-                    ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
-                    if (reactorRef) {
-                        reactorRef->showWritable(self,
-                                                 ntca::ReactorEventOptions());
-                    }
                 }
             }
         }
@@ -1112,6 +1112,12 @@ ntsa::Error DatagramSocket::privateRelaxFlowControl(
         if (relaxReceive) {
             if (context.enableReceive()) {
                 if (d_shutdownState.canReceive()) {
+                    ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
+                    if (reactorRef) {
+                        reactorRef->showReadable(self,
+                                                 ntca::ReactorEventOptions());
+                    }
+
                     if (d_session_sp) {
                         ntca::ReadQueueEvent event;
                         event.setType(
@@ -1127,12 +1133,6 @@ ntsa::Error DatagramSocket::privateRelaxFlowControl(
                             self,
                             defer,
                             &d_mutex);
-                    }
-
-                    ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
-                    if (reactorRef) {
-                        reactorRef->showReadable(self,
-                                                 ntca::ReactorEventOptions());
                     }
                 }
             }
@@ -1171,6 +1171,11 @@ ntsa::Error DatagramSocket::privateApplyFlowControl(
     if (d_flowControlState.apply(&context, direction, lock)) {
         if (applySend) {
             if (!context.enableSend()) {
+                ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
+                if (reactorRef) {
+                    reactorRef->hideWritable(self);
+                }
+
                 if (d_session_sp) {
                     ntca::WriteQueueEvent event;
                     event.setType(
@@ -1187,16 +1192,16 @@ ntsa::Error DatagramSocket::privateApplyFlowControl(
                         defer,
                         &d_mutex);
                 }
-
-                ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
-                if (reactorRef) {
-                    reactorRef->hideWritable(self);
-                }
             }
         }
 
         if (applyReceive) {
             if (!context.enableReceive()) {
+                ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
+                if (reactorRef) {
+                    reactorRef->hideReadable(self);
+                }
+
                 if (d_session_sp) {
                     ntca::ReadQueueEvent event;
                     event.setType(
@@ -1212,11 +1217,6 @@ ntsa::Error DatagramSocket::privateApplyFlowControl(
                         self,
                         defer,
                         &d_mutex);
-                }
-
-                ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
-                if (reactorRef) {
-                    reactorRef->hideReadable(self);
                 }
             }
         }

--- a/groups/ntc/ntcr/ntcr_listenersocket.cpp
+++ b/groups/ntc/ntcr/ntcr_listenersocket.cpp
@@ -780,6 +780,12 @@ ntsa::Error ListenerSocket::privateRelaxFlowControl(
         if (relaxReceive) {
             if (context.enableReceive()) {
                 if (d_shutdownState.canReceive()) {
+                    ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
+                    if (reactorRef) {
+                        reactorRef->showReadable(self,
+                                                 ntca::ReactorEventOptions());
+                    }
+
                     if (d_session_sp) {
                         ntca::AcceptQueueEvent event;
                         event.setType(ntca::AcceptQueueEventType::
@@ -795,12 +801,6 @@ ntsa::Error ListenerSocket::privateRelaxFlowControl(
                             self,
                             defer,
                             &d_mutex);
-                    }
-
-                    ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
-                    if (reactorRef) {
-                        reactorRef->showReadable(self,
-                                                 ntca::ReactorEventOptions());
                     }
                 }
             }
@@ -841,6 +841,11 @@ ntsa::Error ListenerSocket::privateApplyFlowControl(
 
         if (applyReceive) {
             if (!context.enableReceive()) {
+                ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
+                if (reactorRef) {
+                    reactorRef->hideReadable(self);
+                }
+
                 if (d_session_sp) {
                     ntca::AcceptQueueEvent event;
                     event.setType(
@@ -856,11 +861,6 @@ ntsa::Error ListenerSocket::privateApplyFlowControl(
                         self,
                         defer,
                         &d_mutex);
-                }
-
-                ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
-                if (reactorRef) {
-                    reactorRef->hideReadable(self);
                 }
             }
         }

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -1765,6 +1765,12 @@ ntsa::Error StreamSocket::privateRelaxFlowControl(
         if (relaxSend) {
             if (context.enableSend()) {
                 if (d_shutdownState.canSend()) {
+                    ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
+                    if (reactorRef) {
+                        reactorRef->showWritable(self,
+                                                 ntca::ReactorEventOptions());
+                    }
+
                     if (d_session_sp) {
                         ntca::WriteQueueEvent event;
                         event.setType(
@@ -1781,12 +1787,6 @@ ntsa::Error StreamSocket::privateRelaxFlowControl(
                             defer,
                             &d_mutex);
                     }
-
-                    ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
-                    if (reactorRef) {
-                        reactorRef->showWritable(self,
-                                                 ntca::ReactorEventOptions());
-                    }
                 }
             }
         }
@@ -1794,6 +1794,12 @@ ntsa::Error StreamSocket::privateRelaxFlowControl(
         if (relaxReceive) {
             if (context.enableReceive()) {
                 if (d_shutdownState.canReceive()) {
+                    ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
+                    if (reactorRef) {
+                        reactorRef->showReadable(self,
+                                                 ntca::ReactorEventOptions());
+                    }
+
                     if (d_session_sp) {
                         ntca::ReadQueueEvent event;
                         event.setType(
@@ -1809,12 +1815,6 @@ ntsa::Error StreamSocket::privateRelaxFlowControl(
                             self,
                             defer,
                             &d_mutex);
-                    }
-
-                    ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
-                    if (reactorRef) {
-                        reactorRef->showReadable(self,
-                                                 ntca::ReactorEventOptions());
                     }
                 }
             }
@@ -1853,6 +1853,11 @@ ntsa::Error StreamSocket::privateApplyFlowControl(
     if (d_flowControlState.apply(&context, direction, lock)) {
         if (applySend) {
             if (!context.enableSend()) {
+                ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
+                if (reactorRef) {
+                    reactorRef->hideWritable(self);
+                }
+
                 if (d_session_sp) {
                     ntca::WriteQueueEvent event;
                     event.setType(
@@ -1869,16 +1874,16 @@ ntsa::Error StreamSocket::privateApplyFlowControl(
                         defer,
                         &d_mutex);
                 }
-
-                ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
-                if (reactorRef) {
-                    reactorRef->hideWritable(self);
-                }
             }
         }
 
         if (applyReceive) {
             if (!context.enableReceive()) {
+                ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
+                if (reactorRef) {
+                    reactorRef->hideReadable(self);
+                }
+
                 if (d_session_sp) {
                     ntca::ReadQueueEvent event;
                     event.setType(
@@ -1894,11 +1899,6 @@ ntsa::Error StreamSocket::privateApplyFlowControl(
                         self,
                         defer,
                         &d_mutex);
-                }
-
-                ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
-                if (reactorRef) {
-                    reactorRef->hideReadable(self);
                 }
             }
         }


### PR DESCRIPTION
This PR applies the desire to gain/lose interest in readability/writability before announcing the callback alerting the user to that state change. This PR fixes the following race:

Thread 1
1.  Poll the socket is writable
2. Completely drain the write queue by copying its entire contents to the socket send buffer
3. Decide to lose interest in writability
4. Announce e_FLOW_CONTROL_APPLIED (we must unlock the socket mutex to do so)

Thread 2
1. Acquire the socket mutex
2. Call ntci::StreamSocket::send
3. Detect that all data cannot be immediately copied to the socket send buffer, enqueue the remainder to the write queue
4. Apply the gain in interest in writability
5. Unlock the mutex

Thread 1
5. Re-acquire the mutex
6. Act on the previous decision to lose interest in writability
7. We are no longer interested in writability even though the write queue is non-empty