### PR TITLE
Remove references to defunct s_ntstst/s_ntctst and a_ntsdbg/a_ntcdbg

### DIFF
--- a/groups/ntc/ntci/ntci_timer.h
+++ b/groups/ntc/ntci/ntci_timer.h
@@ -98,7 +98,7 @@ namespace ntci {
 ///     ntci::TimerFuture timerFuture;
 ///
 ///     bsl::shared_ptr<ntci::Timer> timer =
-///         s_ntctst::TestUtil::createTimer(timerOptions, timerFuture);
+///         interface->createTimer(timerOptions, timerFuture);
 ///
 /// Schedule the timer 100ms from now.
 ///
@@ -168,7 +168,7 @@ namespace ntci {
 ///     ntci::TimerFuture timerFuture;
 ///
 ///     bsl::shared_ptr<ntci::Timer> timer =
-///         s_ntctst::TestUtil::createTimer(timerOptions, timerFuture);
+///         interface->createTimer(timerOptions, timerFuture);
 ///
 /// Schedule the timer 100ms from now that recurs every 20ms.
 ///
@@ -241,7 +241,7 @@ namespace ntci {
 ///     ntci::TimerFuture timerFuture;
 ///
 ///     bsl::shared_ptr<ntci::Timer> timer =
-///         s_ntctst::TestUtil::createTimer(timerOptions, timerFuture);
+///         interface->createTimer(timerOptions, timerFuture);
 ///
 /// Initially schedule the timer far into the future.
 ///
@@ -318,7 +318,7 @@ namespace ntci {
 ///     ntci::TimerFuture timerFuture;
 ///
 ///     bsl::shared_ptr<ntci::Timer> timer =
-///         s_ntctst::TestUtil::createTimer(timerOptions, timerFuture);
+///         interface->createTimer(timerOptions, timerFuture);
 ///
 /// Initially schedule the timer far into the future.
 ///
@@ -397,7 +397,7 @@ namespace ntci {
 ///     ntci::TimerFuture timerFuture;
 ///
 ///     bsl::shared_ptr<ntci::Timer> timer =
-///         s_ntctst::TestUtil::createTimer(timerOptions, timerFuture);
+///         interface->createTimer(timerOptions, timerFuture);
 ///
 /// Initially schedule the timer far into the future.
 ///
@@ -469,7 +469,7 @@ namespace ntci {
 ///     ntci::TimerFuture timerFuture;
 ///
 ///     bsl::shared_ptr<ntci::Timer> timer =
-///         s_ntctst::TestUtil::createTimer(timerOptions, timerFuture);
+///         interface->createTimer(timerOptions, timerFuture);
 ///
 /// Initially schedule the timer far into the future.
 ///
@@ -541,7 +541,7 @@ namespace ntci {
 ///     ntci::TimerFuture timerFuture;
 ///
 ///     bsl::shared_ptr<ntci::Timer> timer =
-///         s_ntctst::TestUtil::createTimer(timerOptions, timerFuture);
+///         interface->createTimer(timerOptions, timerFuture);
 ///
 /// Initially schedule the timer far into the future.
 ///
@@ -647,7 +647,7 @@ namespace ntci {
 ///     ntci::TimerFuture timerFuture;
 ///
 ///     bsl::shared_ptr<ntci::Timer> timer =
-///         s_ntctst::TestUtil::createTimer(timerOptions, timerFuture);
+///         interface->createTimer(timerOptions, timerFuture);
 ///
 /// Initially schedule the timer far into the future.
 ///

--- a/project.cmake
+++ b/project.cmake
@@ -138,20 +138,6 @@ function(bdeproj_project_process_uors proj listDir)
             ${listDir}/groups/nts
         )
 
-        if (${NTS_BUILD_WITH_MOCKS})
-            bde_project_process_standalone_packages(
-                ${proj}
-                ${listDir}/adapters/a_ntsdbg
-            )
-        endif()
-
-        if (${NTS_BUILD_WITH_INTEGRATION_TESTS})
-            bde_project_process_standalone_packages(
-                ${proj}
-                ${listDir}/standalones/s_ntstst
-            )
-        endif()
-
         if (${NTS_BUILD_WITH_USAGE_EXAMPLES})
             bde_project_process_applications(
                 ${proj}
@@ -172,20 +158,6 @@ function(bdeproj_project_process_uors proj listDir)
             ${proj}
             ${listDir}/groups/ntc
         )
-
-        if (${NTF_BUILD_WITH_MOCKS})
-            bde_project_process_standalone_packages(
-                ${proj}
-                ${listDir}/adapters/a_ntcdbg
-            )
-        endif()
-
-        if (${NTF_BUILD_WITH_INTEGRATION_TESTS})
-            bde_project_process_standalone_packages(
-                ${proj}
-                ${listDir}/standalones/s_ntctst
-            )
-        endif()
 
         if (${NTF_BUILD_WITH_USAGE_EXAMPLES})
             bde_project_process_applications(


### PR DESCRIPTION
This PR removes references to the now-defunct packages: `s_ntstst`, `s_ntctst`, `a_ntsdbg`, and `a_ntcdbg`.