### PR TITLE
Test resolvers using dns.google.com instead of microsoft.com

### DIFF
--- a/groups/ntc/ntcdns/ntcdns_resolver.t.cpp
+++ b/groups/ntc/ntcdns/ntcdns_resolver.t.cpp
@@ -1931,16 +1931,18 @@ NTCCFG_TEST_CASE(20)
         ntca::GetEndpointOptions options;
         options.setIpAddressType(ntsa::IpAddressType::e_V4);
 
-        // Get the endpoint assigned to "microsoft.com:http".
+        // Get the endpoint assigned to "dns.google.com:http".
 
-        error = resolver->getEndpoint("microsoft.com:http", options, callback);
+        error = resolver->getEndpoint(
+            "dns.google.com:http", options, callback);
         NTCCFG_TEST_FALSE(error);
 
         semaphore.wait();
 
-        // Get the endpoint assigned to "microsoft.com:http".
+        // Get the endpoint assigned to "dns.google.com:http".
 
-        error = resolver->getEndpoint("microsoft.com:http", options, callback);
+        error = resolver->getEndpoint(
+            "dns.google.com:http", options, callback);
         NTCCFG_TEST_FALSE(error);
 
         semaphore.wait();

--- a/groups/ntc/ntcf/ntcf_system.t.cpp
+++ b/groups/ntc/ntcf/ntcf_system.t.cpp
@@ -6541,9 +6541,9 @@ void concernResolverGetEndpoint(bslma::Allocator* allocator)
         ntca::GetEndpointOptions options;
         options.setIpAddressType(ntsa::IpAddressType::e_V4);
 
-        // Get the endpoint assigned to "microsoft.com:http".
+        // Get the endpoint assigned to "dns.google.com:http".
 
-        error = resolver->getEndpoint("microsoft.com:http", options, callback);
+        error = resolver->getEndpoint("dns.google.com:http", options, callback);
         NTCCFG_TEST_OK(error);
 
         semaphore.wait();

--- a/groups/nts/ntsb/ntsb_resolver.t.cpp
+++ b/groups/nts/ntsb/ntsb_resolver.t.cpp
@@ -445,7 +445,7 @@ NTSCFG_TEST_CASE(3)
     // Concern: Test resolution of domain names to IP addresses from the
     // system.
     //
-    // Plan: Ensure 'microsoft.com' resolves to at least two of the known
+    // Plan: Ensure 'dns.google.com' resolves to at least two of the known
     // IP addresses at which it has been assigned, as of 2020.
 
     ntscfg::TestAllocator ta;
@@ -455,8 +455,8 @@ NTSCFG_TEST_CASE(3)
         ntsb::Resolver resolver(&ta);
 
         bsl::set<ntsa::IpAddress> ipAddressSet;
-        ipAddressSet.insert(ntsa::IpAddress("20.53.203.50"));
-        ipAddressSet.insert(ntsa::IpAddress("20.84.181.62"));
+        ipAddressSet.insert(ntsa::IpAddress("8.8.8.8"));
+        ipAddressSet.insert(ntsa::IpAddress("8.8.4.4"));
 
         NTSCFG_TEST_EQ(ipAddressSet.size(), 2);
 
@@ -464,7 +464,7 @@ NTSCFG_TEST_CASE(3)
         ntsa::IpAddressOptions       ipAddressOptions;
 
         error = resolver.getIpAddress(&ipAddressList,
-                                      "microsoft.com",
+                                      "dns.google.com",
                                       ipAddressOptions);
         NTSCFG_TEST_FALSE(error);
 

--- a/groups/nts/ntsf/ntsf_system.h
+++ b/groups/nts/ntsf/ntsf_system.h
@@ -666,18 +666,18 @@ namespace ntsf {
 ///     bsl::shared_ptr<ntsi::Resolver> resolver =
 ///                                     ntsf::System::createResolver();
 ///
-/// Next, resolve "microsoft.com" to the IP addresses it is assigned.
+/// Next, resolve "dns.google.com" to the IP addresses it is assigned.
 ///
 ///     bsl::vector<ntsa::IpAddress> addressList;
-///     error = resolver->getIpAddress(&addressList, "microsoft.com");
+///     error = resolver->getIpAddress(&addressList, "dns.google.com");
 ///     BSLS_ASSERT(!error);
 ///
-/// Next, verify that the resolver has resolved "microsoft.com" into at least
+/// Next, verify that the resolver has resolved "dns.google.com" into at least
 /// some of the expected IP addresses (assigned as of January 1, 2020.)
 ///
 ///     bsl::set<ntsa::IpAddress> addressSet;
-///     addressSet.insert(ntsa::IpAddress("20.53.203.50"));
-///     addressSet.insert(ntsa::IpAddress("20.84.181.62"));
+///     addressSet.insert(ntsa::IpAddress("8.8.8.8"));
+///     addressSet.insert(ntsa::IpAddress("8.8.4.4"));
 ///
 ///     for (bsl::vector<ntsa::IpAddress>::const_iterator
 ///             it  = addressList.begin();

--- a/groups/nts/ntsi/ntsi_resolver.h
+++ b/groups/nts/ntsi/ntsi_resolver.h
@@ -89,20 +89,20 @@ namespace ntsi {
 ///     bsl::shared_ptr<ntsi::Resolver> resolver =
 ///                                     ntsf::System::createResolver();
 ///
-/// Next, resolve "microsoft.com" to the IP addresses it is assigned.
+/// Next, resolve "dns.google.com" to the IP addresses it is assigned.
 ///
 ///     bsl::vector<ntsa::IpAddress> ipAddressList;
 ///     error = resolver->getIpAddress(&ipAddressList,
-///                                    "microsoft.com",
+///                                    "dns.google.com",
 ///                                    ntsa::IpAddressOptions());
 ///     BSLS_ASSERT(!error);
 ///
-/// Next, verify that the resolver has resolved "microsoft.com" into at least
+/// Next, verify that the resolver has resolved "dns.google.com" into at least
 /// some of the expected IP addresses (assigned as of January 1, 2020.)
 ///
 ///     bsl::set<ntsa::IpAddress> ipAddressSet;
-///     ipAddressSet.insert(ntsa::IpAddress("20.53.203.50"));
-///     ipAddressSet.insert(ntsa::IpAddress("20.84.181.62"));
+///     ipAddressSet.insert(ntsa::IpAddress("8.8.8.8"));
+///     ipAddressSet.insert(ntsa::IpAddress("8.8.4.4"));
 ///
 ///     for (bsl::vector<ntsa::IpAddress>::const_iterator
 ///             it  = ipAddressList.begin();

--- a/groups/nts/ntsu/ntsu_resolverutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_resolverutil.t.cpp
@@ -87,7 +87,7 @@ NTSCFG_TEST_CASE(3)
     // Concern: Test resolution of domain names to IP addresses for use by
     // an unspecified transport.
     //
-    // Plan: Ensure 'microsoft.com' resolves to at least two of the known
+    // Plan: Ensure 'dns.google.com' resolves to at least two of the known
     // IP addresses at which it has been assigned, as of 2020.
 
     ntscfg::TestAllocator ta;
@@ -95,8 +95,8 @@ NTSCFG_TEST_CASE(3)
         ntsa::Error error;
 
         bsl::set<ntsa::IpAddress> ipAddressSet(&ta);
-        ipAddressSet.insert(ntsa::IpAddress("20.53.203.50"));
-        ipAddressSet.insert(ntsa::IpAddress("20.84.181.62"));
+        ipAddressSet.insert(ntsa::IpAddress("8.8.8.8"));
+        ipAddressSet.insert(ntsa::IpAddress("8.8.4.4"));
 
         NTSCFG_TEST_EQ(ipAddressSet.size(), 2);
 
@@ -104,7 +104,7 @@ NTSCFG_TEST_CASE(3)
         ntsa::IpAddressOptions       ipAddressOptions;
 
         error = ntsu::ResolverUtil::getIpAddress(&ipAddressList,
-                                                 "microsoft.com",
+                                                 "dns.google.com",
                                                  ipAddressOptions);
         NTSCFG_TEST_FALSE(error);
 
@@ -128,7 +128,7 @@ NTSCFG_TEST_CASE(4)
 {
     // Concern: Test resolution of domain names to IPv4 addresses.
     //
-    // Plan: Ensure 'microsoft.com' resolves to at least two of the known
+    // Plan: Ensure 'dns.google.com' resolves to at least two of the known
     // IP addresses at which it has been assigned, as of 2020.
 
     ntscfg::TestAllocator ta;
@@ -136,8 +136,8 @@ NTSCFG_TEST_CASE(4)
         ntsa::Error error;
 
         bsl::set<ntsa::IpAddress> ipAddressSet(&ta);
-        ipAddressSet.insert(ntsa::IpAddress("20.53.203.50"));
-        ipAddressSet.insert(ntsa::IpAddress("20.84.181.62"));
+        ipAddressSet.insert(ntsa::IpAddress("8.8.8.8"));
+        ipAddressSet.insert(ntsa::IpAddress("8.8.4.4"));
 
         NTSCFG_TEST_EQ(ipAddressSet.size(), 2);
 
@@ -147,7 +147,7 @@ NTSCFG_TEST_CASE(4)
         ipAddressOptions.setIpAddressType(ntsa::IpAddressType::e_V4);
 
         error = ntsu::ResolverUtil::getIpAddress(&ipAddressList,
-                                                 "microsoft.com",
+                                                 "dns.google.com",
                                                  ipAddressOptions);
         NTSCFG_TEST_FALSE(error);
 
@@ -171,7 +171,7 @@ NTSCFG_TEST_CASE(5)
 {
     // Concern: Test resolution of domain names to IPv6 addresses.
     //
-    // Plan: Ensure 'microsoft.com' resolves to at least two of the known
+    // Plan: Ensure 'dns.google.com' resolves to at least two of the known
     // IP addresses at which it has been assigned, as of 2020.
 
     ntscfg::TestAllocator ta;
@@ -190,7 +190,7 @@ NTSCFG_TEST_CASE(5)
         ipAddressOptions.setIpAddressType(ntsa::IpAddressType::e_V6);
 
         error = ntsu::ResolverUtil::getIpAddress(&ipAddressList,
-                                                 "microsoft.com",
+                                                 "dns.google.com",
                                                  ipAddressOptions);
         // TODO: NTSCFG_TEST_FALSE(error);
 
@@ -216,7 +216,7 @@ NTSCFG_TEST_CASE(6)
     // Concern: Test resolution of domain names to IP addresses for use by
     // a specific TCP/IPv4-based transport.
     //
-    // Plan: Ensure 'microsoft.com' resolves to at least two of the known
+    // Plan: Ensure 'dns.google.com' resolves to at least two of the known
     // IP addresses at which it has been assigned, as of 2020.
 
     ntscfg::TestAllocator ta;
@@ -224,8 +224,8 @@ NTSCFG_TEST_CASE(6)
         ntsa::Error error;
 
         bsl::set<ntsa::IpAddress> ipAddressSet(&ta);
-        ipAddressSet.insert(ntsa::IpAddress("20.53.203.50"));
-        ipAddressSet.insert(ntsa::IpAddress("20.84.181.62"));
+        ipAddressSet.insert(ntsa::IpAddress("8.8.8.8"));
+        ipAddressSet.insert(ntsa::IpAddress("8.8.4.4"));
 
         NTSCFG_TEST_EQ(ipAddressSet.size(), 2);
 
@@ -235,7 +235,7 @@ NTSCFG_TEST_CASE(6)
         ipAddressOptions.setTransport(ntsa::Transport::e_TCP_IPV4_STREAM);
 
         error = ntsu::ResolverUtil::getIpAddress(&ipAddressList,
-                                                 "microsoft.com",
+                                                 "dns.google.com",
                                                  ipAddressOptions);
         NTSCFG_TEST_FALSE(error);
 
@@ -260,7 +260,7 @@ NTSCFG_TEST_CASE(7)
     // Concern: Test resolution of domain names to IP addresses for use by
     // a specific UDP/IPv4-based transport.
     //
-    // Plan: Ensure 'microsoft.com' resolves to at least two of the known
+    // Plan: Ensure 'dns.google.com' resolves to at least two of the known
     // IP addresses at which it has been assigned, as of 2020.
 
     ntscfg::TestAllocator ta;
@@ -268,8 +268,8 @@ NTSCFG_TEST_CASE(7)
         ntsa::Error error;
 
         bsl::set<ntsa::IpAddress> ipAddressSet(&ta);
-        ipAddressSet.insert(ntsa::IpAddress("20.53.203.50"));
-        ipAddressSet.insert(ntsa::IpAddress("20.84.181.62"));
+        ipAddressSet.insert(ntsa::IpAddress("8.8.8.8"));
+        ipAddressSet.insert(ntsa::IpAddress("8.8.4.4"));
 
         NTSCFG_TEST_EQ(ipAddressSet.size(), 2);
 
@@ -279,7 +279,7 @@ NTSCFG_TEST_CASE(7)
         ipAddressOptions.setTransport(ntsa::Transport::e_UDP_IPV4_DATAGRAM);
 
         error = ntsu::ResolverUtil::getIpAddress(&ipAddressList,
-                                                 "microsoft.com",
+                                                 "dns.google.com",
                                                  ipAddressOptions);
         NTSCFG_TEST_FALSE(error);
 
@@ -304,7 +304,7 @@ NTSCFG_TEST_CASE(8)
     // Concern: Test resolution of domain names to IP addresses for use by
     // a specific TCP/IPv6-based transport.
     //
-    // Plan: Ensure 'microsoft.com' resolves to at least two of the known
+    // Plan: Ensure 'dns.google.com' resolves to at least two of the known
     // IP addresses at which it has been assigned, as of 2020.
 
     ntscfg::TestAllocator ta;
@@ -323,7 +323,7 @@ NTSCFG_TEST_CASE(8)
         ipAddressOptions.setTransport(ntsa::Transport::e_TCP_IPV6_STREAM);
 
         error = ntsu::ResolverUtil::getIpAddress(&ipAddressList,
-                                                 "microsoft.com",
+                                                 "dns.google.com",
                                                  ipAddressOptions);
         // TODO: NTSCFG_TEST_FALSE(error);
 
@@ -349,7 +349,7 @@ NTSCFG_TEST_CASE(9)
     // Concern: Test resolution of domain names to IP addresses for use by
     // a specific UDP/IPv6-based transport.
     //
-    // Plan: Ensure 'microsoft.com' resolves to at least two of the known
+    // Plan: Ensure 'dns.google.com' resolves to at least two of the known
     // IP addresses at which it has been assigned, as of 2020.
 
     ntscfg::TestAllocator ta;
@@ -368,7 +368,7 @@ NTSCFG_TEST_CASE(9)
         ipAddressOptions.setTransport(ntsa::Transport::e_UDP_IPV6_DATAGRAM);
 
         error = ntsu::ResolverUtil::getIpAddress(&ipAddressList,
-                                                 "microsoft.com",
+                                                 "dns.google.com",
                                                  ipAddressOptions);
         // TODO: NTSCFG_TEST_FALSE(error);
 


### PR DESCRIPTION
This PR makes a small update to the test drivers that perform sanity checks of the resolver implementation by resolving some well-known domain name to some IP addresses we expect are assigned to that domain name. Previously, these test drivers resolved "microsoft.com", but the IP addresses assigned to that domain name change periodically. This PR switches those test drivers to use "dns.google.com", as those IP addresses should be much more stable.