### PR TITLE
Respect CC & CXX env variables to set compilers

### DIFF
--- a/configure
+++ b/configure
@@ -72,7 +72,6 @@ if [[ -z "${NTF_CONFIGURE_GENERATOR}" ]]; then
     fi
 fi
 
-NTF_CONFIGURE_COMPILER=""
 NTF_CONFIGURE_SANITIZER=""
 
 if [[ -z "${NTF_CONFIGURE_MULTIPLATFORM}" ]]; then
@@ -290,7 +289,6 @@ usage()
     echo "    --output              <path>       Path to the directory where build artifacts will be staged [${NTF_CONFIGURE_OUTPUT}]"
     echo "    --distribution        <name>       Name of the distribution [${NTF_CONFIGURE_DISTRIBUTION}]"
     echo "    --ufid                <code>       The unified flag identifiers for the build system [${NTF_CONFIGURE_UFID}]"
-    echo "    --compiler            <name>       Compiler name, e.g. \"gcc\", \"clang\", etc."
     echo "    --generator           <name>       CMake generator name: \"Ninja\", \"Unix Makefiles\", \"NMake Makefiles\", or \"msvc\" [\"${NTF_CONFIGURE_GENERATOR}\"]"
     echo "    --sanitizer           <name>       Sanitizer name: \"asan\" (addressability), \"msan\" (uninitialized memory), \"tsan\" (data races), or \"ubsan\" (undefined behavior)"
     echo "    --jobs                <number>     Number of parallel build jobs [${NTF_CONFIGURE_JOBS}]"
@@ -397,8 +395,6 @@ while true ; do
             fi
 
             shift 2 ;;
-        --compiler)
-            NTF_CONFIGURE_COMPILER=$2 ; shift 2 ;;
         --generator)
             NTF_CONFIGURE_GENERATOR=$2 ; shift 2 ;;
         --sanitizer)

--- a/groups/ntc/ntcdns/ntcdns_database.cpp
+++ b/groups/ntc/ntcdns/ntcdns_database.cpp
@@ -505,6 +505,7 @@ ntsa::Error HostDatabase::load(const bsl::shared_ptr<ntcdns::File>& file)
 
     char        current = 0;
     bsl::size_t lines   = 0;
+    NTCCFG_WARNING_UNUSED(lines);
 
     while (true) {
         current = scanner.skipUntilNotWhitespace();
@@ -819,6 +820,7 @@ ntsa::Error PortDatabase::load(const bsl::shared_ptr<ntcdns::File>& file)
 
     char        current = 0;
     bsl::size_t lines   = 0;
+    NTCCFG_WARNING_UNUSED(lines);
 
     while (true) {
         current = scanner.skipUntilNotWhitespace();

--- a/groups/nts/ntsu/ntsu_socketutil.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.cpp
@@ -3749,6 +3749,7 @@ Scanner::Scanner(const char* begin, const char* end)
 , d_current(begin)
 , d_end(end)
 {
+    NTSCFG_WARNING_UNUSED(d_begin);
 }
 
 Scanner::~Scanner()

--- a/toolchain.cmake
+++ b/toolchain.cmake
@@ -31,67 +31,74 @@ if ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "")
         CACHE STRING "Default" FORCE)
 endif()
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
-    find_program(
-        NTF_TOOLCHAIN_COMPILER_CC_PATH gcc clang cc
-        PATHS /opt/bb/bin
-        REQUIRED)
-    find_program(
-        NTF_TOOLCHAIN_COMPILER_CXX_PATH g++ clang++ c++
-        PATHS /opt/bb/bin
-        REQUIRED)
-elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "OpenBSD")
-    find_program(
-        NTF_TOOLCHAIN_COMPILER_CC_PATH gcc clang cc
-        PATHS /opt/bb/bin
-        REQUIRED)
-    find_program(
-        NTF_TOOLCHAIN_COMPILER_CXX_PATH g++ clang++ c++
-        PATHS /opt/bb/bin
-        REQUIRED)
-elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-    find_program(
-        NTF_TOOLCHAIN_COMPILER_CC_PATH clang gcc cc
-        PATHS /opt/bb/bin
-        REQUIRED)
-    find_program(
-        NTF_TOOLCHAIN_COMPILER_CXX_PATH clang++ g++ c++
-        PATHS /opt/bb/bin
-        REQUIRED)
-elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-    find_program(
-        NTF_TOOLCHAIN_COMPILER_CC_PATH gcc clang cc
-        PATHS /opt/bb/bin
-        REQUIRED)
-    find_program(
-        NTF_TOOLCHAIN_COMPILER_CXX_PATH g++ clang++ c++
-        PATHS /opt/bb/bin
-        REQUIRED)
-elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "SunOS")
-    find_program(
-        NTF_TOOLCHAIN_COMPILER_CC_PATH cc gcc clang
-        PATHS /opt/bb/bin
-        REQUIRED)
-    find_program(
-        NTF_TOOLCHAIN_COMPILER_CXX_PATH CC g++ clang++
-        PATHS /opt/bb/bin
-        REQUIRED)
-elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "AIX")
-    find_program(
-        NTF_TOOLCHAIN_COMPILER_CC_PATH xlc_r gcc clang
-        PATHS /opt/bb/bin
-        REQUIRED)
-    find_program(
-        NTF_TOOLCHAIN_COMPILER_CXX_PATH xlC_r g++ clang++
-        PATHS /opt/bb/bin
-        REQUIRED)
-elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-    find_program(NTF_TOOLCHAIN_COMPILER_CC_PATH cl clang gcc
-        REQUIRED)
-    find_program(NTF_TOOLCHAIN_COMPILER_CXX_PATH cl clang++ g++
-        REQUIRED)
+if(DEFINED ENV{CC} AND DEFINED ENV{CXX})
+    set(NTF_TOOLCHAIN_COMPILER_CC_PATH $ENV{CC} CACHE FILEPATH "" FORCE)
+    set(NTF_TOOLCHAIN_COMPILER_CXX_PATH $ENV{CXX} CACHE FILEPATH "" FORCE)
+elseif(NOT NTF_TOOLCHAIN_COMPILER_CC_PATH OR NOT NTF_TOOLCHAIN_COMPILER_CXX_PATH)
+    if("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
+        find_program(
+            NTF_TOOLCHAIN_COMPILER_CC_PATH gcc clang cc
+            PATHS /opt/bb/bin
+            REQUIRED)
+        find_program(
+            NTF_TOOLCHAIN_COMPILER_CXX_PATH g++ clang++ c++
+            PATHS /opt/bb/bin
+            REQUIRED)
+    elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "OpenBSD")
+        find_program(
+            NTF_TOOLCHAIN_COMPILER_CC_PATH gcc clang cc
+            PATHS /opt/bb/bin
+            REQUIRED)
+        find_program(
+            NTF_TOOLCHAIN_COMPILER_CXX_PATH g++ clang++ c++
+            PATHS /opt/bb/bin
+            REQUIRED)
+    elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+        find_program(
+            NTF_TOOLCHAIN_COMPILER_CC_PATH clang gcc cc
+            PATHS /opt/bb/bin
+            REQUIRED)
+        find_program(
+            NTF_TOOLCHAIN_COMPILER_CXX_PATH clang++ g++ c++
+            PATHS /opt/bb/bin
+            REQUIRED)
+    elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+        find_program(
+            NTF_TOOLCHAIN_COMPILER_CC_PATH gcc clang cc
+            PATHS /opt/bb/bin
+            REQUIRED)
+        find_program(
+            NTF_TOOLCHAIN_COMPILER_CXX_PATH g++ clang++ c++
+            PATHS /opt/bb/bin
+            REQUIRED)
+    elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "SunOS")
+        find_program(
+            NTF_TOOLCHAIN_COMPILER_CC_PATH cc gcc clang
+            PATHS /opt/bb/bin
+            REQUIRED)
+        find_program(
+            NTF_TOOLCHAIN_COMPILER_CXX_PATH CC g++ clang++
+            PATHS /opt/bb/bin
+            REQUIRED)
+    elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "AIX")
+        find_program(
+            NTF_TOOLCHAIN_COMPILER_CC_PATH xlc_r gcc clang
+            PATHS /opt/bb/bin
+            REQUIRED)
+        find_program(
+            NTF_TOOLCHAIN_COMPILER_CXX_PATH xlC_r g++ clang++
+            PATHS /opt/bb/bin
+            REQUIRED)
+    elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+        find_program(NTF_TOOLCHAIN_COMPILER_CC_PATH cl clang gcc
+            REQUIRED)
+        find_program(NTF_TOOLCHAIN_COMPILER_CXX_PATH cl clang++ g++
+            REQUIRED)
+    else()
+        message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_NAME}")
+    endif()
 else()
-    message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_NAME}")
+    message(FATAL_ERROR "Failed to determine compiler")
 endif()
 
 get_filename_component(


### PR DESCRIPTION
- If `CC` and `CXX` environment variables are set then use them as paths to compilers. 
- fix minor warnings appeared when `clang++-15` was used
- remove not used `compiler` option from the configuration script