### PR TITLE
Emphasize the user's requirement to explicitly close each timer and socket

### DIFF
--- a/groups/ntc/ntci/ntci_datagramsocket.h
+++ b/groups/ntc/ntci/ntci_datagramsocket.h
@@ -299,6 +299,17 @@ namespace ntci {
 /// and all subsequent send operations will fail, but some data may have been
 /// transmitted.
 ///
+/// @par Closing
+/// Each 'ntci::DatagramSocket' is shared between the user and this library's
+/// asynchronous machinery. It is not sufficient for users to simply release
+/// their reference counts on a datagram socket object to close and destroy it.
+/// Users *must* explicitly close each 'ntci::DatagramSocket'. Closing a socket
+/// is asynchronous, users must wait until the close callback is invoked before
+/// assuming the socket is completely closed. After a socket's close callback
+/// is invoked, the socket remains in a valid state but all member functions
+/// with failure modes will return an error. The socket object will be
+/// destroyed only after it has been closed and all references are released.
+///
 /// @par Thread Safety
 /// This class is thread safe.
 ///

--- a/groups/ntc/ntci/ntci_listenersocket.h
+++ b/groups/ntc/ntci/ntci_listenersocket.h
@@ -79,6 +79,17 @@ namespace ntci {
 /// "UNIX Network Programming, Volume 1: The Sockets Networking API", by W.
 /// Richard Stevens.
 ///
+/// @par Closing
+/// Each 'ntci::ListenerSocket' is shared between the user and this library's
+/// asynchronous machinery. It is not sufficient for users to simply release
+/// their reference counts on a listener socket object to close and destroy it.
+/// Users *must* explicitly close each 'ntci::ListenerSocket'. Closing a socket
+/// is asynchronous, users must wait until the close callback is invoked before
+/// assuming the socket is completely closed. After a socket's close callback
+/// is invoked, the socket remains in a valid state but all member functions
+/// with failure modes will return an error. The socket object will be
+/// destroyed only after it has been closed and all references are released.
+///
 /// @par Thread Safety
 /// This class is thread safe.
 ///

--- a/groups/ntc/ntci/ntci_streamsocket.h
+++ b/groups/ntc/ntci/ntci_streamsocket.h
@@ -471,12 +471,17 @@ namespace ntci {
 /// after userspace as indicated the socket should be closed.
 ///
 /// @par Closing
+/// Each 'ntci::StreamSocket' is shared between the user and this library's
+/// asynchronous machinery. It is not sufficient for users to simply release
+/// their reference counts on a stream socket object to close and destroy it.
 /// Users *must* explicitly close each 'ntci::StreamSocket'. Closing a socket
 /// implicitly shuts it down, unless the socket is already shut down or an
 /// "abortive close" is configured. Closing a socket is asynchronous, users
 /// must wait until the close callback is invoked before assuming the socket is
-/// completely closed. Once a socket is closed, no further operations on the
-/// socket are permitted.
+/// completely closed. After a socket's close callback is invoked, the socket
+/// remains in a valid state but all member functions with failure modes
+/// will return an error. The socket object will be destroyed only after it has
+/// been closed and all references are released.
 ///
 /// @par Asynchronous Operation
 /// Asynchronous operation is classified into two categories: operations that

--- a/groups/ntc/ntci/ntci_timer.h
+++ b/groups/ntc/ntci/ntci_timer.h
@@ -58,6 +58,23 @@ namespace ntci {
 /// timer deadline event callback is invoked, through the timer context
 /// specified to the timer deadline event callback.
 ///
+/// @par Closing
+/// Each 'ntci::Timer' is shared between the user and this library's
+/// asynchronous machinery. It is not sufficient for users to simply release
+/// their reference counts on a timer object to close and destroy it. Users
+/// *must* explicitly close each non-one-shot 'ntci::Timer'. One-shot timers
+/// are automatically closed after they fire. Closing a timer is asynchronous,
+/// and may race with announcement of a timer's deadline event by another
+/// thread. If such a race needs to be resolved, users must wait until either
+/// the timer callback is invoked with a timer event of type
+/// 'ntca::TimerEventType::e_CLOSED' or the
+/// 'ntci::TimerSession::processTimerClosed' function is invoked (depending on
+/// which notification strategy is registered when the timer is created) before
+/// assuming the timer is completely closed. After a timer is closed, the timer
+/// remains in a valid state but all member functions with failure modes will
+/// return an error. The timer object will be destroyed only after it has
+/// been closed and all references are released.
+///
 /// @par Thread Safety
 /// This class is thread safe.
 ///


### PR DESCRIPTION
This PR adds more documentation to the  `ntci::StreamSocket`, `ntci::ListenerSocket`, `ntci::DatagramSocket`, and `ntci::Timer` classes to emphasize the user's requirement to explicitly close each object for it to be eventually destroyed.