### PR TITLE
Copy buffers from a range of write queue entries to the send buffer in a single system call

### DIFF
--- a/groups/ntc/ntcp/ntcp_streamsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.cpp
@@ -671,6 +671,9 @@ void StreamSocket::privateCompleteConnect(
         }
     }
 
+    d_sendOptions.setMaxBuffers(d_socket_sp->maxBuffersPerSend());
+    d_receiveOptions.setMaxBuffers(d_socket_sp->maxBuffersPerReceive());
+
     NTCS_METRICS_UPDATE_CONNECT_COMPLETE();
 
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
@@ -2777,6 +2780,9 @@ ntsa::Error StreamSocket::privateOpen(
             d_receiveOptions.setMaxBytes(receiveBufferSize);
         }
     }
+
+    d_sendOptions.setMaxBuffers(streamSocket->maxBuffersPerSend());
+    d_receiveOptions.setMaxBuffers(streamSocket->maxBuffersPerReceive());
 
     ntcs::ObserverRef<ntci::Proactor> proactorRef(&d_proactor);
     if (!proactorRef) {

--- a/groups/ntc/ntcq/ntcq_send.cpp
+++ b/groups/ntc/ntcq/ntcq_send.cpp
@@ -115,8 +115,7 @@ bool SendQueueEntry::batchNext(ntsa::ConstBufferArray*  result,
     }
     else if (d_data_sp->isSharedBlob()) {
         if (d_data_sp->sharedBlob()) {
-            return this->batchNext(
-                result, *d_data_sp->sharedBlob(), options);
+            return this->batchNext(result, *d_data_sp->sharedBlob(), options);
         }
     }
     else if (d_data_sp->isBlobBuffer()) {
@@ -126,24 +125,25 @@ bool SendQueueEntry::batchNext(ntsa::ConstBufferArray*  result,
         return this->batchNext(result, d_data_sp->constBuffer(), options);
     }
     else if (d_data_sp->isConstBufferArray()) {
-        return this->batchNext(
-            result, d_data_sp->constBufferArray(), options);
+        return this->batchNext(result, d_data_sp->constBufferArray(), options);
     }
     else if (d_data_sp->isConstBufferPtrArray()) {
-        return this->batchNext(
-            result, d_data_sp->constBufferPtrArray(), options);
+        return this->batchNext(result,
+                               d_data_sp->constBufferPtrArray(),
+                               options);
     }
     else if (d_data_sp->isMutableBuffer()) {
-        return this->batchNext(
-            result, d_data_sp->mutableBuffer(), options);
+        return this->batchNext(result, d_data_sp->mutableBuffer(), options);
     }
     else if (d_data_sp->isMutableBufferArray()) {
-        return this->batchNext(
-            result, d_data_sp->mutableBufferArray(), options);
+        return this->batchNext(result,
+                               d_data_sp->mutableBufferArray(),
+                               options);
     }
     else if (d_data_sp->isMutableBufferPtrArray()) {
-        return this->batchNext(
-            result, d_data_sp->mutableBufferPtrArray(), options);
+        return this->batchNext(result,
+                               d_data_sp->mutableBufferPtrArray(),
+                               options);
     }
     else if (d_data_sp->isString()) {
         return this->batchNext(result, d_data_sp->string(), options);
@@ -221,9 +221,9 @@ bool SendQueueEntry::batchNext(ntsa::ConstBufferArray*       result,
 }
 
 bool SendQueueEntry::batchNext(
-        ntsa::ConstBufferArray*          result,
-        const ntsa::ConstBufferPtrArray& constBufferPtrArray,
-        const ntsa::SendOptions&         options) const
+    ntsa::ConstBufferArray*          result,
+    const ntsa::ConstBufferPtrArray& constBufferPtrArray,
+    const ntsa::SendOptions&         options) const
 {
     for (bsl::size_t i = 0; i < constBufferPtrArray.numBuffers(); ++i) {
         if (!this->batchNext(result, constBufferPtrArray.buffer(i), options)) {
@@ -251,9 +251,9 @@ bool SendQueueEntry::batchNext(ntsa::ConstBufferArray*    result,
 }
 
 bool SendQueueEntry::batchNext(
-        ntsa::ConstBufferArray*         result,
-        const ntsa::MutableBufferArray& mutableBufferArray,
-        const ntsa::SendOptions&        options) const
+    ntsa::ConstBufferArray*         result,
+    const ntsa::MutableBufferArray& mutableBufferArray,
+    const ntsa::SendOptions&        options) const
 {
     for (bsl::size_t i = 0; i < mutableBufferArray.numBuffers(); ++i) {
         if (!this->batchNext(result, mutableBufferArray.buffer(i), options)) {
@@ -265,14 +265,12 @@ bool SendQueueEntry::batchNext(
 }
 
 bool SendQueueEntry::batchNext(
-        ntsa::ConstBufferArray*            result,
-        const ntsa::MutableBufferPtrArray& mutableBufferPtrArray,
-        const ntsa::SendOptions&           options) const
+    ntsa::ConstBufferArray*            result,
+    const ntsa::MutableBufferPtrArray& mutableBufferPtrArray,
+    const ntsa::SendOptions&           options) const
 {
     for (bsl::size_t i = 0; i < mutableBufferPtrArray.numBuffers(); ++i) {
-        if (!this->batchNext(result,
-                             mutableBufferPtrArray.buffer(i),
-                             options))
+        if (!this->batchNext(result, mutableBufferPtrArray.buffer(i), options))
         {
             return false;
         }
@@ -285,10 +283,9 @@ bool SendQueueEntry::batchNext(ntsa::ConstBufferArray*  result,
                                const bsl::string&       string,
                                const ntsa::SendOptions& options) const
 {
-    return this->batchNext(
-        result,
-        ntsa::ConstBuffer(string.data(), string.size()),
-        options);
+    return this->batchNext(result,
+                           ntsa::ConstBuffer(string.data(), string.size()),
+                           options);
 }
 
 SendQueue::SendQueue(bslma::Allocator* basicAllocator)
@@ -311,8 +308,8 @@ SendQueue::~SendQueue()
 {
 }
 
-bool SendQueue::batchNext(ntsa::ConstBufferArray   *result,
-                          const ntsa::SendOptions&  options) const
+bool SendQueue::batchNext(ntsa::ConstBufferArray*  result,
+                          const ntsa::SendOptions& options) const
 {
     result->clear();
 

--- a/groups/ntc/ntcq/ntcq_send.cpp
+++ b/groups/ntc/ntcq/ntcq_send.cpp
@@ -195,12 +195,16 @@ bool SendQueueEntry::batchNext(ntsa::ConstBufferArray*  result,
                                const ntsa::ConstBuffer& constBuffer,
                                const ntsa::SendOptions& options) const
 {
-    if (result->numBytes() >= options.maxBytes()) {
-        return false;
+    if (options.maxBytes() > 0) {
+        if (result->numBytes() >= options.maxBytes()) {
+            return false;
+        }
     }
 
-    if (result->numBuffers() >= options.maxBuffers()) {
-        return false;
+    if (options.maxBuffers() > 0) {
+        if (result->numBuffers() >= options.maxBuffers()) {
+            return false;
+        }
     }
 
     result->append(constBuffer);
@@ -238,12 +242,16 @@ bool SendQueueEntry::batchNext(ntsa::ConstBufferArray*    result,
                                const ntsa::MutableBuffer& mutableBuffer,
                                const ntsa::SendOptions&   options) const
 {
-    if (result->numBytes() >= options.maxBytes()) {
-        return false;
+    if (options.maxBytes() > 0) {
+        if (result->numBytes() >= options.maxBytes()) {
+            return false;
+        }
     }
 
-    if (result->numBuffers() >= options.maxBuffers()) {
-        return false;
+    if (options.maxBuffers() > 0) {
+        if (result->numBuffers() >= options.maxBuffers()) {
+            return false;
+        }
     }
 
     result->append(mutableBuffer);

--- a/groups/ntc/ntcq/ntcq_send.cpp
+++ b/groups/ntc/ntcq/ntcq_send.cpp
@@ -26,7 +26,6 @@ BSLS_IDENT_RCSID(ntcq_send_cpp, "$Id$ $CSID$")
 #include <bslma_allocator.h>
 #include <bslma_default.h>
 #include <bsls_assert.h>
-#include <bsls_log.h> // MRM
 #include <bsl_limits.h>
 
 namespace BloombergLP {
@@ -344,20 +343,6 @@ bool SendQueue::batchNext(ntsa::ConstBufferArray   *result,
         result->clear();
         return false;
     }
-
-    // MRM
-#if 0
-    BSLS_LOG_TRACE("MRM: Batching %zu bytes in %zu buffers in %zu entries "
-                  "from send queue having %zu entries "
-                  "to copy to the socket send buffer: "
-                  "limit %zu buffers, %zu bytes",
-                  result->numBytes(),
-                  result->numBuffers(),
-                  numEntries,
-                  d_entryList.size(),
-                  options.maxBuffers(),
-                  options.maxBytes());
-#endif
 
     return true;
 }

--- a/groups/ntc/ntcq/ntcq_send.h
+++ b/groups/ntc/ntcq/ntcq_send.h
@@ -157,6 +157,12 @@ class SendCallbackQueueEntryPool
     /// entry is automatically returned to this pool when its reference
     /// count reaches zero.
     bsl::shared_ptr<ntcq::SendCallbackQueueEntry> create();
+
+    /// Return the total number of objects in the pool.
+    bsl::size_t numObjects() const;
+
+    /// Return the number of un-allocated objects available in the pool.
+    bsl::size_t numObjectsAvailable() const;
 };
 
 /// @internal @brief
@@ -522,6 +528,18 @@ bsl::shared_ptr<ntcq::SendCallbackQueueEntry> SendCallbackQueueEntryPool::
     create()
 {
     return d_pool.getObject();
+}
+
+NTCCFG_INLINE
+bsl::size_t SendCallbackQueueEntryPool::numObjects() const
+{
+    return d_pool.numObjects();
+}
+
+NTCCFG_INLINE
+bsl::size_t SendCallbackQueueEntryPool::numObjectsAvailable() const
+{
+    return d_pool.numAvailableObjects();
 }
 
 NTCCFG_INLINE

--- a/groups/ntc/ntcq/ntcq_send.h
+++ b/groups/ntc/ntcq/ntcq_send.h
@@ -185,6 +185,79 @@ class SendQueueEntry
     bsl::shared_ptr<SendCallbackQueueEntry> d_callbackEntry_sp;
     bool                                    d_inProgress;
 
+  private:
+    /// If this entry is batchable, append a reference to this data of this
+    /// entry represented as the specified 'blob' to the specified 'result'
+    /// according to the specified 'options'. Return true if more entries
+    /// should be attempted to be batched, and false otherwise.
+    bool batchNext(ntsa::ConstBufferArray*  result,
+                   const bdlbb::Blob&       blob,
+                   const ntsa::SendOptions& options) const;
+
+    /// If this entry is batchable, append a reference to this data of this
+    /// entry represented as the specified 'blobBuffer' to the specified
+    /// 'result' according to the specified 'options'. Return true if more
+    /// entries should be attempted to be batched, and false otherwise.
+    bool batchNext(ntsa::ConstBufferArray*  result,
+                   const bdlbb::BlobBuffer& blobBuffer,
+                   const ntsa::SendOptions& options) const;
+
+    /// If this entry is batchable, append a reference to this data of this
+    /// entry represented as the specified 'constBuffer' to the specified
+    /// 'result' according to the specified 'options'. Return true if more
+    /// entries should be attempted to be batched, and false otherwise.
+    bool batchNext(ntsa::ConstBufferArray*  result,
+                   const ntsa::ConstBuffer& constBuffer,
+                   const ntsa::SendOptions& options) const;
+
+    /// If this entry is batchable, append a reference to this data of this
+    /// entry represented as the specified 'constBufferArray' to the specified
+    /// 'result' according to the specified 'options'. Return true if more
+    /// entries should be attempted to be batched, and false otherwise.
+    bool batchNext(ntsa::ConstBufferArray*       result,
+                   const ntsa::ConstBufferArray& constBufferArray,
+                   const ntsa::SendOptions&      options) const;
+
+    /// If this entry is batchable, append a reference to this data of this
+    /// entry represented as the specified 'constBufferPtrArray' to the
+    /// specified 'result' according to the specified 'options'. Return true if
+    /// more entries should be attempted to be batched, and false otherwise.
+    bool batchNext(ntsa::ConstBufferArray*          result,
+                   const ntsa::ConstBufferPtrArray& constBufferPtrArray,
+                   const ntsa::SendOptions&         options) const;
+
+    /// If this entry is batchable, append a reference to this data of this
+    /// entry represented as the specified 'mutableBuffer' to the specified
+    /// 'result' according to the specified 'options'. Return true if more
+    /// entries should be attempted to be batched, and false otherwise.
+    bool batchNext(ntsa::ConstBufferArray*    result,
+                   const ntsa::MutableBuffer& mutableBuffer,
+                   const ntsa::SendOptions&   options) const;
+
+    /// If this entry is batchable, append a reference to this data of this
+    /// entry represented as the specified 'mutableBufferArray' to the
+    /// specified 'result' according to the specified 'options'. Return true if
+    /// more entries should be attempted to be batched, and false otherwise.
+    bool batchNext(ntsa::ConstBufferArray*         result,
+                   const ntsa::MutableBufferArray& mutableBufferArray,
+                   const ntsa::SendOptions&        options) const;
+
+    /// If this entry is batchable, append a reference to this data of this
+    /// entry represented as the specified 'mutableBufferPtrArray' to the
+    /// specified 'result' according to the specified 'options'. Return true if
+    /// more entries should be attempted to be batched, and false otherwise.
+    bool batchNext(ntsa::ConstBufferArray*            result,
+                   const ntsa::MutableBufferPtrArray& mutableBufferPtrArray,
+                   const ntsa::SendOptions&           options) const;
+
+    /// If this entry is batchable, append a reference to this data of this
+    /// entry represented as the specified 'string' to the specified 'result'
+    /// according to the specified 'options'. Return true if more entries
+    /// should be attempted to be batched, and false otherwise.
+    bool batchNext(ntsa::ConstBufferArray*  result,
+                   const bsl::string&       string,
+                   const ntsa::SendOptions& options) const;
+
   public:
     /// Create a new send queue entry.
     SendQueueEntry();
@@ -239,72 +312,10 @@ class SendQueueEntry
     void closeTimer();
 
     /// If this entry is batchable, append a reference to this data of this
-    /// entry to the specified 'result' and return true. Otherwise, return
-    /// false.
+    /// entry to the specified 'result' according to the specified 'options'.
+    /// Return true if more entries should be attempted to be batched, and
+    /// false otherwise.
     bool batchNext(ntsa::ConstBufferArray*  result,
-                   const ntsa::SendOptions& options) const;
-
-    /// If the specified 'blob' is batchable, append to the specified 'result'
-    /// the data referenced by the 'blob' and return true. Otherwise, return
-    /// false.
-    bool batchNext(ntsa::ConstBufferArray*  result,
-                   const bdlbb::Blob&       blob,
-                   const ntsa::SendOptions& options) const;
-
-    /// If the specified 'blobBuffer' is batchable, append to the specified
-    /// 'result' the data referenced by the 'blobBuffer' and return true.
-    /// Otherwise, return false.
-    bool batchNext(ntsa::ConstBufferArray*  result,
-                   const bdlbb::BlobBuffer& blobBuffer,
-                   const ntsa::SendOptions& options) const;
-
-    /// If the specified 'constBuffer' is batchable, append to the specified
-    /// 'result' the data referenced by the 'constBuffer' and return true.
-    /// Otherwise, return false.
-    bool batchNext(ntsa::ConstBufferArray*  result,
-                   const ntsa::ConstBuffer& constBuffer,
-                   const ntsa::SendOptions& options) const;
-
-    /// If the specified 'constBufferArray' is batchable, append to the
-    /// specified 'result' the data referenced by the 'constBufferArray' and
-    /// return true. Otherwise, return false.
-    bool batchNext(ntsa::ConstBufferArray*       result,
-                   const ntsa::ConstBufferArray& constBufferArray,
-                   const ntsa::SendOptions&      options) const;
-
-    /// If the specified 'constBufferPtrArray' is batchable, append to the
-    /// specified 'result' the data referenced by the 'constBufferPtrArray' and
-    /// return true. Otherwise, return false.
-    bool batchNext(ntsa::ConstBufferArray*          result,
-                   const ntsa::ConstBufferPtrArray& constBufferPtrArray,
-                   const ntsa::SendOptions&         options) const;
-
-    /// If the specified 'mutableBuffer' is batchable, append to the specified
-    /// 'result' the data referenced by the 'mutableBuffer' and return true.
-    /// Otherwise, return false.
-    bool batchNext(ntsa::ConstBufferArray*    result,
-                   const ntsa::MutableBuffer& mutableBuffer,
-                   const ntsa::SendOptions&   options) const;
-
-    /// If the specified 'mutableBufferArray' is batchable, append to the
-    /// specified 'result' the data referenced by the 'mutableBufferArray' and
-    /// return true. Otherwise, return false.
-    bool batchNext(ntsa::ConstBufferArray*         result,
-                   const ntsa::MutableBufferArray& mutableBufferArray,
-                   const ntsa::SendOptions&        options) const;
-
-    /// If the specified 'mutableBufferPtrArray' is batchable, append to the
-    /// specified 'result' the data referenced by the 'mutableBufferPtrArray'
-    /// and return true. Otherwise, return false.
-    bool batchNext(ntsa::ConstBufferArray*            result,
-                   const ntsa::MutableBufferPtrArray& mutableBufferPtrArray,
-                   const ntsa::SendOptions&           options) const;
-
-    /// If the specified 'string' is batchable, append to the specified 'result'
-    /// the data referenced by the 'string' and return true. Otherwise, return
-    /// false.
-    bool batchNext(ntsa::ConstBufferArray*  result,
-                   const bsl::string&       string,
                    const ntsa::SendOptions& options) const;
 
     /// Return the identifier used to internally time-out the queue entry.

--- a/groups/ntc/ntcq/ntcq_send.t.cpp
+++ b/groups/ntc/ntcq/ntcq_send.t.cpp
@@ -21,8 +21,8 @@
 #include <ntsa_data.h>
 #include <ntsd_datautil.h>
 #include <bdlbb_blob.h>
-#include <bdlbb_blobutil.h>
 #include <bdlbb_blobstreambuf.h>
+#include <bdlbb_blobutil.h>
 #include <bdlbb_simpleblobbufferfactory.h>
 #include <bdlf_bind.h>
 #include <bdlf_placeholder.h>
@@ -173,16 +173,14 @@ struct EventUtil {
     // Process the specified 'event' from the specified 'sender'. Ensure the
     // event indicates the operation completed successfully. Increment the
     // specified 'numInvoked'.
-    static void processComplete(
-        bsls::AtomicUint*                    numInvoked,
-        const bsl::shared_ptr<ntci::Sender>& sender,
-        const ntca::SendEvent&               event);
+    static void processComplete(bsls::AtomicUint* numInvoked,
+                                const bsl::shared_ptr<ntci::Sender>& sender,
+                                const ntca::SendEvent&               event);
 };
 
-void EventUtil::processComplete(
-        bsls::AtomicUint*                    numInvoked,
-        const bsl::shared_ptr<ntci::Sender>& sender,
-        const ntca::SendEvent&               event)
+void EventUtil::processComplete(bsls::AtomicUint* numInvoked,
+                                const bsl::shared_ptr<ntci::Sender>& sender,
+                                const ntca::SendEvent&               event)
 {
     NTCI_LOG_CONTEXT();
 
@@ -194,7 +192,7 @@ void EventUtil::processComplete(
     ++(*numInvoked);
 }
 
-} // close namespace 'test'
+}  // close namespace 'test'
 
 NTCCFG_TEST_CASE(1)
 {
@@ -332,7 +330,7 @@ NTCCFG_TEST_CASE(2)
         ntca::SendEvent event;
         event.setType(ntca::SendEventType::e_COMPLETE);
 
-        bslmt::Mutex mutex;
+        bslmt::Mutex                   mutex;
         bslmt::LockGuard<bslmt::Mutex> lock(&mutex);
 
         // Test announcement immediately.
@@ -355,13 +353,23 @@ NTCCFG_TEST_CASE(2)
 
             NTCCFG_TEST_EQ(numInvoked, 0);
 
-            Entry::dispatch(
-                entry, sender, event, ntci::Strand::unspecified(), executor, false, &mutex);
+            Entry::dispatch(entry,
+                            sender,
+                            event,
+                            ntci::Strand::unspecified(),
+                            executor,
+                            false,
+                            &mutex);
 
             NTCCFG_TEST_EQ(numInvoked, 1);
 
-            Entry::dispatch(
-                entry, sender, event, ntci::Strand::unspecified(), executor, false, &mutex);
+            Entry::dispatch(entry,
+                            sender,
+                            event,
+                            ntci::Strand::unspecified(),
+                            executor,
+                            false,
+                            &mutex);
 
             NTCCFG_TEST_EQ(numInvoked, 1);
         }
@@ -387,16 +395,26 @@ NTCCFG_TEST_CASE(2)
 
             NTCCFG_TEST_EQ(numInvoked, 0);
 
-            Entry::dispatch(
-                entry, sender, event, ntci::Strand::unspecified(), executor, false, &mutex);
+            Entry::dispatch(entry,
+                            sender,
+                            event,
+                            ntci::Strand::unspecified(),
+                            executor,
+                            false,
+                            &mutex);
 
             NTCCFG_TEST_EQ(numInvoked, 0);
             strand->drain();
             NTCCFG_TEST_EQ(numInvoked, 1);
 
-            Entry::dispatch(
-                entry, sender, event, ntci::Strand::unspecified(), executor, false, &mutex);
-                
+            Entry::dispatch(entry,
+                            sender,
+                            event,
+                            ntci::Strand::unspecified(),
+                            executor,
+                            false,
+                            &mutex);
+
             NTCCFG_TEST_EQ(numInvoked, 1);
             strand->drain();
             NTCCFG_TEST_EQ(numInvoked, 1);
@@ -422,16 +440,26 @@ NTCCFG_TEST_CASE(2)
 
             NTCCFG_TEST_EQ(numInvoked, 0);
 
-            Entry::dispatch(
-                entry, sender, event, ntci::Strand::unspecified(), executor, true, &mutex);
+            Entry::dispatch(entry,
+                            sender,
+                            event,
+                            ntci::Strand::unspecified(),
+                            executor,
+                            true,
+                            &mutex);
 
             NTCCFG_TEST_EQ(numInvoked, 0);
             strand->drain();
             NTCCFG_TEST_EQ(numInvoked, 1);
 
-            Entry::dispatch(
-                entry, sender, event, ntci::Strand::unspecified(), executor, true, &mutex);
-                
+            Entry::dispatch(entry,
+                            sender,
+                            event,
+                            ntci::Strand::unspecified(),
+                            executor,
+                            true,
+                            &mutex);
+
             NTCCFG_TEST_EQ(numInvoked, 1);
             strand->drain();
             NTCCFG_TEST_EQ(numInvoked, 1);
@@ -448,9 +476,9 @@ NTCCFG_TEST_CASE(3)
     ntccfg::TestAllocator ta;
     {
         const bsl::size_t k_ORIGINAL_DATA_SIZE = 1024;
-        const bsl::size_t k_MESSAGE_SIZE = 3;
+        const bsl::size_t k_MESSAGE_SIZE       = 3;
 
-        const bsl::size_t k_LOW_WATERMARK = 0;
+        const bsl::size_t k_LOW_WATERMARK  = 0;
         const bsl::size_t k_HIGH_WATERMARK = 1024 * 1024;
 
         bdlbb::SimpleBlobBufferFactory blobBufferFactory(8, &ta);
@@ -463,17 +491,17 @@ NTCCFG_TEST_CASE(3)
         bsl::shared_ptr<ntsa::Data> originalData;
         originalData.createInplace(&ta, &blobBufferFactory, &ta);
 
-        ntsd::DataUtil::generateData(&originalData->makeBlob(), 
+        ntsd::DataUtil::generateData(&originalData->makeBlob(),
                                      k_ORIGINAL_DATA_SIZE);
         NTCCFG_TEST_EQ(originalData->size(), k_ORIGINAL_DATA_SIZE);
 
         bsl::shared_ptr<ntsa::Data> originalDataRemaining;
-        originalDataRemaining.createInplace(&ta, originalData->blob(), &blobBufferFactory, &ta);
+        originalDataRemaining.createInplace(&ta,
+                                            originalData->blob(),
+                                            &blobBufferFactory,
+                                            &ta);
         NTCCFG_TEST_EQ(originalDataRemaining->size(), k_ORIGINAL_DATA_SIZE);
         NTCCFG_TEST_NE(&originalDataRemaining->blob(), &originalData->blob());
-
-
-
 
         {
             bsl::shared_ptr<ntsa::Data> data;
@@ -487,7 +515,6 @@ NTCCFG_TEST_CASE(3)
             sendQueueEntry.setId(sendQueue.generateEntryId());
             sendQueueEntry.setData(data);
             sendQueueEntry.setLength(data->size());
-
         }
     }
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
@@ -495,7 +522,7 @@ NTCCFG_TEST_CASE(3)
 
 NTCCFG_TEST_CASE(4)
 {
-    // Concern: Batching next suitable entries: empty 
+    // Concern: Batching next suitable entries: empty
     // Plan:
 
     ntccfg::TestAllocator ta;
@@ -518,9 +545,10 @@ NTCCFG_TEST_CASE(5)
     ntccfg::TestAllocator ta;
     {
         const bsl::size_t k_BLOB_BUFFER_SIZE = 32;
-        const bsl::size_t k_MESSAGE_SIZE = 1024;
+        const bsl::size_t k_MESSAGE_SIZE     = 1024;
 
-        bdlbb::SimpleBlobBufferFactory blobBufferFactory(k_BLOB_BUFFER_SIZE, &ta);
+        bdlbb::SimpleBlobBufferFactory blobBufferFactory(k_BLOB_BUFFER_SIZE,
+                                                         &ta);
 
         ntcq::SendQueue sendQueue(&ta);
 
@@ -528,14 +556,10 @@ NTCCFG_TEST_CASE(5)
             bsl::shared_ptr<ntsa::Data> data;
             data.createInplace(&ta, &blobBufferFactory, &ta);
 
-            
-
             ntcq::SendQueueEntry sendQueueEntry;
             sendQueueEntry.setId(sendQueue.generateEntryId());
             sendQueueEntry.setData(data);
             sendQueueEntry.setLength(data->size());
-
-
         }
 
         ntsa::ConstBufferArray bufferArray(&ta);

--- a/groups/ntc/ntcq/ntcq_send.t.cpp
+++ b/groups/ntc/ntcq/ntcq_send.t.cpp
@@ -471,9 +471,9 @@ NTCCFG_TEST_CASE(2)
 
 NTCCFG_TEST_CASE(3)
 {
-    // Concern: Announcement of the low watermark is not authorized until the 
-    // queue is filled up to the high watermark then drained down the low 
-    // watermark. Announcement of the high watermark is authorized once the 
+    // Concern: Announcement of the low watermark is not authorized until the
+    // queue is filled up to the high watermark then drained down the low
+    // watermark. Announcement of the high watermark is authorized once the
     // queue is filled up to the high watermark, but not announced again until
     // the queue is drained down to the low watermark.
 
@@ -484,7 +484,7 @@ NTCCFG_TEST_CASE(3)
         const bsl::size_t k_LOW_WATERMARK    = 0;
         const bsl::size_t k_HIGH_WATERMARK   = 2 * k_MESSAGE_SIZE;
 
-        bdlbb::SimpleBlobBufferFactory blobBufferFactory(k_BLOB_BUFFER_SIZE, 
+        bdlbb::SimpleBlobBufferFactory blobBufferFactory(k_BLOB_BUFFER_SIZE,
                                                          &ta);
 
         ntcq::SendQueue sendQueue(&ta);
@@ -535,7 +535,7 @@ NTCCFG_TEST_CASE(3)
                 sendQueueEntry.setData(data);
                 sendQueueEntry.setLength(data->size());
 
-                sendQueue.pushEntry(sendQueueEntry);    
+                sendQueue.pushEntry(sendQueueEntry);
             }
 
             NTCCFG_TEST_EQ(sendQueue.size(), k_MESSAGE_SIZE * 2);
@@ -587,7 +587,7 @@ NTCCFG_TEST_CASE(4)
         ntsa::Data batch(&ta);
         batch.makeConstBufferArray();
 
-        bool result = sendQueue.batchNext(&batch.constBufferArray(), 
+        bool result = sendQueue.batchNext(&batch.constBufferArray(),
                                           ntsa::SendOptions());
         NTCCFG_TEST_FALSE(result);
 
@@ -627,13 +627,13 @@ NTCCFG_TEST_CASE(5)
             sendQueue.pushEntry(sendQueueEntry);
         }
 
-        NTCCFG_TEST_EQ(sendQueue.size(), 
+        NTCCFG_TEST_EQ(sendQueue.size(),
                        static_cast<bsl::size_t>(blob.length()));
 
         ntsa::Data batch(&ta);
         batch.makeConstBufferArray();
 
-        bool result = sendQueue.batchNext(&batch.constBufferArray(), 
+        bool result = sendQueue.batchNext(&batch.constBufferArray(),
                                           ntsa::SendOptions());
         NTCCFG_TEST_FALSE(result);
 
@@ -688,23 +688,23 @@ NTCCFG_TEST_CASE(6)
         }
 
         NTCCFG_TEST_EQ(
-            sendQueue.size(), 
+            sendQueue.size(),
             static_cast<bsl::size_t>(blob1.length() + blob2.length()));
 
         ntsa::Data batch(&ta);
         batch.makeConstBufferArray();
 
-        bool result = sendQueue.batchNext(&batch.constBufferArray(), 
+        bool result = sendQueue.batchNext(&batch.constBufferArray(),
                                           ntsa::SendOptions());
         NTCCFG_TEST_TRUE(result);
 
-        NTCCFG_TEST_EQ(batch.constBufferArray().numBuffers(), 
-                       static_cast<bsl::size_t>(blob1.numDataBuffers() + 
+        NTCCFG_TEST_EQ(batch.constBufferArray().numBuffers(),
+                       static_cast<bsl::size_t>(blob1.numDataBuffers() +
                                                 blob2.numDataBuffers()));
 
-        NTCCFG_TEST_EQ(batch.constBufferArray().numBytes(),
-                       static_cast<bsl::size_t>(blob1.length() + 
-                                                blob2.length()));
+        NTCCFG_TEST_EQ(
+            batch.constBufferArray().numBytes(),
+            static_cast<bsl::size_t>(blob1.length() + blob2.length()));
 
         ntsa::Data batchExpected(&blobBufferFactory, &ta);
         batchExpected.makeBlob();
@@ -793,26 +793,24 @@ NTCCFG_TEST_CASE(7)
         }
 
         NTCCFG_TEST_EQ(
-            sendQueue.size(), 
-            static_cast<bsl::size_t>(blob1.length() + 
-                                     blob2.length() + 
-                                     file3.bytesRemaining() + 
-                                     blob4.length()));
+            sendQueue.size(),
+            static_cast<bsl::size_t>(blob1.length() + blob2.length() +
+                                     file3.bytesRemaining() + blob4.length()));
 
         ntsa::Data batch(&ta);
         batch.makeConstBufferArray();
 
-        bool result = sendQueue.batchNext(&batch.constBufferArray(), 
+        bool result = sendQueue.batchNext(&batch.constBufferArray(),
                                           ntsa::SendOptions());
         NTCCFG_TEST_TRUE(result);
 
-        NTCCFG_TEST_EQ(batch.constBufferArray().numBuffers(), 
-                       static_cast<bsl::size_t>(blob1.numDataBuffers() + 
+        NTCCFG_TEST_EQ(batch.constBufferArray().numBuffers(),
+                       static_cast<bsl::size_t>(blob1.numDataBuffers() +
                                                 blob2.numDataBuffers()));
 
-        NTCCFG_TEST_EQ(batch.constBufferArray().numBytes(),
-                       static_cast<bsl::size_t>(blob1.length() + 
-                                                blob2.length()));
+        NTCCFG_TEST_EQ(
+            batch.constBufferArray().numBytes(),
+            static_cast<bsl::size_t>(blob1.length() + blob2.length()));
 
         ntsa::Data batchExpected(&blobBufferFactory, &ta);
         batchExpected.makeBlob();

--- a/groups/ntc/ntcq/ntcq_send.t.cpp
+++ b/groups/ntc/ntcq/ntcq_send.t.cpp
@@ -15,8 +15,17 @@
 
 #include <ntcq_send.h>
 
+#include <ntccfg_bind.h>
 #include <ntccfg_test.h>
-
+#include <ntci_mutex.h>
+#include <ntsa_data.h>
+#include <ntsd_datautil.h>
+#include <bdlbb_blob.h>
+#include <bdlbb_blobutil.h>
+#include <bdlbb_blobstreambuf.h>
+#include <bdlbb_simpleblobbufferfactory.h>
+#include <bdlf_bind.h>
+#include <bdlf_placeholder.h>
 #include <bslma_allocator.h>
 #include <bslma_default.h>
 #include <bsls_assert.h>
@@ -36,7 +45,541 @@ using namespace BloombergLP;
 // [ 1]
 //-----------------------------------------------------------------------------
 
+namespace test {
+
+/// Provide an interface to guarantee sequential, non-concurrent
+/// execution.
+class Strand : public ntci::Strand, public ntccfg::Shared<Strand>
+{
+    /// Define a type alias for a mutex.
+    typedef ntci::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntci::LockGuard LockGuard;
+
+    /// Define a type alias for a queue of callbacks to
+    /// execute on this thread.
+    typedef ntci::Executor::FunctorSequence FunctorQueue;
+
+    ntccfg::Object    d_object;
+    mutable Mutex     d_functorQueueMutex;
+    FunctorQueue      d_functorQueue;
+    bslma::Allocator* d_allocator_p;
+
+  private:
+    Strand(const Strand&) BSLS_KEYWORD_DELETED;
+    Strand& operator=(const Strand&) BSLS_KEYWORD_DELETED;
+
+  public:
+    /// Create a new strand with characteristics suitable for this
+    /// test driver. Optionally specify a 'basicAllocator' used to supply
+    /// memory. If 'basicAllocator' is 0, the currently installed default
+    /// allocator is used.
+    explicit Strand(bslma::Allocator* basicAllocator = 0);
+
+    /// Destroy this object.
+    ~Strand() BSLS_KEYWORD_OVERRIDE;
+
+    /// Defer the specified 'function' to execute sequentially, and
+    /// non-concurrently, after all previously deferred functions. Note that
+    /// the 'function' is not necessarily guaranteed to execute on the same
+    /// thread as previously deferred functions were executed, or is it
+    /// necessarily guaranteed to execute on a different thread than
+    /// previously deferred functions were executed.
+    void execute(const Functor& function) BSLS_KEYWORD_OVERRIDE;
+
+    /// Atomically defer the execution of the specified 'functorSequence'
+    /// immediately followed by the specified 'functor', then clear the
+    /// 'functorSequence'.
+    void moveAndExecute(FunctorSequence* functorSequence,
+                        const Functor&   functor) BSLS_KEYWORD_OVERRIDE;
+
+    /// Execute all pending operations on the calling thread. The behavior
+    /// is undefined unless no other thread is processing pending
+    /// operations.
+    void drain() BSLS_KEYWORD_OVERRIDE;
+
+    /// Cancel all pending functions.
+    void clear() BSLS_KEYWORD_OVERRIDE;
+
+    /// Return true if operations in this strand are currently being invoked
+    /// by the current thread, otherwise return false.
+    bool isRunningInCurrentThread() const BSLS_KEYWORD_OVERRIDE;
+};
+
+Strand::Strand(bslma::Allocator* basicAllocator)
+: d_object("test::Strand")
+, d_functorQueueMutex()
+, d_functorQueue(basicAllocator)
+, d_allocator_p(bslma::Default::allocator(basicAllocator))
+{
+}
+
+Strand::~Strand()
+{
+}
+
+void Strand::execute(const Functor& function)
+{
+    LockGuard lock(&d_functorQueueMutex);
+
+    d_functorQueue.push_back(function);
+}
+
+void Strand::moveAndExecute(FunctorSequence* functorSequence,
+                            const Functor&   functor)
+{
+    LockGuard lock(&d_functorQueueMutex);
+
+    d_functorQueue.splice(d_functorQueue.end(), *functorSequence);
+    if (functor) {
+        d_functorQueue.push_back(functor);
+    }
+}
+
+void Strand::drain()
+{
+    FunctorQueue functorQueue;
+    {
+        LockGuard lock(&d_functorQueueMutex);
+        functorQueue.swap(d_functorQueue);
+    }
+
+    ntci::StrandGuard strandGuard(this);
+
+    for (FunctorQueue::iterator it = functorQueue.begin();
+         it != functorQueue.end();
+         ++it)
+    {
+        (*it)();
+    }
+}
+
+void Strand::clear()
+{
+    LockGuard lock(&d_functorQueueMutex);
+
+    d_functorQueue.clear();
+}
+
+bool Strand::isRunningInCurrentThread() const
+{
+    const ntci::Strand* current = ntci::Strand::getThreadLocal();
+    return (current == this);
+}
+
+// Provide utilities to process events used by this test driver.
+struct EventUtil {
+    // Process the specified 'event' from the specified 'sender'. Ensure the
+    // event indicates the operation completed successfully. Increment the
+    // specified 'numInvoked'.
+    static void processComplete(
+        bsls::AtomicUint*                    numInvoked,
+        const bsl::shared_ptr<ntci::Sender>& sender,
+        const ntca::SendEvent&               event);
+};
+
+void EventUtil::processComplete(
+        bsls::AtomicUint*                    numInvoked,
+        const bsl::shared_ptr<ntci::Sender>& sender,
+        const ntca::SendEvent&               event)
+{
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_STREAM_DEBUG << "Event = " << event << NTCI_LOG_STREAM_END;
+
+    NTCCFG_TEST_EQ(event.type(), ntca::SendEventType::e_COMPLETE);
+    NTCCFG_TEST_FALSE(event.context().error());
+
+    ++(*numInvoked);
+}
+
+} // close namespace 'test'
+
 NTCCFG_TEST_CASE(1)
+{
+    // Concern: The pool of shared objects correctly creates a shared pointer
+    // to an entry, which is released back to the pool when its reference
+    // count reaches zero. The pool grows by one each time a new object must
+    // be created but no objects are available.
+
+    ntccfg::TestAllocator ta;
+    {
+        typedef ntcq::SendCallbackQueueEntry     Entry;
+        typedef ntcq::SendCallbackQueueEntryPool Pool;
+
+        // Create a pool an ensure it is initially empty.
+
+        Pool pool(&ta);
+
+        NTCCFG_TEST_EQ(pool.numObjects(), 0);
+        NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 0);
+
+        // Allocate a shared object from the pool, ensure the pool is now
+        // managing one object, with zero objects free, then reset the
+        // shared pointer to the object, and ensure the shared object is
+        // released back to the pool.
+
+        {
+            bsl::shared_ptr<Entry> entry = pool.create();
+
+            NTCCFG_TEST_EQ(pool.numObjects(), 1);
+            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 0);
+
+            entry.reset();
+
+            NTCCFG_TEST_EQ(pool.numObjects(), 1);
+            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 1);
+        }
+
+        // Allocate another shared object from the pool and ensure the
+        // returned object is from the pool, the reset the shared pointer to
+        // return the object back to the pool.
+
+        {
+            bsl::shared_ptr<Entry> entry = pool.create();
+
+            NTCCFG_TEST_EQ(pool.numObjects(), 1);
+            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 0);
+
+            entry.reset();
+
+            NTCCFG_TEST_EQ(pool.numObjects(), 1);
+            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 1);
+        }
+
+        // Allocate two shared objects from the pool, and ensure the pool
+        // grows by one.
+
+        {
+            bsl::shared_ptr<Entry> entry1 = pool.create();
+
+            NTCCFG_TEST_EQ(pool.numObjects(), 1);
+            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 0);
+
+            bsl::shared_ptr<Entry> entry2 = pool.create();
+
+            NTCCFG_TEST_EQ(pool.numObjects(), 2);
+            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 0);
+
+            entry1.reset();
+
+            NTCCFG_TEST_EQ(pool.numObjects(), 2);
+            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 1);
+
+            entry2.reset();
+
+            NTCCFG_TEST_EQ(pool.numObjects(), 2);
+            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 2);
+        }
+
+        // Allocate three shared objects from the pool, and ensure the pool
+        // grows by one.
+
+        {
+            bsl::shared_ptr<Entry> entry1 = pool.create();
+
+            NTCCFG_TEST_EQ(pool.numObjects(), 2);
+            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 1);
+
+            bsl::shared_ptr<Entry> entry2 = pool.create();
+
+            NTCCFG_TEST_EQ(pool.numObjects(), 2);
+            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 0);
+
+            bsl::shared_ptr<Entry> entry3 = pool.create();
+
+            NTCCFG_TEST_EQ(pool.numObjects(), 3);
+            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 0);
+
+            entry1.reset();
+
+            NTCCFG_TEST_EQ(pool.numObjects(), 3);
+            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 1);
+
+            entry2.reset();
+
+            NTCCFG_TEST_EQ(pool.numObjects(), 3);
+            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 2);
+
+            entry3.reset();
+
+            NTCCFG_TEST_EQ(pool.numObjects(), 3);
+            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 3);
+        }
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(2)
+{
+    // Concern: The callback entry invokes the callback with the correct
+    // parameters, the correct number of times, when completed, canceled, and
+    // aborted, from within a context that allows the callback entry to be
+    // immediately executed.
+
+    ntccfg::TestAllocator ta;
+    {
+        typedef ntcq::SendCallbackQueueEntry Entry;
+
+        bsl::shared_ptr<ntci::Sender> sender;
+
+        bsl::shared_ptr<test::Strand> strand;
+        strand.createInplace(&ta, &ta);
+
+        bsl::shared_ptr<ntci::Executor> executor = strand;
+
+        ntca::SendEvent event;
+        event.setType(ntca::SendEventType::e_COMPLETE);
+
+        bslmt::Mutex mutex;
+        bslmt::LockGuard<bslmt::Mutex> lock(&mutex);
+
+        // Test announcement immediately.
+
+        {
+            bsl::shared_ptr<Entry> entry;
+            entry.createInplace(&ta, &ta);
+
+            bsls::AtomicUint numInvoked(0);
+
+            ntci::SendCallback sendCallback(
+                NTCCFG_BIND(&test::EventUtil::processComplete,
+                            &numInvoked,
+                            NTCCFG_BIND_PLACEHOLDER_1,
+                            NTCCFG_BIND_PLACEHOLDER_2));
+
+            ntca::SendOptions sendOptions;
+
+            entry->assign(sendCallback, sendOptions);
+
+            NTCCFG_TEST_EQ(numInvoked, 0);
+
+            Entry::dispatch(
+                entry, sender, event, ntci::Strand::unspecified(), executor, false, &mutex);
+
+            NTCCFG_TEST_EQ(numInvoked, 1);
+
+            Entry::dispatch(
+                entry, sender, event, ntci::Strand::unspecified(), executor, false, &mutex);
+
+            NTCCFG_TEST_EQ(numInvoked, 1);
+        }
+
+        // Test announcement through a strand.
+
+        {
+            bsl::shared_ptr<Entry> entry;
+            entry.createInplace(&ta, &ta);
+
+            bsls::AtomicUint numInvoked(0);
+
+            ntci::SendCallback sendCallback(
+                NTCCFG_BIND(&test::EventUtil::processComplete,
+                            &numInvoked,
+                            NTCCFG_BIND_PLACEHOLDER_1,
+                            NTCCFG_BIND_PLACEHOLDER_2),
+                strand);
+
+            ntca::SendOptions sendOptions;
+
+            entry->assign(sendCallback, sendOptions);
+
+            NTCCFG_TEST_EQ(numInvoked, 0);
+
+            Entry::dispatch(
+                entry, sender, event, ntci::Strand::unspecified(), executor, false, &mutex);
+
+            NTCCFG_TEST_EQ(numInvoked, 0);
+            strand->drain();
+            NTCCFG_TEST_EQ(numInvoked, 1);
+
+            Entry::dispatch(
+                entry, sender, event, ntci::Strand::unspecified(), executor, false, &mutex);
+                
+            NTCCFG_TEST_EQ(numInvoked, 1);
+            strand->drain();
+            NTCCFG_TEST_EQ(numInvoked, 1);
+        }
+
+        // Test announcement forcing it to be deferred through an executor.
+
+        {
+            bsl::shared_ptr<Entry> entry;
+            entry.createInplace(&ta, &ta);
+
+            bsls::AtomicUint numInvoked(0);
+
+            ntci::SendCallback sendCallback(
+                NTCCFG_BIND(&test::EventUtil::processComplete,
+                            &numInvoked,
+                            NTCCFG_BIND_PLACEHOLDER_1,
+                            NTCCFG_BIND_PLACEHOLDER_2));
+
+            ntca::SendOptions sendOptions;
+
+            entry->assign(sendCallback, sendOptions);
+
+            NTCCFG_TEST_EQ(numInvoked, 0);
+
+            Entry::dispatch(
+                entry, sender, event, ntci::Strand::unspecified(), executor, true, &mutex);
+
+            NTCCFG_TEST_EQ(numInvoked, 0);
+            strand->drain();
+            NTCCFG_TEST_EQ(numInvoked, 1);
+
+            Entry::dispatch(
+                entry, sender, event, ntci::Strand::unspecified(), executor, true, &mutex);
+                
+            NTCCFG_TEST_EQ(numInvoked, 1);
+            strand->drain();
+            NTCCFG_TEST_EQ(numInvoked, 1);
+        }
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(3)
+{
+    // Concern:
+    // Plan:
+
+    ntccfg::TestAllocator ta;
+    {
+        const bsl::size_t k_ORIGINAL_DATA_SIZE = 1024;
+        const bsl::size_t k_MESSAGE_SIZE = 3;
+
+        const bsl::size_t k_LOW_WATERMARK = 0;
+        const bsl::size_t k_HIGH_WATERMARK = 1024 * 1024;
+
+        bdlbb::SimpleBlobBufferFactory blobBufferFactory(8, &ta);
+
+        ntcq::SendQueue sendQueue(&ta);
+
+        sendQueue.setLowWatermark(k_LOW_WATERMARK);
+        sendQueue.setHighWatermark(k_HIGH_WATERMARK);
+
+        bsl::shared_ptr<ntsa::Data> originalData;
+        originalData.createInplace(&ta, &blobBufferFactory, &ta);
+
+        ntsd::DataUtil::generateData(&originalData->makeBlob(), 
+                                     k_ORIGINAL_DATA_SIZE);
+        NTCCFG_TEST_EQ(originalData->size(), k_ORIGINAL_DATA_SIZE);
+
+        bsl::shared_ptr<ntsa::Data> originalDataRemaining;
+        originalDataRemaining.createInplace(&ta, originalData->blob(), &blobBufferFactory, &ta);
+        NTCCFG_TEST_EQ(originalDataRemaining->size(), k_ORIGINAL_DATA_SIZE);
+        NTCCFG_TEST_NE(&originalDataRemaining->blob(), &originalData->blob());
+
+
+
+
+        {
+            bsl::shared_ptr<ntsa::Data> data;
+            data.createInplace(&ta, &blobBufferFactory, &ta);
+
+            {
+                bdlbb::Blob& blob = data->makeBlob();
+            }
+
+            ntcq::SendQueueEntry sendQueueEntry;
+            sendQueueEntry.setId(sendQueue.generateEntryId());
+            sendQueueEntry.setData(data);
+            sendQueueEntry.setLength(data->size());
+
+        }
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(4)
+{
+    // Concern: Batching next suitable entries: empty 
+    // Plan:
+
+    ntccfg::TestAllocator ta;
+    {
+        ntcq::SendQueue sendQueue(&ta);
+
+        ntsa::ConstBufferArray bufferArray(&ta);
+
+        bool result = sendQueue.batchNext(&bufferArray, ntsa::SendOptions());
+        NTCCFG_TEST_FALSE(result);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(5)
+{
+    // Concern: Batching next suitable entries: blob
+    // Plan:
+
+    ntccfg::TestAllocator ta;
+    {
+        const bsl::size_t k_BLOB_BUFFER_SIZE = 32;
+        const bsl::size_t k_MESSAGE_SIZE = 1024;
+
+        bdlbb::SimpleBlobBufferFactory blobBufferFactory(k_BLOB_BUFFER_SIZE, &ta);
+
+        ntcq::SendQueue sendQueue(&ta);
+
+        {
+            bsl::shared_ptr<ntsa::Data> data;
+            data.createInplace(&ta, &blobBufferFactory, &ta);
+
+            
+
+            ntcq::SendQueueEntry sendQueueEntry;
+            sendQueueEntry.setId(sendQueue.generateEntryId());
+            sendQueueEntry.setData(data);
+            sendQueueEntry.setLength(data->size());
+
+
+        }
+
+        ntsa::ConstBufferArray bufferArray(&ta);
+
+        bool result = sendQueue.batchNext(&bufferArray, ntsa::SendOptions());
+        NTCCFG_TEST_FALSE(result);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(6)
+{
+    // Concern: Batching next suitable entries: blob -> blob
+    // Plan:
+
+    ntccfg::TestAllocator ta;
+    {
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(7)
+{
+    // Concern: Batching next suitable entries: blob -> file
+    // Plan:
+
+    ntccfg::TestAllocator ta;
+    {
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(8)
+{
+    // Concern: Batching next suitable entries: file -> blob
+    // Plan:
+
+    ntccfg::TestAllocator ta;
+    {
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(9)
 {
     // Concern:
     // Plan:
@@ -50,5 +593,13 @@ NTCCFG_TEST_CASE(1)
 NTCCFG_TEST_DRIVER
 {
     NTCCFG_TEST_REGISTER(1);
+    NTCCFG_TEST_REGISTER(2);
+    NTCCFG_TEST_REGISTER(3);
+    NTCCFG_TEST_REGISTER(4);
+    NTCCFG_TEST_REGISTER(5);
+    NTCCFG_TEST_REGISTER(6);
+    NTCCFG_TEST_REGISTER(7);
+    NTCCFG_TEST_REGISTER(8);
+    NTCCFG_TEST_REGISTER(9);
 }
 NTCCFG_TEST_DRIVER_END;

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -874,6 +874,9 @@ ntsa::Error StreamSocket::privateSocketWritableConnection(
         }
     }
 
+    d_sendOptions.setMaxBuffers(d_socket_sp->maxBuffersPerSend());
+    d_receiveOptions.setMaxBuffers(d_socket_sp->maxBuffersPerReceive());
+
     NTCS_METRICS_UPDATE_CONNECT_COMPLETE();
 
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
@@ -3195,6 +3198,9 @@ ntsa::Error StreamSocket::privateOpen(
             d_receiveOptions.setMaxBytes(receiveBufferSize);
         }
     }
+
+    d_sendOptions.setMaxBuffers(streamSocket->maxBuffersPerSend());
+    d_receiveOptions.setMaxBuffers(streamSocket->maxBuffersPerReceive());
 
     {
         ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -963,13 +963,145 @@ ntsa::Error StreamSocket::privateSocketWritableConnection(
 ntsa::Error StreamSocket::privateSocketWritableIteration(
     const bsl::shared_ptr<StreamSocket>& self)
 {
+    if (!d_sendQueue.hasEntry()) {
+        return ntsa::Error(ntsa::Error::e_WOULD_BLOCK);
+    }
+
+    if (d_sendQueue.batchNext(&d_sendData_sp->constBufferArray(),
+                              d_sendOptions))
+    {
+        return this->privateSocketWritableIterationBatch(self);
+    }
+    else
+    {
+        return this->privateSocketWritableIterationFront(self);
+    }
+}
+
+ntsa::Error StreamSocket::privateSocketWritableIterationBatch(
+    const bsl::shared_ptr<StreamSocket>& self)
+{
     NTCI_LOG_CONTEXT();
 
     ntsa::Error error;
 
-    if (!d_sendQueue.hasEntry()) {
-        return ntsa::Error(ntsa::Error::e_WOULD_BLOCK);
+    ntsa::SendContext context;
+    error = this->privateEnqueueSendBuffer(self, &context, *d_sendData_sp);
+    if (NTCCFG_UNLIKELY(error)) {
+        return error;
     }
+
+    bsl::size_t numBytesRemaining = context.bytesSent();
+
+    typedef bsl::vector< bsl::shared_ptr<ntcq::SendCallbackQueueEntry> >
+    SendCallbackQueueEntryVector;
+
+    bdlma::LocalSequentialAllocator<1024> callbackEntryVectorAllocator;
+
+    SendCallbackQueueEntryVector callbackEntryVector(
+                                              &callbackEntryVectorAllocator);
+
+    while (true) {
+        if (numBytesRemaining == 0) {
+            break;
+        }
+
+        ntcq::SendQueueEntry& entry = d_sendQueue.frontEntry();
+
+        const bool hasDeadline = !entry.deadline().isNull();
+
+        if (numBytesRemaining >= entry.length()) {
+            numBytesRemaining -= entry.length();
+
+            NTCS_METRICS_UPDATE_WRITE_QUEUE_DELAY(entry.delay());
+
+            if (entry.callbackEntry()) {
+                callbackEntryVector.push_back(entry.callbackEntry());
+            }
+
+            d_sendQueue.popEntry();
+        }
+        else {
+            if (hasDeadline) {
+                entry.setDeadline(bdlb::NullableValue<bsls::TimeInterval>());
+                entry.closeTimer();
+            }
+            d_sendQueue.popSize(numBytesRemaining);
+            numBytesRemaining = 0;
+
+            break;
+        }
+    }
+
+    NTCR_STREAMSOCKET_LOG_WRITE_QUEUE_DRAINED(d_sendQueue.size(),
+                                              d_sendQueue.highWatermark());
+
+    NTCS_METRICS_UPDATE_WRITE_QUEUE_SIZE(d_sendQueue.size());
+
+    if (!callbackEntryVector.empty()) {
+        for (SendCallbackQueueEntryVector::iterator
+                it  = callbackEntryVector.begin();
+                it != callbackEntryVector.end();
+              ++it)
+        {
+            const bsl::shared_ptr<ntcq::SendCallbackQueueEntry>&
+            callbackEntry = *it;
+
+            ntca::SendContext sendContext;
+
+            ntca::SendEvent sendEvent;
+            sendEvent.setType(ntca::SendEventType::e_COMPLETE);
+            sendEvent.setContext(sendContext);
+
+            ntcq::SendCallbackQueueEntry::dispatch(callbackEntry,
+                                                   self,
+                                                   sendEvent,
+                                                   d_reactorStrand_sp,
+                                                   self,
+                                                   false,
+                                                   &d_mutex);
+        }
+    }
+
+    if (d_sendQueue.authorizeLowWatermarkEvent()) {
+        NTCR_STREAMSOCKET_LOG_WRITE_QUEUE_LOW_WATERMARK(
+            d_sendQueue.lowWatermark(),
+            d_sendQueue.size());
+
+        if (d_session_sp) {
+            ntca::WriteQueueEvent event;
+            event.setType(ntca::WriteQueueEventType::e_LOW_WATERMARK);
+            event.setContext(d_sendQueue.context());
+
+            ntcs::Dispatch::announceWriteQueueLowWatermark(
+                d_session_sp,
+                self,
+                event,
+                d_sessionStrand_sp,
+                d_reactorStrand_sp,
+                self,
+                true,
+                &d_mutex);
+        }
+    }
+
+    if (!d_sendQueue.hasEntry()) {
+        this->privateApplyFlowControl(self,
+                                      ntca::FlowControlType::e_SEND,
+                                      ntca::FlowControlMode::e_IMMEDIATE,
+                                      false,
+                                      false);
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error StreamSocket::privateSocketWritableIterationFront(
+    const bsl::shared_ptr<StreamSocket>& self)
+{
+    NTCI_LOG_CONTEXT();
+
+    ntsa::Error error;
 
     ntcq::SendQueueEntry& entry = d_sendQueue.frontEntry();
 
@@ -3585,6 +3717,7 @@ StreamSocket::StreamSocket(
 , d_sendRateTimer_sp()
 , d_sendGreedily(NTCCFG_DEFAULT_STREAM_SOCKET_WRITE_GREEDILY)
 , d_sendCount(0)
+, d_sendData_sp()
 , d_receiveOptions()
 , d_receiveQueue(basicAllocator)
 , d_receiveFeedback()
@@ -3617,6 +3750,10 @@ StreamSocket::StreamSocket(
     }
 
     d_sendQueue.setData(d_dataPool_sp->createOutgoingBlob());
+
+    d_sendData_sp = d_dataPool_sp->createOutgoingData();
+    d_sendData_sp->makeConstBufferArray();
+
     d_receiveQueue.setData(d_dataPool_sp->createIncomingBlob());
     d_receiveBlob_sp = d_dataPool_sp->createIncomingBlob();
 

--- a/groups/ntc/ntcr/ntcr_streamsocket.h
+++ b/groups/ntc/ntcr/ntcr_streamsocket.h
@@ -110,6 +110,7 @@ class StreamSocket : public ntci::StreamSocket,
     bsl::shared_ptr<ntci::Timer>               d_sendRateTimer_sp;
     bool                                       d_sendGreedily;
     bsl::uint64_t                              d_sendCount;
+    bsl::shared_ptr<ntsa::Data>                d_sendData_sp;
     ntsa::ReceiveOptions                       d_receiveOptions;
     ntcq::ReceiveQueue                         d_receiveQueue;
     ntcq::ReceiveFeedback                      d_receiveFeedback;
@@ -210,6 +211,17 @@ class StreamSocket : public ntci::StreamSocket,
     /// Process the writability of the socket by performing one write
     /// iteration.
     ntsa::Error privateSocketWritableIteration(
+        const bsl::shared_ptr<StreamSocket>& self);
+
+    /// Process the writability of the socket by performing one write
+    /// iteration from the contiguous range of suitable entries at the front
+    /// of the write queue.
+    ntsa::Error privateSocketWritableIterationBatch(
+        const bsl::shared_ptr<StreamSocket>& self);
+
+    /// Process the writability of the socket by performing one write
+    /// iteration from the entry at the front of the write queue.
+    ntsa::Error privateSocketWritableIterationFront(
         const bsl::shared_ptr<StreamSocket>& self);
 
     /// Indicate a connection failure has occurred. If the specified 'defer'

--- a/groups/nts/ntsa/ntsa_data.cpp
+++ b/groups/nts/ntsa/ntsa_data.cpp
@@ -18,8 +18,8 @@
 #include <bsls_ident.h>
 BSLS_IDENT_RCSID(ntsa_data_cpp, "$Id$ $CSID$")
 
-#include <bdlbb_blobutil.h>
 #include <bdlbb_blobstreambuf.h>
+#include <bdlbb_blobutil.h>
 #include <bdlbb_simpleblobbufferfactory.h>
 #include <bdls_filesystemutil.h>
 
@@ -1874,43 +1874,57 @@ struct DataUtilImpl {
 
     /// Copy of the specified 'source' into the specified destination. Return
     /// the error.
-    static ntsa::Error copyBlob(bsl::streambuf *destination, const bdlbb::Blob& source);
+    static ntsa::Error copyBlob(bsl::streambuf*    destination,
+                                const bdlbb::Blob& source);
 
     /// Copy of the specified 'source' into the specified destination. Return
     /// the error.
-    static ntsa::Error copyBlobBuffer(bsl::streambuf *destination, const bdlbb::BlobBuffer& source);
+    static ntsa::Error copyBlobBuffer(bsl::streambuf*          destination,
+                                      const bdlbb::BlobBuffer& source);
 
     /// Copy of the specified 'source' into the specified destination. Return
     /// the error.
-    static ntsa::Error copyConstBuffer(bsl::streambuf *destination, const ntsa::ConstBuffer& source);
+    static ntsa::Error copyConstBuffer(bsl::streambuf*          destination,
+                                       const ntsa::ConstBuffer& source);
 
     /// Copy of the specified 'source' into the specified destination. Return
     /// the error.
-    static ntsa::Error copyConstBufferArray(bsl::streambuf *destination, const ntsa::ConstBufferArray& source);
+    static ntsa::Error copyConstBufferArray(
+        bsl::streambuf*               destination,
+        const ntsa::ConstBufferArray& source);
 
     /// Copy of the specified 'source' into the specified destination. Return
     /// the error.
-    static ntsa::Error copyConstBufferPtrArray(bsl::streambuf *destination, const ntsa::ConstBufferPtrArray& source);
+    static ntsa::Error copyConstBufferPtrArray(
+        bsl::streambuf*                  destination,
+        const ntsa::ConstBufferPtrArray& source);
 
     /// Copy of the specified 'source' into the specified destination. Return
     /// the error.
-    static ntsa::Error copyMutableBuffer(bsl::streambuf *destination, const ntsa::MutableBuffer& source);
+    static ntsa::Error copyMutableBuffer(bsl::streambuf* destination,
+                                         const ntsa::MutableBuffer& source);
 
     /// Copy of the specified 'source' into the specified destination. Return
     /// the error.
-    static ntsa::Error copyMutableBufferArray(bsl::streambuf *destination, const ntsa::MutableBufferArray& source);
+    static ntsa::Error copyMutableBufferArray(
+        bsl::streambuf*                 destination,
+        const ntsa::MutableBufferArray& source);
 
     /// Copy of the specified 'source' into the specified destination. Return
     /// the error.
-    static ntsa::Error copyMutableBufferPtrArray(bsl::streambuf *destination, const ntsa::MutableBufferPtrArray& source);
+    static ntsa::Error copyMutableBufferPtrArray(
+        bsl::streambuf*                    destination,
+        const ntsa::MutableBufferPtrArray& source);
 
     /// Copy of the specified 'source' into the specified destination. Return
     /// the error.
-    static ntsa::Error copyFile(bsl::streambuf *destination, const ntsa::File& source);
+    static ntsa::Error copyFile(bsl::streambuf*   destination,
+                                const ntsa::File& source);
 
     /// Copy of the specified 'source' into the specified destination. Return
     /// the error.
-    static ntsa::Error copyString(bsl::streambuf *destination, const bsl::string& source);
+    static ntsa::Error copyString(bsl::streambuf*    destination,
+                                  const bsl::string& source);
 };
 
 bsl::size_t DataUtilImpl::appendUndefined(bdlbb::Blob*      destination,
@@ -2279,7 +2293,8 @@ void DataUtilImpl::popFile(ntsa::Data* data, bsl::size_t numBytes)
     file->setBytesRemaining(file->bytesRemaining() - numBytesToPop);
 }
 
-ntsa::Error DataUtilImpl::copyBlob(bsl::streambuf *destination, const bdlbb::Blob& source)
+ntsa::Error DataUtilImpl::copyBlob(bsl::streambuf*    destination,
+                                   const bdlbb::Blob& source)
 {
     ntsa::Error error;
 
@@ -2298,7 +2313,8 @@ ntsa::Error DataUtilImpl::copyBlob(bsl::streambuf *destination, const bdlbb::Blo
 
         const char* data = buffer.data();
 
-        error = DataUtilImpl::copyConstBuffer(destination, ntsa::ConstBuffer(data, size));
+        error = DataUtilImpl::copyConstBuffer(destination,
+                                              ntsa::ConstBuffer(data, size));
         if (error) {
             return error;
         }
@@ -2307,17 +2323,21 @@ ntsa::Error DataUtilImpl::copyBlob(bsl::streambuf *destination, const bdlbb::Blo
     return ntsa::Error();
 }
 
-ntsa::Error DataUtilImpl::copyBlobBuffer(bsl::streambuf *destination, const bdlbb::BlobBuffer& source)
+ntsa::Error DataUtilImpl::copyBlobBuffer(bsl::streambuf*          destination,
+                                         const bdlbb::BlobBuffer& source)
 {
-    return DataUtilImpl::copyConstBuffer(destination, ntsa::ConstBuffer(source.data(), source.size()));
+    return DataUtilImpl::copyConstBuffer(
+        destination,
+        ntsa::ConstBuffer(source.data(), source.size()));
 }
 
-ntsa::Error DataUtilImpl::copyConstBuffer(bsl::streambuf *destination, const ntsa::ConstBuffer& source)
+ntsa::Error DataUtilImpl::copyConstBuffer(bsl::streambuf*          destination,
+                                          const ntsa::ConstBuffer& source)
 {
-    const std::streamsize numBytesToCopyMax = 
+    const std::streamsize numBytesToCopyMax =
         bsl::numeric_limits<std::streamsize>::max();
 
-    const char* currentDataSource = 
+    const char* currentDataSource =
         reinterpret_cast<const char*>(source.data());
 
     bsl::size_t numBytesRemaining = source.size();
@@ -2334,8 +2354,8 @@ ntsa::Error DataUtilImpl::copyConstBuffer(bsl::streambuf *destination, const nts
         else {
             numBytesToCopy = numBytesToCopyMax;
         }
-    
-        std::streamsize numBytesCopied = 
+
+        std::streamsize numBytesCopied =
             destination->sputn(currentDataSource, numBytesToCopy);
 
         currentDataSource += numBytesCopied;
@@ -2351,7 +2371,9 @@ ntsa::Error DataUtilImpl::copyConstBuffer(bsl::streambuf *destination, const nts
     return ntsa::Error();
 }
 
-ntsa::Error DataUtilImpl::copyConstBufferArray(bsl::streambuf *destination, const ntsa::ConstBufferArray& source)
+ntsa::Error DataUtilImpl::copyConstBufferArray(
+    bsl::streambuf*               destination,
+    const ntsa::ConstBufferArray& source)
 {
     ntsa::Error error;
 
@@ -2367,7 +2389,9 @@ ntsa::Error DataUtilImpl::copyConstBufferArray(bsl::streambuf *destination, cons
     return ntsa::Error();
 }
 
-ntsa::Error DataUtilImpl::copyConstBufferPtrArray(bsl::streambuf *destination, const ntsa::ConstBufferPtrArray& source)
+ntsa::Error DataUtilImpl::copyConstBufferPtrArray(
+    bsl::streambuf*                  destination,
+    const ntsa::ConstBufferPtrArray& source)
 {
     ntsa::Error error;
 
@@ -2383,19 +2407,25 @@ ntsa::Error DataUtilImpl::copyConstBufferPtrArray(bsl::streambuf *destination, c
     return ntsa::Error();
 }
 
-ntsa::Error DataUtilImpl::copyMutableBuffer(bsl::streambuf *destination, const ntsa::MutableBuffer& source)
+ntsa::Error DataUtilImpl::copyMutableBuffer(bsl::streambuf* destination,
+                                            const ntsa::MutableBuffer& source)
 {
-    return DataUtilImpl::copyConstBuffer(destination, ntsa::ConstBuffer(source));
+    return DataUtilImpl::copyConstBuffer(destination,
+                                         ntsa::ConstBuffer(source));
 }
 
-ntsa::Error DataUtilImpl::copyMutableBufferArray(bsl::streambuf *destination, const ntsa::MutableBufferArray& source)
+ntsa::Error DataUtilImpl::copyMutableBufferArray(
+    bsl::streambuf*                 destination,
+    const ntsa::MutableBufferArray& source)
 {
     ntsa::Error error;
 
     const bsl::size_t numBuffers = source.numBuffers();
 
     for (bsl::size_t i = 0; i < numBuffers; ++i) {
-        error = DataUtilImpl::copyConstBuffer(destination, ntsa::ConstBuffer(source.buffer(i)));
+        error =
+            DataUtilImpl::copyConstBuffer(destination,
+                                          ntsa::ConstBuffer(source.buffer(i)));
         if (error) {
             return error;
         }
@@ -2404,14 +2434,18 @@ ntsa::Error DataUtilImpl::copyMutableBufferArray(bsl::streambuf *destination, co
     return ntsa::Error();
 }
 
-ntsa::Error DataUtilImpl::copyMutableBufferPtrArray(bsl::streambuf *destination, const ntsa::MutableBufferPtrArray& source)
+ntsa::Error DataUtilImpl::copyMutableBufferPtrArray(
+    bsl::streambuf*                    destination,
+    const ntsa::MutableBufferPtrArray& source)
 {
     ntsa::Error error;
 
     const bsl::size_t numBuffers = source.numBuffers();
 
     for (bsl::size_t i = 0; i < numBuffers; ++i) {
-        error = DataUtilImpl::copyConstBuffer(destination, ntsa::ConstBuffer(source.buffer(i)));
+        error =
+            DataUtilImpl::copyConstBuffer(destination,
+                                          ntsa::ConstBuffer(source.buffer(i)));
         if (error) {
             return error;
         }
@@ -2420,7 +2454,7 @@ ntsa::Error DataUtilImpl::copyMutableBufferPtrArray(bsl::streambuf *destination,
     return ntsa::Error();
 }
 
-ntsa::Error DataUtilImpl::copyFile(bsl::streambuf*   destination, 
+ntsa::Error DataUtilImpl::copyFile(bsl::streambuf*   destination,
                                    const ntsa::File& source)
 {
     ntsa::Error error;
@@ -2431,11 +2465,10 @@ ntsa::Error DataUtilImpl::copyFile(bsl::streambuf*   destination,
         return ntsa::Error(ntsa::Error::e_INVALID);
     }
 
-    bdls::FilesystemUtil::Offset currentPosition =
-        bdls::FilesystemUtil::seek(
-            fileDescriptor, 
-            source.position(), 
-            bdls::FilesystemUtil::e_SEEK_FROM_BEGINNING);
+    bdls::FilesystemUtil::Offset currentPosition = bdls::FilesystemUtil::seek(
+        fileDescriptor,
+        source.position(),
+        bdls::FilesystemUtil::e_SEEK_FROM_BEGINNING);
 
     if (currentPosition != source.position()) {
         error = ntsa::Error::last();
@@ -2456,8 +2489,8 @@ ntsa::Error DataUtilImpl::copyFile(bsl::streambuf*   destination,
         char buffer[k_BUFFER_SIZE];
 
         int numBytesToRead;
-        if (numBytesRemaining < 
-            static_cast<bdls::FilesystemUtil::Offset>(k_BUFFER_SIZE)) 
+        if (numBytesRemaining <
+            static_cast<bdls::FilesystemUtil::Offset>(k_BUFFER_SIZE))
         {
             numBytesToRead = static_cast<int>(numBytesRemaining);
         }
@@ -2465,15 +2498,16 @@ ntsa::Error DataUtilImpl::copyFile(bsl::streambuf*   destination,
             numBytesToRead = static_cast<int>(k_BUFFER_SIZE);
         }
 
-        int numBytesRead = bdls::FilesystemUtil::read(
-            fileDescriptor, &buffer, numBytesToRead);
+        int numBytesRead = bdls::FilesystemUtil::read(fileDescriptor,
+                                                      &buffer,
+                                                      numBytesToRead);
 
         BSLS_ASSERT(numBytesRead <= numBytesToRead);
 
         if (numBytesRead > 0) {
             error = DataUtilImpl::copyConstBuffer(
-                destination, 
-                ntsa::ConstBuffer(buffer, 
+                destination,
+                ntsa::ConstBuffer(buffer,
                                   static_cast<bsl::size_t>(numBytesRead)));
             if (error) {
                 return error;
@@ -2495,9 +2529,12 @@ ntsa::Error DataUtilImpl::copyFile(bsl::streambuf*   destination,
     return ntsa::Error();
 }
 
-ntsa::Error DataUtilImpl::copyString(bsl::streambuf *destination, const bsl::string& source)
+ntsa::Error DataUtilImpl::copyString(bsl::streambuf*    destination,
+                                     const bsl::string& source)
 {
-    return DataUtilImpl::copyConstBuffer(destination, ntsa::ConstBuffer(source.data(), source.size()));
+    return DataUtilImpl::copyConstBuffer(
+        destination,
+        ntsa::ConstBuffer(source.data(), source.size()));
 }
 
 DataUtilImplAppend s_append[12] = {
@@ -2541,7 +2578,8 @@ void DataUtil::pop(ntsa::Data* data, bsl::size_t numBytes)
     s_pop[data->type()](data, numBytes);
 }
 
-ntsa::Error DataUtil::copy(bsl::streambuf *destination, const ntsa::Data& source)
+ntsa::Error DataUtil::copy(bsl::streambuf*   destination,
+                           const ntsa::Data& source)
 {
     if (source.isBlob()) {
         return DataUtilImpl::copyBlob(destination, source.blob());
@@ -2550,22 +2588,31 @@ ntsa::Error DataUtil::copy(bsl::streambuf *destination, const ntsa::Data& source
         return DataUtilImpl::copyBlobBuffer(destination, source.blobBuffer());
     }
     else if (source.isConstBuffer()) {
-        return DataUtilImpl::copyConstBuffer(destination, source.constBuffer());
+        return DataUtilImpl::copyConstBuffer(destination,
+                                             source.constBuffer());
     }
     else if (source.isConstBufferArray()) {
-        return DataUtilImpl::copyConstBufferArray(destination, source.constBufferArray());
+        return DataUtilImpl::copyConstBufferArray(destination,
+                                                  source.constBufferArray());
     }
     else if (source.isConstBufferPtrArray()) {
-        return DataUtilImpl::copyConstBufferPtrArray(destination, source.constBufferPtrArray());
+        return DataUtilImpl::copyConstBufferPtrArray(
+            destination,
+            source.constBufferPtrArray());
     }
     else if (source.isMutableBuffer()) {
-        return DataUtilImpl::copyMutableBuffer(destination, source.mutableBuffer());
+        return DataUtilImpl::copyMutableBuffer(destination,
+                                               source.mutableBuffer());
     }
     else if (source.isMutableBufferArray()) {
-        return DataUtilImpl::copyMutableBufferArray(destination, source.mutableBufferArray());
+        return DataUtilImpl::copyMutableBufferArray(
+            destination,
+            source.mutableBufferArray());
     }
     else if (source.isMutableBufferPtrArray()) {
-        return DataUtilImpl::copyMutableBufferPtrArray(destination, source.mutableBufferPtrArray());
+        return DataUtilImpl::copyMutableBufferPtrArray(
+            destination,
+            source.mutableBufferPtrArray());
     }
     else if (source.isFile()) {
         return DataUtilImpl::copyFile(destination, source.file());
@@ -2586,8 +2633,7 @@ ntsa::Error DataUtil::copy(bsl::streambuf *destination, const ntsa::Data& source
     }
 }
 
-
-ntsa::Error DataUtil::copy(ntsa::Data *destination, const ntsa::Data& source)
+ntsa::Error DataUtil::copy(ntsa::Data* destination, const ntsa::Data& source)
 {
     destination->reset();
 
@@ -2596,7 +2642,8 @@ ntsa::Error DataUtil::copy(ntsa::Data *destination, const ntsa::Data& source)
     }
     else {
         bdlbb::SimpleBlobBufferFactory blobBufferFactory(
-            1024, bslma::Default::globalAllocator());
+            1024,
+            bslma::Default::globalAllocator());
 
         bdlbb::Blob blob(&blobBufferFactory);
 
@@ -2609,7 +2656,7 @@ ntsa::Error DataUtil::copy(ntsa::Data *destination, const ntsa::Data& source)
     }
 }
 
-ntsa::Error DataUtil::copy(bdlbb::Blob *destination, const ntsa::Data& source)
+ntsa::Error DataUtil::copy(bdlbb::Blob* destination, const ntsa::Data& source)
 {
     ntsa::Error error;
 
@@ -2647,7 +2694,8 @@ bool DataUtil::equals(const ntsa::Data& lhs, const ntsa::Data& rhs)
     }
     else {
         bdlbb::SimpleBlobBufferFactory blobBufferFactory(
-            8192, bslma::Default::globalAllocator());
+            8192,
+            bslma::Default::globalAllocator());
 
         bdlbb::Blob lhsBlob(&blobBufferFactory);
         bdlbb::Blob rhsBlob(&blobBufferFactory);

--- a/groups/nts/ntsa/ntsa_data.cpp
+++ b/groups/nts/ntsa/ntsa_data.cpp
@@ -1872,56 +1872,56 @@ struct DataUtilImpl {
 
     /// *** Copy ***
 
-    /// Copy of the specified 'source' into the specified destination. Return
+    /// Copy the specified 'source' into the specified 'destination'. Return
     /// the error.
     static ntsa::Error copyBlob(bsl::streambuf*    destination,
                                 const bdlbb::Blob& source);
 
-    /// Copy of the specified 'source' into the specified destination. Return
+    /// Copy the specified 'source' into the specified 'destination'. Return
     /// the error.
     static ntsa::Error copyBlobBuffer(bsl::streambuf*          destination,
                                       const bdlbb::BlobBuffer& source);
 
-    /// Copy of the specified 'source' into the specified destination. Return
+    /// Copy the specified 'source' into the specified 'destination'. Return
     /// the error.
     static ntsa::Error copyConstBuffer(bsl::streambuf*          destination,
                                        const ntsa::ConstBuffer& source);
 
-    /// Copy of the specified 'source' into the specified destination. Return
+    /// Copy the specified 'source' into the specified 'destination'. Return
     /// the error.
     static ntsa::Error copyConstBufferArray(
         bsl::streambuf*               destination,
         const ntsa::ConstBufferArray& source);
 
-    /// Copy of the specified 'source' into the specified destination. Return
+    /// Copy the specified 'source' into the specified 'destination'. Return
     /// the error.
     static ntsa::Error copyConstBufferPtrArray(
         bsl::streambuf*                  destination,
         const ntsa::ConstBufferPtrArray& source);
 
-    /// Copy of the specified 'source' into the specified destination. Return
+    /// Copy the specified 'source' into the specified 'destination'. Return
     /// the error.
     static ntsa::Error copyMutableBuffer(bsl::streambuf* destination,
                                          const ntsa::MutableBuffer& source);
 
-    /// Copy of the specified 'source' into the specified destination. Return
+    /// Copy the specified 'source' into the specified 'destination'. Return
     /// the error.
     static ntsa::Error copyMutableBufferArray(
         bsl::streambuf*                 destination,
         const ntsa::MutableBufferArray& source);
 
-    /// Copy of the specified 'source' into the specified destination. Return
+    /// Copy the specified 'source' into the specified 'destination'. Return
     /// the error.
     static ntsa::Error copyMutableBufferPtrArray(
         bsl::streambuf*                    destination,
         const ntsa::MutableBufferPtrArray& source);
 
-    /// Copy of the specified 'source' into the specified destination. Return
+    /// Copy the specified 'source' into the specified 'destination'. Return
     /// the error.
     static ntsa::Error copyFile(bsl::streambuf*   destination,
                                 const ntsa::File& source);
 
-    /// Copy of the specified 'source' into the specified destination. Return
+    /// Copy the specified 'source' into the specified 'destination'. Return
     /// the error.
     static ntsa::Error copyString(bsl::streambuf*    destination,
                                   const bsl::string& source);
@@ -2581,7 +2581,10 @@ void DataUtil::pop(ntsa::Data* data, bsl::size_t numBytes)
 ntsa::Error DataUtil::copy(bsl::streambuf*   destination,
                            const ntsa::Data& source)
 {
-    if (source.isBlob()) {
+    if (source.isUndefined()) {
+        return ntsa::Error();
+    }
+    else if (source.isBlob()) {
         return DataUtilImpl::copyBlob(destination, source.blob());
     }
     else if (source.isBlobBuffer()) {

--- a/groups/nts/ntsa/ntsa_data.cpp
+++ b/groups/nts/ntsa/ntsa_data.cpp
@@ -2686,8 +2686,6 @@ bool DataUtil::equals(const ntsa::Data& lhs, const ntsa::Data& rhs)
         return false;
     }
 
-    const bsl::size_t size = lhsSize;
-
     if (lhs.isBlob() && rhs.isBlob()) {
         rc = bdlbb::BlobUtil::compare(lhs.blob(), rhs.blob());
         return rc == 0;

--- a/groups/nts/ntsa/ntsa_data.h
+++ b/groups/nts/ntsa/ntsa_data.h
@@ -21,6 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #include <ntsa_buffer.h>
 #include <ntsa_datatype.h>
+#include <ntsa_error.h>
 #include <ntsa_file.h>
 #include <ntscfg_platform.h>
 #include <ntsscm_version.h>
@@ -560,6 +561,31 @@ struct DataUtil {
 
     /// Pop the specified 'numBytes' from the specified 'destination'.
     static void pop(ntsa::Data* data, bsl::size_t numBytes);
+
+    /// Copy of the specified 'source' into the specified destination. Return
+    /// the error. Note that this function may be considerably expensive, as it
+    /// performs a deep copy of all data referenced by 'source', including
+    /// any data referenced in a file.
+    static ntsa::Error copy(bsl::streambuf *destination, const ntsa::Data& source);
+
+    /// Copy of the specified 'source' into the specified destination. Return
+    /// the error. Note that this function may be considerably expensive, as it
+    /// performs a deep copy of all data referenced by 'source', including
+    /// any data referenced in a file.
+    static ntsa::Error copy(ntsa::Data *destination, const ntsa::Data& source);
+
+    /// Copy of the specified 'source' into the specified destination. Return
+    /// the error. Note that this function may be considerably expensive, as it
+    /// performs a deep copy of all data referenced by 'source', including
+    /// any data referenced in a file.
+    static ntsa::Error copy(bdlbb::Blob *destination, const ntsa::Data& source);
+
+    /// Return true if the specified 'lhs' refers to data having the same value
+    /// as the specified 'rhs', otherwise return false. Note that this function
+    /// may be considerably expensive, as it may perform a deep copy of all 
+    /// data referenced by 'lhs' or 'rhs', including any data referenced in a 
+    /// file.
+    static bool equals(const ntsa::Data& lhs, const ntsa::Data& rhs);
 };
 
 NTSCFG_INLINE

--- a/groups/nts/ntsa/ntsa_data.h
+++ b/groups/nts/ntsa/ntsa_data.h
@@ -566,24 +566,26 @@ struct DataUtil {
     /// the error. Note that this function may be considerably expensive, as it
     /// performs a deep copy of all data referenced by 'source', including
     /// any data referenced in a file.
-    static ntsa::Error copy(bsl::streambuf *destination, const ntsa::Data& source);
+    static ntsa::Error copy(bsl::streambuf*   destination,
+                            const ntsa::Data& source);
 
     /// Copy of the specified 'source' into the specified destination. Return
     /// the error. Note that this function may be considerably expensive, as it
     /// performs a deep copy of all data referenced by 'source', including
     /// any data referenced in a file.
-    static ntsa::Error copy(ntsa::Data *destination, const ntsa::Data& source);
+    static ntsa::Error copy(ntsa::Data* destination, const ntsa::Data& source);
 
     /// Copy of the specified 'source' into the specified destination. Return
     /// the error. Note that this function may be considerably expensive, as it
     /// performs a deep copy of all data referenced by 'source', including
     /// any data referenced in a file.
-    static ntsa::Error copy(bdlbb::Blob *destination, const ntsa::Data& source);
+    static ntsa::Error copy(bdlbb::Blob*      destination,
+                            const ntsa::Data& source);
 
     /// Return true if the specified 'lhs' refers to data having the same value
     /// as the specified 'rhs', otherwise return false. Note that this function
-    /// may be considerably expensive, as it may perform a deep copy of all 
-    /// data referenced by 'lhs' or 'rhs', including any data referenced in a 
+    /// may be considerably expensive, as it may perform a deep copy of all
+    /// data referenced by 'lhs' or 'rhs', including any data referenced in a
     /// file.
     static bool equals(const ntsa::Data& lhs, const ntsa::Data& rhs);
 };

--- a/groups/nts/ntsa/ntsa_data.t.cpp
+++ b/groups/nts/ntsa/ntsa_data.t.cpp
@@ -15,8 +15,8 @@
 
 #include <ntsa_data.h>
 
-#include <ntscfg_test.h>
 #include <ntsa_temporary.h>
+#include <ntscfg_test.h>
 
 #include <bdlbb_blob.h>
 #include <bdlbb_blobstreambuf.h>
@@ -688,16 +688,15 @@ NTSCFG_TEST_CASE(24)
         error = tempFile.write(bsl::string(test::DATA, test::DATA_SIZE));
         NTSCFG_TEST_OK(error);
 
-        bdls::FilesystemUtil::FileDescriptor fileDescriptor = 
-            bdls::FilesystemUtil::open(
-                tempFile.path().c_str(),
-                bdls::FilesystemUtil::e_OPEN,
-                bdls::FilesystemUtil::e_READ_ONLY);
+        bdls::FilesystemUtil::FileDescriptor fileDescriptor =
+            bdls::FilesystemUtil::open(tempFile.path().c_str(),
+                                       bdls::FilesystemUtil::e_OPEN,
+                                       bdls::FilesystemUtil::e_READ_ONLY);
 
         NTSCFG_TEST_NE(fileDescriptor, bdls::FilesystemUtil::k_INVALID_FD);
 
         ntsa::Data data(&ta);
-        {            
+        {
             ntsa::File& file = data.makeFile();
 
             file.setDescriptor(fileDescriptor);
@@ -712,16 +711,6 @@ NTSCFG_TEST_CASE(24)
     }
     NTSCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
-
-
-
-
-
-
-
-
-
-
 
 NTSCFG_TEST_CASE(25)
 {
@@ -1136,16 +1125,15 @@ NTSCFG_TEST_CASE(36)
         error = tempFile.write(bsl::string(test::DATA, test::DATA_SIZE));
         NTSCFG_TEST_OK(error);
 
-        bdls::FilesystemUtil::FileDescriptor fileDescriptor = 
-            bdls::FilesystemUtil::open(
-                tempFile.path().c_str(),
-                bdls::FilesystemUtil::e_OPEN,
-                bdls::FilesystemUtil::e_READ_ONLY);
+        bdls::FilesystemUtil::FileDescriptor fileDescriptor =
+            bdls::FilesystemUtil::open(tempFile.path().c_str(),
+                                       bdls::FilesystemUtil::e_OPEN,
+                                       bdls::FilesystemUtil::e_READ_ONLY);
 
         NTSCFG_TEST_NE(fileDescriptor, bdls::FilesystemUtil::k_INVALID_FD);
 
         ntsa::Data data(&ta);
-        {            
+        {
             ntsa::File& file = data.makeFile();
 
             file.setDescriptor(fileDescriptor);
@@ -1161,7 +1149,6 @@ NTSCFG_TEST_CASE(36)
     }
     NTSCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
-
 
 NTSCFG_TEST_DRIVER
 {
@@ -1191,7 +1178,6 @@ NTSCFG_TEST_DRIVER
     NTSCFG_TEST_REGISTER(23);
     NTSCFG_TEST_REGISTER(24);
 
-    
     NTSCFG_TEST_REGISTER(25);
     NTSCFG_TEST_REGISTER(26);
     NTSCFG_TEST_REGISTER(27);

--- a/groups/nts/ntsa/ntsa_temporary.cpp
+++ b/groups/nts/ntsa/ntsa_temporary.cpp
@@ -33,7 +33,7 @@ namespace ntsa {
 
 namespace {
 
-// Provide utilities for implementing temporary directory and file guards. 
+// Provide utilities for implementing temporary directory and file guards.
 // This struct is thread safe.
 struct TempUtil {
     // Return the effective temporary directory defined for the user and
@@ -41,18 +41,18 @@ struct TempUtil {
     // separator, even if the definition of the environment variable does
     // not.
     static bsl::string tempDir();
-        
+
     // Return the default temporary directory when no environment variables
     // are defined.  The result is guaranteed to have a trailing path
     // separator.
-    static bsl::string tempDirDefault();  
+    static bsl::string tempDirDefault();
 };
 
 #if defined(BSLS_PLATFORM_OS_UNIX)
 
 bsl::string TempUtil::tempDir()
 {
-    const char *tmp;
+    const char* tmp;
     tmp = std::getenv("TMPDIR");
     if (tmp == 0) {
         tmp = std::getenv("TMP");
@@ -96,7 +96,7 @@ bsl::string TempUtil::tempDir()
 {
     char buffer[MAX_PATH + 1];
 
-    const char *tmp;
+    const char* tmp;
 
     tmp = std::getenv("TMPDIR");
     if (tmp != 0) {
@@ -117,8 +117,8 @@ bsl::string TempUtil::tempDir()
         result = ".";
     }
 
-    if (result[result.size() - 1] != '/' && result[result.size() - 1] !=
-                                                '\\') {
+    if (result[result.size() - 1] != '/' && result[result.size() - 1] != '\\')
+    {
         result.push_back('\\');
     }
 
@@ -137,8 +137,8 @@ bsl::string TempUtil::tempDirDefault()
         result = ".";
     }
 
-    if (result[result.size() - 1] != '/' && result[result.size() - 1] !=
-                                                '\\') {
+    if (result[result.size() - 1] != '/' && result[result.size() - 1] != '\\')
+    {
         result.push_back('\\');
     }
 
@@ -149,10 +149,10 @@ bsl::string TempUtil::tempDirDefault()
 #error Not implemented
 #endif
 
-} // close unnamed namespace
+}  // close unnamed namespace
 
 // CREATORS
-TemporaryDirectory::TemporaryDirectory(bslma::Allocator *basicAllocator)
+TemporaryDirectory::TemporaryDirectory(bslma::Allocator* basicAllocator)
 : d_path(basicAllocator)
 , d_keep(false)
 {
@@ -183,7 +183,7 @@ const bsl::string& TemporaryDirectory::path() const
 }
 
 // CREATORS
-TemporaryFile::TemporaryFile(bslma::Allocator *basicAllocator)
+TemporaryFile::TemporaryFile(bslma::Allocator* basicAllocator)
 : d_path(basicAllocator)
 , d_keep(false)
 {
@@ -198,8 +198,8 @@ TemporaryFile::TemporaryFile(bslma::Allocator *basicAllocator)
     BSLS_ASSERT_OPT(rc == 0);
 }
 
-TemporaryFile::TemporaryFile(ntsa::TemporaryDirectory *tempDirectory, 
-                   bslma::Allocator         *basicAllocator)
+TemporaryFile::TemporaryFile(ntsa::TemporaryDirectory* tempDirectory,
+                             bslma::Allocator*         basicAllocator)
 : d_path(basicAllocator)
 , d_keep(false)
 {
@@ -226,9 +226,9 @@ TemporaryFile::TemporaryFile(ntsa::TemporaryDirectory *tempDirectory,
     BSLS_ASSERT_OPT(rc == 0);
 }
 
-TemporaryFile::TemporaryFile(ntsa::TemporaryDirectory *tempDirectory, 
-                   const bsl::string&        filename, 
-                   bslma::Allocator         *basicAllocator)
+TemporaryFile::TemporaryFile(ntsa::TemporaryDirectory* tempDirectory,
+                             const bsl::string&        filename,
+                             bslma::Allocator*         basicAllocator)
 : d_path(basicAllocator)
 , d_keep(false)
 {
@@ -251,11 +251,10 @@ TemporaryFile::TemporaryFile(ntsa::TemporaryDirectory *tempDirectory,
     rc = bdls::PathUtil::appendIfValid(&d_path, filename.c_str());
     BSLS_ASSERT_OPT(rc == 0);
 
-    bdls::FilesystemUtil::FileDescriptor descriptor = 
-        bdls::FilesystemUtil::open(
-            d_path.c_str(), 
-            bdls::FilesystemUtil::e_CREATE, 
-            bdls::FilesystemUtil::e_READ_WRITE);
+    bdls::FilesystemUtil::FileDescriptor descriptor =
+        bdls::FilesystemUtil::open(d_path.c_str(),
+                                   bdls::FilesystemUtil::e_CREATE,
+                                   bdls::FilesystemUtil::e_READ_WRITE);
 
     BSLS_ASSERT_OPT(descriptor != bdls::FilesystemUtil::k_INVALID_FD);
 
@@ -281,11 +280,10 @@ ntsa::Error TemporaryFile::write(const bsl::string& content)
 {
     int rc;
 
-    bdls::FilesystemUtil::FileDescriptor descriptor = 
-        bdls::FilesystemUtil::open(
-            d_path.c_str(), 
-            bdls::FilesystemUtil::e_OPEN, 
-            bdls::FilesystemUtil::e_READ_WRITE);
+    bdls::FilesystemUtil::FileDescriptor descriptor =
+        bdls::FilesystemUtil::open(d_path.c_str(),
+                                   bdls::FilesystemUtil::e_OPEN,
+                                   bdls::FilesystemUtil::e_READ_WRITE);
 
     BSLS_ASSERT_OPT(descriptor != bdls::FilesystemUtil::k_INVALID_FD);
 
@@ -294,9 +292,11 @@ ntsa::Error TemporaryFile::write(const bsl::string& content)
 
     while (c != 0) {
         const bsl::size_t k_CHUNK_SIZE = 1024 * 32;
-        bsl::size_t numBytesToWrite = c < k_CHUNK_SIZE ? c : k_CHUNK_SIZE;
+        bsl::size_t numBytesToWrite    = c < k_CHUNK_SIZE ? c : k_CHUNK_SIZE;
 
-        rc = bdls::FilesystemUtil::write(descriptor, p, static_cast<int>(numBytesToWrite));
+        rc = bdls::FilesystemUtil::write(descriptor,
+                                         p,
+                                         static_cast<int>(numBytesToWrite));
         if (rc < 0) {
             return ntsa::Error::last();
         }

--- a/groups/nts/ntsa/ntsa_temporary.cpp
+++ b/groups/nts/ntsa/ntsa_temporary.cpp
@@ -41,11 +41,6 @@ struct TempUtil {
     // separator, even if the definition of the environment variable does
     // not.
     static bsl::string tempDir();
-
-    // Return the default temporary directory when no environment variables
-    // are defined.  The result is guaranteed to have a trailing path
-    // separator.
-    static bsl::string tempDirDefault();
 };
 
 #if defined(BSLS_PLATFORM_OS_UNIX)
@@ -85,11 +80,6 @@ bsl::string TempUtil::tempDir()
     return result;
 }
 
-bsl::string TempUtil::tempDirDefault()
-{
-    return bsl::string("/tmp/");
-}
-
 #elif defined(BSLS_PLATFORM_OS_WINDOWS)
 
 bsl::string TempUtil::tempDir()
@@ -110,26 +100,6 @@ bsl::string TempUtil::tempDir()
         DWORD rc = GetTempPathA(static_cast<DWORD>(sizeof buffer), buffer);
         BSLS_ASSERT_OPT(0 != rc);
     }
-
-    bsl::string result(buffer);
-
-    if (result.empty()) {
-        result = ".";
-    }
-
-    if (result[result.size() - 1] != '/' && result[result.size() - 1] != '\\')
-    {
-        result.push_back('\\');
-    }
-
-    return result;
-}
-
-bsl::string TempUtil::tempDirDefault()
-{
-    char  buffer[MAX_PATH + 1];
-    DWORD rc = GetWindowsDirectoryA(buffer, static_cast<UINT>(sizeof buffer));
-    BSLS_ASSERT_OPT(0 != rc);
 
     bsl::string result(buffer);
 

--- a/groups/nts/ntsa/ntsa_temporary.cpp
+++ b/groups/nts/ntsa/ntsa_temporary.cpp
@@ -1,0 +1,325 @@
+// Copyright 2020-2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ntsa_temporary.h>
+
+#include <bsls_ident.h>
+BSLS_IDENT_RCSID(ntsa_temporary_cpp, "$Id$ $CSID$")
+
+#include <bdls_pathutil.h>
+#include <bsls_assert.h>
+#include <bsls_platform.h>
+#include <bsl_cstdlib.h>
+#include <bsl_cstring.h>
+
+#if defined(BSLS_PLATFORM_OS_WINDOWS)
+#include <windows.h>
+#endif
+
+namespace BloombergLP {
+namespace ntsa {
+
+namespace {
+
+// Provide utilities for implementing temporary directory and file guards. 
+// This struct is thread safe.
+struct TempUtil {
+    // Return the effective temporary directory defined for the user and
+    // the system. The result is guaranteed to have a trailing path
+    // separator, even if the definition of the environment variable does
+    // not.
+    static bsl::string tempDir();
+        
+    // Return the default temporary directory when no environment variables
+    // are defined.  The result is guaranteed to have a trailing path
+    // separator.
+    static bsl::string tempDirDefault();  
+};
+
+#if defined(BSLS_PLATFORM_OS_UNIX)
+
+bsl::string TempUtil::tempDir()
+{
+    const char *tmp;
+    tmp = std::getenv("TMPDIR");
+    if (tmp == 0) {
+        tmp = std::getenv("TMP");
+        if (tmp == 0) {
+            tmp = std::getenv("TEMP");
+            if (tmp == 0) {
+                tmp = "/tmp/";
+            }
+        }
+    }
+
+    char buffer[PATH_MAX + 1];
+
+    std::size_t length = std::strlen(tmp);
+    BSLS_ASSERT_OPT(sizeof buffer >= length + 1);
+
+    std::memcpy(buffer, tmp, length);
+    buffer[length] = 0;
+
+    bsl::string result(buffer);
+
+    if (result.empty()) {
+        result = ".";
+    }
+
+    if (result[result.size() - 1] != '/') {
+        result.push_back('/');
+    }
+
+    return result;
+}
+
+bsl::string TempUtil::tempDirDefault()
+{
+    return bsl::string("/tmp/");
+}
+
+#elif defined(BSLS_PLATFORM_OS_WINDOWS)
+
+bsl::string TempUtil::tempDir()
+{
+    char buffer[MAX_PATH + 1];
+
+    const char *tmp;
+
+    tmp = std::getenv("TMPDIR");
+    if (tmp != 0) {
+        std::size_t length = std::strlen(tmp);
+        BSLS_ASSERT_OPT(sizeof buffer >= length + 1);
+
+        std::memcpy(buffer, tmp, length);
+        buffer[length] = 0;
+    }
+    else {
+        DWORD rc = GetTempPathA(static_cast<DWORD>(sizeof buffer), buffer);
+        BSLS_ASSERT_OPT(0 != rc);
+    }
+
+    bsl::string result(buffer);
+
+    if (result.empty()) {
+        result = ".";
+    }
+
+    if (result[result.size() - 1] != '/' && result[result.size() - 1] !=
+                                                '\\') {
+        result.push_back('\\');
+    }
+
+    return result;
+}
+
+bsl::string TempUtil::tempDirDefault()
+{
+    char  buffer[MAX_PATH + 1];
+    DWORD rc = GetWindowsDirectoryA(buffer, static_cast<UINT>(sizeof buffer));
+    BSLS_ASSERT_OPT(0 != rc);
+
+    bsl::string result(buffer);
+
+    if (result.empty()) {
+        result = ".";
+    }
+
+    if (result[result.size() - 1] != '/' && result[result.size() - 1] !=
+                                                '\\') {
+        result.push_back('\\');
+    }
+
+    return result;
+}
+
+#else
+#error Not implemented
+#endif
+
+} // close unnamed namespace
+
+// CREATORS
+TemporaryDirectory::TemporaryDirectory(bslma::Allocator *basicAllocator)
+: d_path(basicAllocator)
+, d_keep(false)
+{
+    bsl::string prefix = TempUtil::tempDir();
+
+    int rc = bdls::FilesystemUtil::createTemporaryDirectory(&d_path, prefix);
+    BSLS_ASSERT_OPT(rc == 0);
+}
+
+TemporaryDirectory::~TemporaryDirectory()
+{
+    if (!d_keep) {
+        int rc = bdls::FilesystemUtil::remove(d_path, true);
+        BSLS_ASSERT_OPT(rc == 0);
+    }
+}
+
+// MANIPULATORS
+void TemporaryDirectory::keep()
+{
+    d_keep = true;
+}
+
+// ACCESSORS
+const bsl::string& TemporaryDirectory::path() const
+{
+    return d_path;
+}
+
+// CREATORS
+TemporaryFile::TemporaryFile(bslma::Allocator *basicAllocator)
+: d_path(basicAllocator)
+, d_keep(false)
+{
+    bsl::string prefix = TempUtil::tempDir();
+
+    bdls::FilesystemUtil::FileDescriptor descriptor =
+        bdls::FilesystemUtil::createTemporaryFile(&d_path, prefix);
+
+    BSLS_ASSERT_OPT(descriptor != bdls::FilesystemUtil::k_INVALID_FD);
+
+    int rc = bdls::FilesystemUtil::close(descriptor);
+    BSLS_ASSERT_OPT(rc == 0);
+}
+
+TemporaryFile::TemporaryFile(ntsa::TemporaryDirectory *tempDirectory, 
+                   bslma::Allocator         *basicAllocator)
+: d_path(basicAllocator)
+, d_keep(false)
+{
+    bsl::string prefix = tempDirectory->path();
+
+#if defined(BSLS_PLATFORM_OS_UNIX)
+    if (prefix[prefix.size() - 1] != '/') {
+        prefix.push_back('/');
+    }
+#elif defined(BSLS_PLATFORM_OS_WINDOWS)
+    if (prefix[prefix.size() - 1] != '\\') {
+        prefix.push_back('\\');
+    }
+#else
+#error Not implemented
+#endif
+
+    bdls::FilesystemUtil::FileDescriptor descriptor =
+        bdls::FilesystemUtil::createTemporaryFile(&d_path, prefix);
+
+    BSLS_ASSERT_OPT(descriptor != bdls::FilesystemUtil::k_INVALID_FD);
+
+    int rc = bdls::FilesystemUtil::close(descriptor);
+    BSLS_ASSERT_OPT(rc == 0);
+}
+
+TemporaryFile::TemporaryFile(ntsa::TemporaryDirectory *tempDirectory, 
+                   const bsl::string&        filename, 
+                   bslma::Allocator         *basicAllocator)
+: d_path(basicAllocator)
+, d_keep(false)
+{
+    int rc;
+
+    d_path = tempDirectory->path();
+
+#if defined(BSLS_PLATFORM_OS_UNIX)
+    if (d_path[d_path.size() - 1] != '/') {
+        d_path.push_back('/');
+    }
+#elif defined(BSLS_PLATFORM_OS_WINDOWS)
+    if (d_path[d_path.size() - 1] != '\\') {
+        d_path.push_back('\\');
+    }
+#else
+#error Not implemented
+#endif
+
+    rc = bdls::PathUtil::appendIfValid(&d_path, filename.c_str());
+    BSLS_ASSERT_OPT(rc == 0);
+
+    bdls::FilesystemUtil::FileDescriptor descriptor = 
+        bdls::FilesystemUtil::open(
+            d_path.c_str(), 
+            bdls::FilesystemUtil::e_CREATE, 
+            bdls::FilesystemUtil::e_READ_WRITE);
+
+    BSLS_ASSERT_OPT(descriptor != bdls::FilesystemUtil::k_INVALID_FD);
+
+    rc = bdls::FilesystemUtil::close(descriptor);
+    BSLS_ASSERT_OPT(rc == 0);
+}
+
+TemporaryFile::~TemporaryFile()
+{
+    if (!d_keep) {
+        int rc = bdls::FilesystemUtil::remove(d_path, false);
+        BSLS_ASSERT_OPT(rc == 0);
+    }
+}
+
+// MANIPULATORS
+void TemporaryFile::keep()
+{
+    d_keep = true;
+}
+
+ntsa::Error TemporaryFile::write(const bsl::string& content)
+{
+    int rc;
+
+    bdls::FilesystemUtil::FileDescriptor descriptor = 
+        bdls::FilesystemUtil::open(
+            d_path.c_str(), 
+            bdls::FilesystemUtil::e_OPEN, 
+            bdls::FilesystemUtil::e_READ_WRITE);
+
+    BSLS_ASSERT_OPT(descriptor != bdls::FilesystemUtil::k_INVALID_FD);
+
+    const char* p = content.c_str();
+    bsl::size_t c = content.size();
+
+    while (c != 0) {
+        const bsl::size_t k_CHUNK_SIZE = 1024 * 32;
+        bsl::size_t numBytesToWrite = c < k_CHUNK_SIZE ? c : k_CHUNK_SIZE;
+
+        rc = bdls::FilesystemUtil::write(descriptor, p, static_cast<int>(numBytesToWrite));
+        if (rc < 0) {
+            return ntsa::Error::last();
+        }
+
+        bsl::size_t numBytesWritten = static_cast<bsl::size_t>(rc);
+
+        BSLS_ASSERT_OPT(c >= numBytesWritten);
+
+        p += numBytesWritten;
+        c -= numBytesWritten;
+    }
+
+    rc = bdls::FilesystemUtil::close(descriptor);
+    BSLS_ASSERT_OPT(rc == 0);
+
+    return ntsa::Error();
+}
+
+// ACCESSORS
+const bsl::string& TemporaryFile::path() const
+{
+    return d_path;
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/groups/nts/ntsa/ntsa_temporary.cpp
+++ b/groups/nts/ntsa/ntsa_temporary.cpp
@@ -121,7 +121,6 @@ bsl::string TempUtil::tempDir()
 
 }  // close unnamed namespace
 
-// CREATORS
 TemporaryDirectory::TemporaryDirectory(bslma::Allocator* basicAllocator)
 : d_path(basicAllocator)
 , d_keep(false)
@@ -140,19 +139,16 @@ TemporaryDirectory::~TemporaryDirectory()
     }
 }
 
-// MANIPULATORS
 void TemporaryDirectory::keep()
 {
     d_keep = true;
 }
 
-// ACCESSORS
 const bsl::string& TemporaryDirectory::path() const
 {
     return d_path;
 }
 
-// CREATORS
 TemporaryFile::TemporaryFile(bslma::Allocator* basicAllocator)
 : d_path(basicAllocator)
 , d_keep(false)
@@ -240,7 +236,6 @@ TemporaryFile::~TemporaryFile()
     }
 }
 
-// MANIPULATORS
 void TemporaryFile::keep()
 {
     d_keep = true;
@@ -285,7 +280,6 @@ ntsa::Error TemporaryFile::write(const bsl::string& content)
     return ntsa::Error();
 }
 
-// ACCESSORS
 const bsl::string& TemporaryFile::path() const
 {
     return d_path;

--- a/groups/nts/ntsa/ntsa_temporary.h
+++ b/groups/nts/ntsa/ntsa_temporary.h
@@ -35,7 +35,7 @@ namespace ntsa {
 /// temporary directory for the current process whose name is randomly assigned
 /// to guarantee no collisions with other directories or files in the effective
 /// temporary directory. The guarded directory, and all its contents, are
-/// automatically removed when an object of this class is destroyed destroyed.
+/// automatically removed when an object of this class is destroyed.
 ///
 /// @par Thread Safety
 /// This class is not thread safe.
@@ -128,42 +128,39 @@ class TemporaryFile
     TemporaryFile& operator=(const TemporaryFile&) BSLS_KEYWORD_DELETED;
 
   public:
-    // CREATORS
-    explicit TemporaryFile(bslma::Allocator* basicAllocator = 0);
     // Create a new file in the temporary directory that is removed when
     // this object is destroyed. Optionally specify a 'basicAllocator' used
     // to supply memory. If 'basicAllocator' is 0, the currently installed
     // default allocator is used.
-
-    TemporaryFile(ntsa::TemporaryDirectory* tempDirectory,
-                  bslma::Allocator*         basicAllocator = 0);
+    explicit TemporaryFile(bslma::Allocator* basicAllocator = 0);
+    
     // Create a new file in the specified 'tempDirectory' that is removed
     // when this object is destroyed. Optionally specify a 'basicAllocator'
     // used to supply memory. If 'basicAllocator' is 0, the currently
     // installed default allocator is used.
-
     TemporaryFile(ntsa::TemporaryDirectory* tempDirectory,
-                  const bsl::string&        filename,
                   bslma::Allocator*         basicAllocator = 0);
+    
     // Create a new file in the specified 'tempDirectory' having the
     // specified 'filename' that is removed when this object is destroyed.
     // Optionally specify a 'basicAllocator' used to supply memory. If
     // 'basicAllocator' is 0, the currently installed default allocator is
     // used.
-
-    ~TemporaryFile();
+    TemporaryFile(ntsa::TemporaryDirectory* tempDirectory,
+                  const bsl::string&        filename,
+                  bslma::Allocator*         basicAllocator = 0);
+    
     // Destroy this object.
+    ~TemporaryFile();
 
-    // MANIPULATORS
-    void keep();
     // Do not remove the file upon the destruction of this object.
-
-    ntsa::Error write(const bsl::string& content);
+    void keep();
+    
     // Write the specified 'content' to the file.
+    ntsa::Error write(const bsl::string& content);
 
-    // ACCESSORS
-    const bsl::string& path() const;
     // Return the path to the file.
+    const bsl::string& path() const;
 };
 
 }  // close package namespace

--- a/groups/nts/ntsa/ntsa_temporary.h
+++ b/groups/nts/ntsa/ntsa_temporary.h
@@ -19,9 +19,9 @@
 #include <bsls_ident.h>
 BSLS_IDENT("$Id: $")
 
+#include <ntsa_error.h>
 #include <ntscfg_platform.h>
 #include <ntsscm_version.h>
-#include <ntsa_error.h>
 #include <bdls_filesystemutil.h>
 #include <bsl_string.h>
 
@@ -61,31 +61,33 @@ namespace ntsa {
 ///     BSLS_ASSERT(!bdls::FilesystemUtil::exists(directoryPath));
 ///
 /// @ingroup module_ntsa_system
-class TemporaryDirectory {
+class TemporaryDirectory
+{
     bsl::string d_path;
     bool        d_keep;
 
   private:
     // NOT IMPLEMENTED
     TemporaryDirectory(const TemporaryDirectory&) BSLS_KEYWORD_DELETED;
-    TemporaryDirectory& operator=(const TemporaryDirectory&) BSLS_KEYWORD_DELETED;
+    TemporaryDirectory& operator=(const TemporaryDirectory&)
+        BSLS_KEYWORD_DELETED;
 
   public:
     /// Create a new directory in the temporary directory that is removed
     /// when this object is destroyed. Optionally specify a 'basicAllocator'
     /// used to supply memory. If 'basicAllocator' is 0, the currently
     /// installed default allocator is used.
-    explicit TemporaryDirectory(bslma::Allocator *basicAllocator = 0);
-        
+    explicit TemporaryDirectory(bslma::Allocator* basicAllocator = 0);
+
     /// Destroy this object.
     ~TemporaryDirectory();
 
-    /// Do not remove the directory and all its contents upon the 
+    /// Do not remove the directory and all its contents upon the
     /// destruction of this object.
     void keep();
-        
+
     /// Return the path to the directory.
-    const bsl::string& path() const; 
+    const bsl::string& path() const;
 };
 
 /// Provide a temporary file.
@@ -116,7 +118,8 @@ class TemporaryDirectory {
 ///     BSLS_ASSERT(!bdls::FilesystemUtil::exists(filePath));
 ///
 /// @ingroup module_ntsa_system
-class TemporaryFile {
+class TemporaryFile
+{
     bsl::string d_path;
     bool        d_keep;
 
@@ -126,41 +129,41 @@ class TemporaryFile {
 
   public:
     // CREATORS
-    explicit TemporaryFile(bslma::Allocator *basicAllocator = 0);
-        // Create a new file in the temporary directory that is removed when
-        // this object is destroyed. Optionally specify a 'basicAllocator' used
-        // to supply memory. If 'basicAllocator' is 0, the currently installed
-        // default allocator is used.
+    explicit TemporaryFile(bslma::Allocator* basicAllocator = 0);
+    // Create a new file in the temporary directory that is removed when
+    // this object is destroyed. Optionally specify a 'basicAllocator' used
+    // to supply memory. If 'basicAllocator' is 0, the currently installed
+    // default allocator is used.
 
-    TemporaryFile(ntsa::TemporaryDirectory *tempDirectory, 
-             bslma::Allocator         *basicAllocator = 0);
-        // Create a new file in the specified 'tempDirectory' that is removed
-        // when this object is destroyed. Optionally specify a 'basicAllocator'
-        // used to supply memory. If 'basicAllocator' is 0, the currently 
-        // installed default allocator is used.
+    TemporaryFile(ntsa::TemporaryDirectory* tempDirectory,
+                  bslma::Allocator*         basicAllocator = 0);
+    // Create a new file in the specified 'tempDirectory' that is removed
+    // when this object is destroyed. Optionally specify a 'basicAllocator'
+    // used to supply memory. If 'basicAllocator' is 0, the currently
+    // installed default allocator is used.
 
-    TemporaryFile(ntsa::TemporaryDirectory *tempDirectory, 
-             const bsl::string&        filename, 
-             bslma::Allocator         *basicAllocator = 0);
-        // Create a new file in the specified 'tempDirectory' having the 
-        // specified 'filename' that is removed when this object is destroyed.
-        // Optionally specify a 'basicAllocator' used to supply memory. If 
-        // 'basicAllocator' is 0, the currently installed default allocator is
-        // used.
+    TemporaryFile(ntsa::TemporaryDirectory* tempDirectory,
+                  const bsl::string&        filename,
+                  bslma::Allocator*         basicAllocator = 0);
+    // Create a new file in the specified 'tempDirectory' having the
+    // specified 'filename' that is removed when this object is destroyed.
+    // Optionally specify a 'basicAllocator' used to supply memory. If
+    // 'basicAllocator' is 0, the currently installed default allocator is
+    // used.
 
     ~TemporaryFile();
-        // Destroy this object.
+    // Destroy this object.
 
     // MANIPULATORS
     void keep();
-        // Do not remove the file upon the destruction of this object.
+    // Do not remove the file upon the destruction of this object.
 
     ntsa::Error write(const bsl::string& content);
-        // Write the specified 'content' to the file.
+    // Write the specified 'content' to the file.
 
     // ACCESSORS
     const bsl::string& path() const;
-        // Return the path to the file.
+    // Return the path to the file.
 };
 
 }  // close package namespace

--- a/groups/nts/ntsa/ntsa_temporary.h
+++ b/groups/nts/ntsa/ntsa_temporary.h
@@ -1,0 +1,168 @@
+// Copyright 2020-2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_NTSA_TEMPORARY
+#define INCLUDED_NTSA_TEMPORARY
+
+#include <bsls_ident.h>
+BSLS_IDENT("$Id: $")
+
+#include <ntscfg_platform.h>
+#include <ntsscm_version.h>
+#include <ntsa_error.h>
+#include <bdls_filesystemutil.h>
+#include <bsl_string.h>
+
+namespace BloombergLP {
+namespace ntsa {
+
+/// Provide a temporary directory.
+///
+/// @details
+/// This class provides a guard to create a directory in the effective
+/// temporary directory for the current process whose name is randomly assigned
+/// to guarantee no collisions with other directories or files in the effective
+/// temporary directory. The guarded directory, and all its contents, are
+/// automatically removed when an object of this class is destroyed destroyed.
+///
+/// @par Thread Safety
+/// This class is not thread safe.
+///
+/// @par Usage Example
+/// This example shows how to create a temporary directory which is
+/// automatically deleted by a 'ntsa::TemporaryDirectory' guard.
+///
+///     bsl::string directoryPath;
+///     {
+///         ntsa::TemporaryDirectory tempDirectory;
+///         directoryPath = tempDirectory.path();
+///
+///         bsl::string filePath = tempDirectory.path();
+///         bdls::PathUtil::appendRaw(&filePath, "file.txt");
+///
+///         bsl::ofstream ofs(filePath.c_str());
+///         BSLS_ASSERT(ofs);
+///
+///         ofs << "Hello, world!" << bsl::endl;
+///     }
+///
+///     BSLS_ASSERT(!bdls::FilesystemUtil::exists(directoryPath));
+///
+/// @ingroup module_ntsa_system
+class TemporaryDirectory {
+    bsl::string d_path;
+    bool        d_keep;
+
+  private:
+    // NOT IMPLEMENTED
+    TemporaryDirectory(const TemporaryDirectory&) BSLS_KEYWORD_DELETED;
+    TemporaryDirectory& operator=(const TemporaryDirectory&) BSLS_KEYWORD_DELETED;
+
+  public:
+    /// Create a new directory in the temporary directory that is removed
+    /// when this object is destroyed. Optionally specify a 'basicAllocator'
+    /// used to supply memory. If 'basicAllocator' is 0, the currently
+    /// installed default allocator is used.
+    explicit TemporaryDirectory(bslma::Allocator *basicAllocator = 0);
+        
+    /// Destroy this object.
+    ~TemporaryDirectory();
+
+    /// Do not remove the directory and all its contents upon the 
+    /// destruction of this object.
+    void keep();
+        
+    /// Return the path to the directory.
+    const bsl::string& path() const; 
+};
+
+/// Provide a temporary file.
+///
+/// @details
+/// This class provides a guard to create a file in the effective temporary
+/// directory for the current process that is automatically removed when an
+/// object of this class is destroyed.
+///
+/// @par Thread Safety
+/// This class is not thread safe.
+///
+/// @par Usage Example
+/// This example shows how to create a temporary file which is automatically
+/// deleted by a 'ntsa::TemporaryFile' guard.
+///
+///     bsl::string filePath;
+///     {
+///         ntsa::TemporaryFile tempFile;
+///         filePath = tempFile.path();
+///
+///         bsl::ofstream ofs(filePath.c_str());
+///         BSLS_ASSERT(ofs);
+///
+///         ofs << "Hello, world!";
+///     }
+///
+///     BSLS_ASSERT(!bdls::FilesystemUtil::exists(filePath));
+///
+/// @ingroup module_ntsa_system
+class TemporaryFile {
+    bsl::string d_path;
+    bool        d_keep;
+
+  private:
+    TemporaryFile(const TemporaryFile&) BSLS_KEYWORD_DELETED;
+    TemporaryFile& operator=(const TemporaryFile&) BSLS_KEYWORD_DELETED;
+
+  public:
+    // CREATORS
+    explicit TemporaryFile(bslma::Allocator *basicAllocator = 0);
+        // Create a new file in the temporary directory that is removed when
+        // this object is destroyed. Optionally specify a 'basicAllocator' used
+        // to supply memory. If 'basicAllocator' is 0, the currently installed
+        // default allocator is used.
+
+    TemporaryFile(ntsa::TemporaryDirectory *tempDirectory, 
+             bslma::Allocator         *basicAllocator = 0);
+        // Create a new file in the specified 'tempDirectory' that is removed
+        // when this object is destroyed. Optionally specify a 'basicAllocator'
+        // used to supply memory. If 'basicAllocator' is 0, the currently 
+        // installed default allocator is used.
+
+    TemporaryFile(ntsa::TemporaryDirectory *tempDirectory, 
+             const bsl::string&        filename, 
+             bslma::Allocator         *basicAllocator = 0);
+        // Create a new file in the specified 'tempDirectory' having the 
+        // specified 'filename' that is removed when this object is destroyed.
+        // Optionally specify a 'basicAllocator' used to supply memory. If 
+        // 'basicAllocator' is 0, the currently installed default allocator is
+        // used.
+
+    ~TemporaryFile();
+        // Destroy this object.
+
+    // MANIPULATORS
+    void keep();
+        // Do not remove the file upon the destruction of this object.
+
+    ntsa::Error write(const bsl::string& content);
+        // Write the specified 'content' to the file.
+
+    // ACCESSORS
+    const bsl::string& path() const;
+        // Return the path to the file.
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+#endif

--- a/groups/nts/ntsa/ntsa_temporary.t.cpp
+++ b/groups/nts/ntsa/ntsa_temporary.t.cpp
@@ -51,7 +51,7 @@ NTSCFG_TEST_CASE(1)
             ntsa::TemporaryDirectory tempDirectory;
             directoryPath = tempDirectory.path();
 
-            BSLS_LOG_DEBUG("Create temporary directory: %s", 
+            BSLS_LOG_DEBUG("Create temporary directory: %s",
                            directoryPath.c_str());
 
             bsl::string filePath = tempDirectory.path();

--- a/groups/nts/ntsa/ntsa_temporary.t.cpp
+++ b/groups/nts/ntsa/ntsa_temporary.t.cpp
@@ -1,0 +1,101 @@
+// Copyright 2020-2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ntsa_temporary.h>
+
+#include <ntscfg_test.h>
+
+#include <bdls_filesystemutil.h>
+#include <bdls_pathutil.h>
+#include <bslma_allocator.h>
+#include <bslma_default.h>
+#include <bsls_assert.h>
+#include <bsl_fstream.h>
+
+using namespace BloombergLP;
+
+//=============================================================================
+//                                 TEST PLAN
+//-----------------------------------------------------------------------------
+//                                 Overview
+//                                 --------
+//
+//-----------------------------------------------------------------------------
+
+// [ 1]
+//-----------------------------------------------------------------------------
+// [ 1]
+//-----------------------------------------------------------------------------
+
+NTSCFG_TEST_CASE(1)
+{
+    // Concern: A temporary directory is automatically created and removed
+    // by a temporary directory guard.
+
+    ntscfg::TestAllocator ta;
+    {
+        bsl::string directoryPath;
+        {
+            ntsa::TemporaryDirectory tempDirectory;
+            directoryPath = tempDirectory.path();
+
+            BSLS_LOG_DEBUG("Create temporary directory: %s", 
+                           directoryPath.c_str());
+
+            bsl::string filePath = tempDirectory.path();
+            bdls::PathUtil::appendRaw(&filePath, "file.txt");
+
+            bsl::ofstream ofs(filePath.c_str());
+            BSLS_ASSERT(ofs);
+
+            ofs << "Hello, world!" << bsl::endl;
+        }
+
+        BSLS_ASSERT(!bdls::FilesystemUtil::exists(directoryPath));
+    }
+    NTSCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTSCFG_TEST_CASE(2)
+{
+    // Concern: A temporary file is automatically created and removed
+    // by a temporary file guard.
+
+    ntscfg::TestAllocator ta;
+    {
+        bsl::string filePath;
+        {
+            ntsa::TemporaryFile tempFile;
+            filePath = tempFile.path();
+
+            BSLS_LOG_DEBUG("Create temporary file: %s", filePath.c_str());
+
+            bsl::ofstream ofs(filePath.c_str());
+            BSLS_ASSERT(ofs);
+
+            ofs << "Hello, world!";
+        }
+
+        BSLS_ASSERT(!bdls::FilesystemUtil::exists(filePath));
+    }
+    NTSCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTSCFG_TEST_DRIVER
+{
+    NTSCFG_TEST_REGISTER(1);
+    NTSCFG_TEST_REGISTER(2);
+}
+NTSCFG_TEST_DRIVER_END;

--- a/groups/nts/ntsa/package/ntsa.mem
+++ b/groups/nts/ntsa/package/ntsa.mem
@@ -42,5 +42,6 @@ ntsa_socketoptiontype
 ntsa_socketinfo
 ntsa_socketinfofilter
 ntsa_socketstate
+ntsa_temporary
 ntsa_transport
 ntsa_uri

--- a/groups/nts/ntsd/ntsd_datautil.cpp
+++ b/groups/nts/ntsd/ntsd_datautil.cpp
@@ -78,5 +78,13 @@ void DataUtil::generateData(bdlbb::Blob* result,
     }
 }
 
+void DataUtil::generateData(ntsa::Data* result,
+                            bsl::size_t size,
+                            bsl::size_t offset,
+                            bsl::size_t dataset)
+{
+    DataUtil::generateData(&result->makeBlob(), size, offset, dataset);
+}
+
 }  // close package namespace
 }  // close enterprise namespace

--- a/groups/nts/ntsd/ntsd_datautil.h
+++ b/groups/nts/ntsd/ntsd_datautil.h
@@ -57,6 +57,14 @@ struct DataUtil {
                              bsl::size_t  size,
                              bsl::size_t  offset  = 0,
                              bsl::size_t  dataset = 0);
+
+    /// Load into the specified 'result' the specified 'size' sequence of
+    /// bytes from the specified 'dataset' starting at the specified
+    /// 'offset'.
+    static void generateData(ntsa::Data*  result,
+                             bsl::size_t  size,
+                             bsl::size_t  offset  = 0,
+                             bsl::size_t  dataset = 0);
 };
 
 }  // close package namespace

--- a/groups/nts/ntsd/ntsd_datautil.h
+++ b/groups/nts/ntsd/ntsd_datautil.h
@@ -61,10 +61,10 @@ struct DataUtil {
     /// Load into the specified 'result' the specified 'size' sequence of
     /// bytes from the specified 'dataset' starting at the specified
     /// 'offset'.
-    static void generateData(ntsa::Data*  result,
-                             bsl::size_t  size,
-                             bsl::size_t  offset  = 0,
-                             bsl::size_t  dataset = 0);
+    static void generateData(ntsa::Data* result,
+                             bsl::size_t size,
+                             bsl::size_t offset  = 0,
+                             bsl::size_t dataset = 0);
 };
 
 }  // close package namespace

--- a/targets.cmake
+++ b/targets.cmake
@@ -147,6 +147,7 @@ if (${NTF_BUILD_WITH_NTS})
     ntf_component(NAME ntsa_socketinfo)
     ntf_component(NAME ntsa_socketinfofilter)
     ntf_component(NAME ntsa_socketstate)
+    ntf_component(NAME ntsa_temporary)
     ntf_component(NAME ntsa_transport)
     ntf_component(NAME ntsa_uri)
 


### PR DESCRIPTION
This PR optimizes how a reactor-based stream socket write queue is drained, by combining buffers from contiguous, suitable write queue entries into a single call to `sendmsg`.

This optimization had been previously performed but had been removed when support for `sendfile` was added: As the source of data to transmit via `sendfile` is not represented as a vector of `struct iovec`, it became necessary to represent the write queue with a structure that retained awareness of the `sendfile` state (which is something like a file descriptor, offset into the file, and number of remaining bytes to transmit.) In other words, it became impossible to represent the write queue a simple `bdlbb::Blob`.

The write queue consists of a linked list of entries, each entry representing the data to transmit as an `ntsa::Data` (itself a union of popular representations of data; e.g. `bdlbb::Blob`, `bsl::vector<struct ::iovec>`, "sendfile state", etc.) When the socket send buffer is "full", the remainder of the data to transmit (an any new data the user desires to transmit) is enqueued onto a write queue, and the socket is monitored for writability. When we detect that the socket is writable, we attempt to "drain" the write queue by copying buffers from the head of the queue into the socket send buffer, erasing entries from the write queue when their data has been complely copied to the send buffer.

The current implementation only attempts to copy those buffers from the single entry at the front of the write queue. This implement is inefficient when the send buffer has considerable capacity but the user has enqueued many entries of many small buffers.

The proposed implementation "batches" together suitable buffers from entries at the front of the write queue and combines them into a single `sendmsg` call. So, for example if the write queue contains two entries of two buffers each, this implementation now attempts to drain them both simultaneously by submitting an array of 4 `struct iovec` to a single system call, rather than copying them individually, with two calls to `sendmsg` referencing 2 buffers each.

Some observations and implementation details:
1) We can batch everything except for `sendfile` data. This implementation grabs all buffers starting at the front of the write queue and working backwards until it either reaches a) a configured byte limit, b) a configured buffer limit, or c) `sendfile` data

2) Accounting for what has actually been copied to the send buffer from a batch by erasing corresponding entries from the write queue might be slightly more expensive than the case of knowingly copying only from a single entry at the front of the write queue. There is a special case for processing a write queue of just one entry.

3) This optimization cannot be performed for `ntcr::DatagramSocket` as we must obey datagram semantics implied by the original `ntcr::DatagramSocket::send` calls by the user. We should think about future work leveraging `sendmmsg` (send multiple message), however.

4) This PR does not attempt a similar optimization for `ntcp::StreamSocket`, which uses a proactive interface to the operating system (e.g. Windows I/O completion ports.) Such an optimization is possible and desirable, though, and we are probably punished even more in that component, comparatively, by not pursuing this optimization. A future PR to optimize `ntcp::StreamSocket` will be forthcoming. 