### PR TITLE
Modify .gitignore to ignore CLion files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ extras/
 *.sdf
 *.opensdf
 .vscode
+.idea
 *.VC.db
 *.VC.opendb
 *.VC.db-shm


### PR DESCRIPTION
`CLion` creates `.idea` folder in the project directory for its files. This PR adds `.idea` folder into `.gitignore` list.
