### PR TITLE
Lock the mutex inside 'processNotifications()' in ntcr_datagramsocket and ntcr_streamsocket

### DIFF
--- a/groups/ntc/ntcr/ntcr_datagramsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.cpp
@@ -330,6 +330,15 @@ void DatagramSocket::processSocketError(const ntca::ReactorEvent& event)
 void DatagramSocket::processNotifications(
     const ntsa::NotificationQueue& notifications)
 {
+    NTCCFG_OBJECT_GUARD(&d_object);
+
+    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+
     const bsl::vector<ntsa::Notification>& nots =
         notifications.notifications();
 

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -401,6 +401,16 @@ void StreamSocket::processSocketError(const ntca::ReactorEvent& event)
 void StreamSocket::processNotifications(
     const ntsa::NotificationQueue& notifications)
 {
+    NTCCFG_OBJECT_GUARD(&d_object);
+
+    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+
     const bsl::vector<ntsa::Notification>& nots =
         notifications.notifications();
     for (size_t i = 0; i < nots.size(); ++i) {


### PR DESCRIPTION
This PR add correction to timestamping feature implementation: now notifications from reactor drivers are processed under a lock