### PR TITLE
Modernize the ntcf_system usage examples

### DIFF
--- a/groups/ntc/ntcf/ntcf_system.h
+++ b/groups/ntc/ntcf/ntcf_system.h
@@ -163,7 +163,6 @@ namespace ntcf {
 /// Next, connect a socket to the listener.
 ///
 ///    ntca::StreamSocketOptions streamSocketOptions;
-///    streamSocketOptions.setRemoteEndpoint(listenerSocket->sourceEndpoint());
 ///
 ///     bsl::shared_ptr<ntci::StreamSocket> clientSocket =
 ///         interface->createStreamSocket(streamSocketOptions);
@@ -175,7 +174,9 @@ namespace ntcf {
 ///                                  bdlf::PlaceHolders::_2,
 ///                                  &semaphore));
 ///
-///     error = clientSocket->connect(ntca::ConnectOptions(), connectCallback);
+///     error = clientSocket->connect(listenerSocket->sourceEndpoint(),
+//                                    ntca::ConnectOptions(),
+//                                    connectCallback);
 ///     BSLS_ASSERT(!error);
 ///
 ///     semaphore.wait();


### PR DESCRIPTION
This PR fixes an `ntcf_system` usage example to correctly specify the endpoint to which a socket connects when the connect operation is initiated, rather than when the socket is created.