### PR TITLE
Remove artificial limit on the number of buffers to supply to sendmsg

### DIFF
--- a/groups/ntc/ntcp/ntcp_streamsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.cpp
@@ -2778,14 +2778,6 @@ ntsa::Error StreamSocket::privateOpen(
         }
     }
 
-    d_sendOptions.setMaxBuffers(bsl::min(
-        streamSocket->maxBuffersPerSend(),
-        static_cast<bsl::size_t>(NTCCFG_DEFAULT_MAX_INPLACE_BUFFERS)));
-
-    d_receiveOptions.setMaxBuffers(bsl::min(
-        streamSocket->maxBuffersPerReceive(),
-        static_cast<bsl::size_t>(NTCCFG_DEFAULT_MAX_INPLACE_BUFFERS)));
-
     ntcs::ObserverRef<ntci::Proactor> proactorRef(&d_proactor);
     if (!proactorRef) {
         return ntsa::Error(ntsa::Error::e_INVALID);

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -3064,14 +3064,6 @@ ntsa::Error StreamSocket::privateOpen(
         }
     }
 
-    d_sendOptions.setMaxBuffers(bsl::min(
-        streamSocket->maxBuffersPerSend(),
-        static_cast<bsl::size_t>(NTCCFG_DEFAULT_MAX_INPLACE_BUFFERS)));
-
-    d_receiveOptions.setMaxBuffers(bsl::min(
-        streamSocket->maxBuffersPerReceive(),
-        static_cast<bsl::size_t>(NTCCFG_DEFAULT_MAX_INPLACE_BUFFERS)));
-
     {
         ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
         if (!reactorRef) {


### PR DESCRIPTION
A previous "optimization" artificially limited the maximum number of buffers a `ntcr::StreamSocket` or `ntcp::StreamSocket` would supply to `sendmsg`. The motivation for this limit was to avoid dynamically allocating memory for an array of `struct ::iovec` by ensuring the maximum number of buffers that we would try to copy fit into some arena on the stack. We no longer have this motivation: the implementation of `ntsu::SocketUtil::send(bdbb::Blob)` naturally limits the maximum number of buffers to an array of `struct iovec` of size `IOV_MAX` on the stack.

This "optimization" now prevents the implementation from copying  buffers in cases where we actually *do* want to supply a large number of buffers to `sendmsg`, e.g. when we are draining a write queue consisting of many entries of many small buffers.