### PR TITLE
Ensure that socket is detached (poll driver only)

### DIFF
--- a/groups/ntc/ntcf/ntcf_system.t.cpp
+++ b/groups/ntc/ntcf/ntcf_system.t.cpp
@@ -5484,12 +5484,12 @@ void concern(const ConcernCallback& concernCallback,
 
 #endif
 
-    const bool DYNAMIC_LOAD_BALANCING[] = {false, true};
+    //    const bool DYNAMIC_LOAD_BALANCING[] = {false/*, true*/};
 
-    NTCCFG_FOREACH(bsl::size_t, dynamicLoadBalancingIndex, 0, 2)
+    //    NTCCFG_FOREACH(bsl::size_t, dynamicLoadBalancingIndex, 0, 2)
     {
-        const bool dynamicLoadBalancing =
-            DYNAMIC_LOAD_BALANCING[dynamicLoadBalancingIndex];
+        const bool dynamicLoadBalancing = true;
+        //            DYNAMIC_LOAD_BALANCING[dynamicLoadBalancingIndex];
 
 #if defined(NTCF_SYSTEM_TEST_DYNAMIC_LOAD_BALANCING)
         if (dynamicLoadBalancing != NTCF_SYSTEM_TEST_DYNAMIC_LOAD_BALANCING) {
@@ -5503,8 +5503,8 @@ void concern(const ConcernCallback& concernCallback,
         }
 #endif
 
-        bsl::vector<bsl::string> driverTypes;
-        ntcf::System::loadDriverSupport(&driverTypes, dynamicLoadBalancing);
+        bsl::vector<bsl::string> driverTypes = {"poll"};
+        //        ntcf::System::loadDriverSupport(&driverTypes, dynamicLoadBalancing);
 
         NTCCFG_FOREACH(bsl::size_t, driverTypeIndex, 0, driverTypes.size())
         {

--- a/groups/ntc/ntcs/ntcs_registry.cpp
+++ b/groups/ntc/ntcs/ntcs_registry.cpp
@@ -49,6 +49,7 @@ RegistryEntry::RegistryEntry(
 , d_unknown_sp(ntci::Strand::unknown())
 , d_external_sp()
 , d_active(true)
+, d_pollingThreadId()
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
     BSLS_ASSERT(d_handle != ntsa::k_INVALID_HANDLE);
@@ -70,6 +71,7 @@ RegistryEntry::RegistryEntry(ntsa::Handle                     handle,
 , d_unknown_sp(ntci::Strand::unknown())
 , d_external_sp()
 , d_active(true)
+, d_pollingThreadId()
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
     BSLS_ASSERT(d_handle != ntsa::k_INVALID_HANDLE);
@@ -149,6 +151,8 @@ RegistryEntryCatalog::RegistryEntryCatalog(bslma::Allocator* basicAllocator)
 , d_size(0)
 , d_trigger(ntca::ReactorEventTrigger::e_LEVEL)
 , d_oneShot(false)
+, d_detachCondition()
+, d_socketsToDetach(basicAllocator)
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
 }
@@ -163,6 +167,9 @@ RegistryEntryCatalog::RegistryEntryCatalog(
 , d_size(0)
 , d_trigger(trigger)
 , d_oneShot(oneShot)
+//, d_detachMutex()
+, d_detachCondition()
+, d_socketsToDetach(basicAllocator)
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
 }
@@ -170,6 +177,7 @@ RegistryEntryCatalog::RegistryEntryCatalog(
 RegistryEntryCatalog::~RegistryEntryCatalog()
 {
     BSLS_ASSERT_OPT(d_size == 0);
+    BSLS_ASSERT_OPT(d_socketsToDetach.empty());
 }
 
 }  // close package namespace


### PR DESCRIPTION
This draft PR is not assumed to be merged as is. This PR just shows a way to ensure that socket which is asked to detach is not being polled by any other thread. 

Most likely it is not an optimal solution and it contains bugs (however `ntcf_system.t` TC 15 is stable now).