### PR TITLE
Increase ntcs::Event::d_address size to >= _SS_MAXSIZE

### DIFF
--- a/groups/ntc/ntcs/ntcs_event.h
+++ b/groups/ntc/ntcs/ntcs_event.h
@@ -265,7 +265,7 @@ class Event
 #if defined(BSLS_PLATFORM_OS_UNIX)
 
     char                                  d_message[64];
-    char                                  d_address[192];
+    char                                  d_address[256];
     char                                  d_control[256];
     char                                  d_buffers[1024 * 16];
 
@@ -305,9 +305,9 @@ class Event
     template <typename TYPE>
     TYPE* message();
 
-    /// Return the array of structures of the parameterized 'TYPE' stored in 
+    /// Return the array of structures of the parameterized 'TYPE' stored in
     /// the buffer arena and load into the specified 'maxBuffers' the maximum
-    /// number of structures that may be stored in the array. The resulting 
+    /// number of structures that may be stored in the array. The resulting
     /// address is guaranteed to be 8-byte aligned.
     template <typename TYPE>
     TYPE* buffers(bsl::size_t* maxBuffers);
@@ -317,8 +317,8 @@ class Event
     template <typename TYPE>
     TYPE* address();
 
-    /// Return the structure of the parameterized 'TYPE' stored in the 
-    /// indicator arena. The template will fail to compile if 
+    /// Return the structure of the parameterized 'TYPE' stored in the
+    /// indicator arena. The template will fail to compile if
     /// 'sizeof(TYPE) != 4'. The resulting address is guaranteed to be 4-byte
     /// aligned.
     template <typename TYPE>


### PR DESCRIPTION
The `ntcs::Event` structure stores necessary state for asynchronous operations performed by `ntci::Proactor` implementations. Part of this state stores the value of a `sockaddr_storage` type. On certain platforms, e.g. Solaris 11.3, the size of `sockaddr_storage` is greater than the previously calculated minimum value necessary for portability. This PR increases `sizeof(ntcs::Event::d_address)` to >= `_SS_MAXSIZE` on all supported Unix platforms. The technique used for abstraction here is recognized to be brittle and should be addresses in a future PR.
