### PR TITLE
Expose the transport used by a proactor socket

### DIFF
--- a/groups/ntc/ntcd/ntcd_proactor.t.cpp
+++ b/groups/ntc/ntcd/ntcd_proactor.t.cpp
@@ -161,6 +161,9 @@ class ProactorStreamSocket : public ntci::ProactorSocket,
     /// connection requests, otherwise return false.
     bool isListener() const BSLS_KEYWORD_OVERRIDE;
 
+    /// Return the transport used by the socket.
+    ntsa::Transport::Value transport() const BSLS_KEYWORD_OVERRIDE;
+
     /// Return the strand on which this object's functions should be called.
     const bsl::shared_ptr<ntci::Strand>& strand() const BSLS_KEYWORD_OVERRIDE;
 
@@ -518,6 +521,11 @@ bool ProactorStreamSocket::isDatagram() const
 bool ProactorStreamSocket::isListener() const
 {
     return false;
+}
+
+ntsa::Transport::Value ProactorStreamSocket::transport() const
+{
+    return ntsa::Transport::e_TCP_IPV4_STREAM;
 }
 
 const bsl::shared_ptr<ntci::Strand>& ProactorStreamSocket::strand() const
@@ -908,6 +916,9 @@ class ProactorListenerSocket : public ntci::ProactorSocket,
     /// connection requests, otherwise return false.
     bool isListener() const BSLS_KEYWORD_OVERRIDE;
 
+    /// Return the transport used by the socket.
+    ntsa::Transport::Value transport() const BSLS_KEYWORD_OVERRIDE;
+
     /// Return the strand on which this object's functions should be called.
     const bsl::shared_ptr<ntci::Strand>& strand() const BSLS_KEYWORD_OVERRIDE;
 
@@ -1106,6 +1117,11 @@ bool ProactorListenerSocket::isDatagram() const
 bool ProactorListenerSocket::isListener() const
 {
     return true;
+}
+
+ntsa::Transport::Value ProactorListenerSocket::transport() const
+{
+    return ntsa::Transport::e_TCP_IPV4_STREAM;
 }
 
 const bsl::shared_ptr<ntci::Strand>& ProactorListenerSocket::strand() const

--- a/groups/ntc/ntci/ntci_proactorsocket.cpp
+++ b/groups/ntc/ntci/ntci_proactorsocket.cpp
@@ -77,5 +77,10 @@ bool ProactorSocket::isListener() const
     return false;
 }
 
+ntsa::Transport::Value ProactorSocket::transport() const
+{
+    return ntsa::Transport::e_UNDEFINED;
+}
+
 }  // close package namespace
 }  // close enterprise namespace

--- a/groups/ntc/ntci/ntci_proactorsocket.h
+++ b/groups/ntc/ntci/ntci_proactorsocket.h
@@ -115,6 +115,9 @@ class ProactorSocket : public ntci::ProactorSocketBase, public ntsi::Descriptor
     /// Return true if the proactor socket is a listener for incoming
     /// connection requests, otherwise return false.
     virtual bool isListener() const;
+
+    /// Return the transport used by the socket.
+    virtual ntsa::Transport::Value transport() const;
 };
 
 NTCCFG_INLINE

--- a/groups/ntc/ntco/ntco_iocp.t.cpp
+++ b/groups/ntc/ntco/ntco_iocp.t.cpp
@@ -164,6 +164,10 @@ class ProactorStreamSocket : public ntci::ProactorSocket,
     // Return true if the proactor socket is a listener for incoming
     // connection requests, otherwise return false.
 
+    ntsa::Transport::Value transport() const BSLS_KEYWORD_OVERRIDE;
+    // Return true if the proactor socket is a listener for incoming
+    // connection requests, otherwise return false.
+
     const bsl::shared_ptr<ntci::Strand>& strand() const BSLS_KEYWORD_OVERRIDE;
     // Return the strand on which this object's functions should be called.
 
@@ -518,6 +522,11 @@ bool ProactorStreamSocket::isDatagram() const
 bool ProactorStreamSocket::isListener() const
 {
     return false;
+}
+
+ntsa::Transport::Value ProactorStreamSocket::transport() const
+{
+    return ntsa::Transport::e_TCP_IPV4_STREAM;
 }
 
 const bsl::shared_ptr<ntci::Strand>& ProactorStreamSocket::strand() const
@@ -903,6 +912,10 @@ class ProactorListenerSocket : public ntci::ProactorSocket,
     // Return true if the proactor socket is a listener for incoming
     // connection requests, otherwise return false.
 
+    ntsa::Transport::Value transport() const BSLS_KEYWORD_OVERRIDE;
+    // Return true if the proactor socket is a listener for incoming
+    // connection requests, otherwise return false.
+
     const bsl::shared_ptr<ntci::Strand>& strand() const BSLS_KEYWORD_OVERRIDE;
     // Return the strand on which this object's functions should be called.
 
@@ -1096,6 +1109,11 @@ bool ProactorListenerSocket::isDatagram() const
 bool ProactorListenerSocket::isListener() const
 {
     return true;
+}
+
+ntsa::Transport::Value ProactorListenerSocket::transport() const
+{
+    return ntsa::Transport::e_TCP_IPV4_STREAM;
 }
 
 const bsl::shared_ptr<ntci::Strand>& ProactorListenerSocket::strand() const

--- a/groups/ntc/ntcp/ntcp_listenersocket.h
+++ b/groups/ntc/ntcp/ntcp_listenersocket.h
@@ -592,7 +592,7 @@ class ListenerSocket : public ntci::ListenerSocket,
     /// Return the descriptor handle.
     ntsa::Handle handle() const BSLS_KEYWORD_OVERRIDE;
 
-    /// Return the transport of the datagram socket.
+    /// Return the transport of the listener socket.
     ntsa::Transport::Value transport() const BSLS_KEYWORD_OVERRIDE;
 
     /// Return the source address.

--- a/groups/ntc/ntcp/ntcp_streamsocket.h
+++ b/groups/ntc/ntcp/ntcp_streamsocket.h
@@ -1208,7 +1208,7 @@ class StreamSocket : public ntci::StreamSocket,
     /// Return the descriptor handle.
     ntsa::Handle handle() const BSLS_KEYWORD_OVERRIDE;
 
-    /// Return the transport of the datagram socket.
+    /// Return the transport of the stream socket.
     ntsa::Transport::Value transport() const BSLS_KEYWORD_OVERRIDE;
 
     /// Return the source endpoint.

--- a/groups/nts/ntsa/ntsa_domainname.t.cpp
+++ b/groups/nts/ntsa/ntsa_domainname.t.cpp
@@ -179,7 +179,7 @@ NTSCFG_TEST_CASE(1)
         found = parentDomainName.domain(&grandParentDomainName);
         NTSCFG_TEST_TRUE(found);
 
-        equals = parentDomainName.equals("baz");
+        equals = grandParentDomainName.equals("baz");
         NTSCFG_TEST_TRUE(equals);
 
         name = grandParentDomainName.name();


### PR DESCRIPTION
This PR adds a new function, `ntci::ProactorSocket::transport()`, to allow `ntci::Proactor` implementations to determine the socket address family and transport protocol used by the socket being proactively managed.