### PR TITLE
Support a default, globally-accessible ntci::Interface and other similar mechanisms

### DIFF
--- a/groups/ntc/ntcf/ntcf_system.h
+++ b/groups/ntc/ntcf/ntcf_system.h
@@ -949,6 +949,62 @@ struct System {
     /// produce proactors implemented by the specified 'driverName', and
     /// false otherwise.
     static bool supportsProactorFactory(const bsl::string& driverName);
+    
+    // Install the specified 'executor' as the default executor.
+    static void setDefault(const bsl::shared_ptr<ntci::Executor>& executor);
+
+    // Install the specified 'strand' as the default strand.
+    static void setDefault(const bsl::shared_ptr<ntci::Strand>& strand);
+
+    // Install the specified 'driver' as the default driver.
+    static void setDefault(const bsl::shared_ptr<ntci::Driver>& driver);
+
+    // Install the specified 'reactor' as the default reactor.
+    static void setDefault(const bsl::shared_ptr<ntci::Reactor>& reactor);
+
+    // Install the specified 'proactor' as the default proactor.
+    static void setDefault(const bsl::shared_ptr<ntci::Proactor>& proactor);
+
+    // Install the specified 'interface' as the default interface.
+    static void setDefault(const bsl::shared_ptr<ntci::Interface>& interface);
+
+    // Install the specified 'resolver' as the default resolver.
+    static void setDefault(const bsl::shared_ptr<ntci::Resolver>& resolver);
+
+    // Load into the specified 'result' the default executor. If no default
+    // executor is explicitly installed, automatically create install a default
+    // executor with a default configuration.
+    static void getDefault(bsl::shared_ptr<ntci::Executor>* result);
+
+    // Load into the specified 'result' the default strand. If no default
+    // strand is explicitly installed, automatically create install a default
+    // strand with a default configuration.
+    static void getDefault(bsl::shared_ptr<ntci::Strand>* result);
+
+    // Load into the specified 'result' the default driver. If no default
+    // driver is explicitly installed, automatically create install a default
+    // driver with a default configuration.
+    static void getDefault(bsl::shared_ptr<ntci::Driver>* result);
+
+    // Load into the specified 'result' the default reactor. If no default
+    // reactor is explicitly installed, automatically create install a default
+    // reactor with a default configuration.
+    static void getDefault(bsl::shared_ptr<ntci::Reactor>* result);
+
+    // Load into the specified 'result' the default proactor. If no default
+    // proactor is explicitly installed, automatically create install a default
+    // proactor with a default configuration.
+    static void getDefault(bsl::shared_ptr<ntci::Proactor>* result);
+
+    // Load into the specified 'result' the default interface. If no default
+    // interface is explicitly installed, automatically create install a default
+    // interface with a default configuration.
+    static void getDefault(bsl::shared_ptr<ntci::Interface>* result);
+
+    // Load into the specified 'result' the default resolver. If no default
+    // resolver is explicitly installed, automatically create install a default
+    // resolver with a default configuration.
+    static void getDefault(bsl::shared_ptr<ntci::Resolver>* result);
 
     /// Release the resources necessary for this library's implementation.
     static void exit();

--- a/groups/ntc/ntcf/ntcf_system.t.cpp
+++ b/groups/ntc/ntcf/ntcf_system.t.cpp
@@ -11383,6 +11383,41 @@ NTCCFG_TEST_CASE(61)
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
 
+NTCCFG_TEST_CASE(62)
+{
+    // Concern: Default executors.
+
+    ntccfg::TestAllocator ta;
+    {
+        bsl::shared_ptr<ntci::Executor> executor;
+        ntcf::System::getDefault(&executor);
+
+        bsl::size_t numReferences = executor.use_count();
+        NTCCFG_TEST_EQ(numReferences, 2);
+
+        bslmt::Latch latch(1);
+        executor->execute(NTCCFG_BIND(&bslmt::Latch::arrive, &latch));
+        latch.wait();
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(63)
+{
+    // Concern: Default interfaces.
+
+    ntccfg::TestAllocator ta;
+    {
+        bsl::shared_ptr<ntci::Interface> interface;
+        ntcf::System::getDefault(&interface);
+
+        bslmt::Latch latch(1);
+        interface->execute(NTCCFG_BIND(&bslmt::Latch::arrive, &latch));
+        latch.wait();
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
 NTCCFG_TEST_DRIVER
 {
     NTCCFG_TEST_REGISTER(1);
@@ -11446,5 +11481,7 @@ NTCCFG_TEST_DRIVER
     NTCCFG_TEST_REGISTER(59);
     NTCCFG_TEST_REGISTER(60);
     NTCCFG_TEST_REGISTER(61);
+    NTCCFG_TEST_REGISTER(62);
+    NTCCFG_TEST_REGISTER(63);
 }
 NTCCFG_TEST_DRIVER_END;

--- a/groups/ntc/ntcs/ntcs_global.cpp
+++ b/groups/ntc/ntcs/ntcs_global.cpp
@@ -18,10 +18,791 @@
 #include <bsls_ident.h>
 BSLS_IDENT_RCSID(ntcs_global_cpp, "$Id$ $CSID$")
 
+#include <ntci_mutex.h>
+#include <bslmt_once.h>
+#include <bslma_newdeleteallocator.h>
 #include <bsls_assert.h>
+#include <bsl_cstdlib.h>
 
 namespace BloombergLP {
 namespace ntcs {
+
+namespace {
+
+typedef ntci::Mutex Mutex;
+typedef ntci::LockGuard LockGuard;
+
+bslma::Allocator*         s_allocator_p;
+Mutex*                    s_mutex_p;
+ntci::Executor*           s_executor_p;
+bslma::SharedPtrRep*      s_executorRep_p;
+Global::ExecutorProvider  s_executorProvider;
+ntci::Strand*             s_strand_p;
+bslma::SharedPtrRep*      s_strandRep_p;
+Global::StrandProvider    s_strandProvider;
+ntci::Driver*             s_driver_p;
+bslma::SharedPtrRep*      s_driverRep_p;
+Global::DriverProvider    s_driverProvider;
+ntci::Reactor*            s_reactor_p;
+bslma::SharedPtrRep*      s_reactorRep_p;
+Global::ReactorProvider   s_reactorProvider;
+ntci::Proactor*           s_proactor_p;
+bslma::SharedPtrRep*      s_proactorRep_p;
+Global::ProactorProvider  s_proactorProvider;
+ntci::Interface*          s_interface_p;
+bslma::SharedPtrRep*      s_interfaceRep_p;
+Global::InterfaceProvider s_interfaceProvider;
+ntci::Resolver*           s_resolver_p;
+bslma::SharedPtrRep*      s_resolverRep_p;
+Global::ResolverProvider  s_resolverProvider;
+
+void registerExecutor(ntci::Executor*      executor, 
+                      bslma::SharedPtrRep* executorRep)
+{
+    BSLS_ASSERT_OPT(s_executor_p == 0);
+    BSLS_ASSERT_OPT(s_executorRep_p == 0);
+
+    s_executor_p    = executor;
+    s_executorRep_p = executorRep;
+
+    BSLS_ASSERT_OPT(s_executor_p);
+    BSLS_ASSERT_OPT(s_executorRep_p);
+}
+
+void registerStrand(ntci::Strand*        strand, 
+                    bslma::SharedPtrRep* strandRep)
+{
+    BSLS_ASSERT_OPT(s_strand_p == 0);
+    BSLS_ASSERT_OPT(s_strandRep_p == 0);
+
+    s_strand_p    = strand;
+    s_strandRep_p = strandRep;
+
+    BSLS_ASSERT_OPT(s_strand_p);
+    BSLS_ASSERT_OPT(s_strandRep_p);
+
+    if (s_executor_p == 0) {
+        s_strandRep_p->acquireRef();
+        registerExecutor(s_strand_p, s_strandRep_p);
+    }
+}
+
+void registerDriver(ntci::Driver*        driver, 
+                    bslma::SharedPtrRep* driverRep)
+{
+    BSLS_ASSERT_OPT(s_driver_p == 0);
+    BSLS_ASSERT_OPT(s_driverRep_p == 0);
+
+    s_driver_p    = driver;
+    s_driverRep_p = driverRep;
+
+    BSLS_ASSERT_OPT(s_driver_p);
+    BSLS_ASSERT_OPT(s_driverRep_p);
+}
+
+void registerReactor(ntci::Reactor*       reactor, 
+                     bslma::SharedPtrRep* reactorRep)
+{
+    BSLS_ASSERT_OPT(s_reactor_p == 0);
+    BSLS_ASSERT_OPT(s_reactorRep_p == 0);
+
+    s_reactor_p    = reactor;
+    s_reactorRep_p = reactorRep;
+
+    BSLS_ASSERT_OPT(s_reactor_p);
+    BSLS_ASSERT_OPT(s_reactorRep_p);
+
+    if (s_driver_p == 0) {
+        s_reactorRep_p->acquireRef();
+        registerDriver(s_reactor_p, s_reactorRep_p);
+    }
+}
+
+void registerProactor(ntci::Proactor*      proactor, 
+                      bslma::SharedPtrRep* proactorRep)
+{
+    BSLS_ASSERT_OPT(s_proactor_p == 0);
+    BSLS_ASSERT_OPT(s_proactorRep_p == 0);
+
+    s_proactor_p    = proactor;
+    s_proactorRep_p = proactorRep;
+
+    BSLS_ASSERT_OPT(s_proactor_p);
+    BSLS_ASSERT_OPT(s_proactorRep_p);
+
+    if (s_driver_p == 0) {
+        s_proactorRep_p->acquireRef();
+        registerDriver(s_proactor_p, s_proactorRep_p);
+    }
+}
+
+void registerInterface(ntci::Interface*     interface, 
+                       bslma::SharedPtrRep* interfaceRep)
+{
+    BSLS_ASSERT_OPT(s_interface_p == 0);
+    BSLS_ASSERT_OPT(s_interfaceRep_p == 0);
+
+    s_interface_p    = interface;
+    s_interfaceRep_p = interfaceRep;
+
+    BSLS_ASSERT_OPT(s_interface_p);
+    BSLS_ASSERT_OPT(s_interfaceRep_p);
+
+    if (s_executor_p == 0) {
+        s_interfaceRep_p->acquireRef();
+        registerExecutor(s_interface_p, s_interfaceRep_p);
+    }
+}
+
+void registerResolver(ntci::Resolver*      resolver, 
+                      bslma::SharedPtrRep* resolverRep)
+{
+    BSLS_ASSERT_OPT(s_resolver_p == 0);
+    BSLS_ASSERT_OPT(s_resolverRep_p == 0);
+
+    s_resolver_p    = resolver;
+    s_resolverRep_p = resolverRep;
+
+    BSLS_ASSERT_OPT(s_resolver_p);
+    BSLS_ASSERT_OPT(s_resolverRep_p);
+}
+
+void deregisterExecutor()
+{
+    BSLS_ASSERT_OPT(s_executor_p);
+    BSLS_ASSERT_OPT(s_executorRep_p);
+
+    s_executorRep_p->releaseRef();
+
+    s_executor_p    = 0;
+    s_executorRep_p = 0;
+}
+
+void deregisterStrand()
+{
+    BSLS_ASSERT_OPT(s_strand_p);
+    BSLS_ASSERT_OPT(s_strandRep_p);
+
+    ntci::Strand* strand = s_strand_p;
+
+    s_strand_p->clear();
+
+    s_strandRep_p->releaseRef();
+
+    s_strand_p    = 0;
+    s_strandRep_p = 0;
+
+    if (s_executor_p == strand) {
+        deregisterExecutor();
+    }
+}
+
+void deregisterDriver()
+{
+    BSLS_ASSERT_OPT(s_driver_p);
+    BSLS_ASSERT_OPT(s_driverRep_p);
+
+    s_driverRep_p->releaseRef();
+
+    s_driver_p    = 0;
+    s_driverRep_p = 0;
+}
+
+void deregisterReactor()
+{
+    BSLS_ASSERT_OPT(s_reactor_p);
+    BSLS_ASSERT_OPT(s_reactorRep_p);
+
+    ntci::Reactor* reactor = s_reactor_p;
+
+    s_reactor_p->closeAll();
+    s_reactor_p->clear();
+
+    s_reactorRep_p->releaseRef();
+
+    s_reactor_p    = 0;
+    s_reactorRep_p = 0;
+
+    if (s_driver_p == reactor) {
+        deregisterDriver();
+    }
+}
+
+void deregisterProactor()
+{
+    BSLS_ASSERT_OPT(s_proactor_p);
+    BSLS_ASSERT_OPT(s_proactorRep_p);
+
+    ntci::Proactor* proactor = s_proactor_p;
+
+    s_proactor_p->closeAll();
+    s_proactor_p->clear();
+
+    s_proactorRep_p->releaseRef();
+
+    s_proactor_p    = 0;
+    s_proactorRep_p = 0;
+
+    if (s_driver_p == proactor) {
+        deregisterDriver();
+    }
+}
+
+void deregisterInterface()
+{
+    BSLS_ASSERT_OPT(s_interface_p);
+    BSLS_ASSERT_OPT(s_interfaceRep_p);
+
+    ntci::Interface* interface = s_interface_p;
+
+    s_interface_p->closeAll();
+    s_interface_p->shutdown();
+    s_interface_p->linger();
+
+    s_interfaceRep_p->releaseRef();
+
+    s_interface_p    = 0;
+    s_interfaceRep_p = 0;
+
+    if (s_executor_p == interface) {
+        deregisterExecutor();
+    }
+}
+
+void deregisterResolver()
+{
+    BSLS_ASSERT_OPT(s_resolver_p);
+    BSLS_ASSERT_OPT(s_resolverRep_p);
+
+    s_resolver_p->shutdown();
+    s_resolver_p->linger();
+
+    s_resolverRep_p->releaseRef();
+
+    s_resolver_p    = 0;
+    s_resolverRep_p = 0;
+}
+
+} // close unnamed namespace
+
+void Global::initialize()
+{
+    // We use a new delete allocator instead of the global allocator here
+    // because we want to prevent a visible "memory leak" if the global
+    // allocator has been replaced in main.  This is because the memory
+    // allocated by the global objects won't be freed until the process
+    // exits.
+
+    BSLMT_ONCE_DO
+    {
+        s_allocator_p = &bslma::NewDeleteAllocator::singleton();
+        s_mutex_p = new (*s_allocator_p) Mutex();
+
+        bsl::atexit(&Global::exit);
+    }
+}
+
+void Global::setDefault(Global::ExecutorProvider provider)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+    s_executorProvider = provider;
+}
+
+void Global::setDefault(Global::StrandProvider provider)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+    s_strandProvider = provider;
+}
+
+void Global::setDefault(Global::DriverProvider provider)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+    s_driverProvider = provider;
+}
+
+void Global::setDefault(Global::ReactorProvider provider)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+    s_reactorProvider = provider;
+}
+
+void Global::setDefault(Global::ProactorProvider provider)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+    s_proactorProvider = provider;
+}
+
+void Global::setDefault(Global::InterfaceProvider provider)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+    s_interfaceProvider = provider;
+}
+
+void Global::setDefault(Global::ResolverProvider provider)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+    s_resolverProvider = provider;
+}
+
+void Global::setDefault(const bsl::shared_ptr<ntci::Executor>& executor)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+
+    if (s_executor_p != 0) {
+        deregisterExecutor();
+    }
+
+    bsl::shared_ptr<ntci::Executor>                  temp = executor;
+    bsl::pair<ntci::Executor*, bslma::SharedPtrRep*> pair = temp.release();
+
+    BSLS_ASSERT_OPT(!temp);
+
+    registerExecutor(pair.first, pair.second);
+}
+
+void Global::setDefault(const bsl::shared_ptr<ntci::Strand>& strand)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+
+    if (s_strand_p != 0) {
+        deregisterStrand();
+    }
+
+    bsl::shared_ptr<ntci::Strand>                  temp = strand;
+    bsl::pair<ntci::Strand*, bslma::SharedPtrRep*> pair = temp.release();
+
+    BSLS_ASSERT_OPT(!temp);
+
+    registerStrand(pair.first, pair.second);
+}
+
+void Global::setDefault(const bsl::shared_ptr<ntci::Driver>& driver)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+
+    if (s_driver_p != 0) {
+        deregisterDriver();
+    }
+
+    bsl::shared_ptr<ntci::Driver>                  temp = driver;
+    bsl::pair<ntci::Driver*, bslma::SharedPtrRep*> pair = temp.release();
+
+    BSLS_ASSERT_OPT(!temp);
+
+    registerDriver(pair.first, pair.second);
+}
+
+void Global::setDefault(const bsl::shared_ptr<ntci::Reactor>& reactor)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+
+    if (s_reactor_p != 0) {
+        deregisterReactor();
+    }
+
+    bsl::shared_ptr<ntci::Reactor>                  temp = reactor;
+    bsl::pair<ntci::Reactor*, bslma::SharedPtrRep*> pair = temp.release();
+
+    BSLS_ASSERT_OPT(!temp);
+
+    registerReactor(pair.first, pair.second);
+}
+
+void Global::setDefault(const bsl::shared_ptr<ntci::Proactor>& proactor)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+
+    if (s_proactor_p != 0) {
+        deregisterProactor();
+    }
+
+    bsl::shared_ptr<ntci::Proactor>                  temp = proactor;
+    bsl::pair<ntci::Proactor*, bslma::SharedPtrRep*> pair = temp.release();
+
+    BSLS_ASSERT_OPT(!temp);
+
+    registerProactor(pair.first, pair.second);
+}
+
+void Global::setDefault(const bsl::shared_ptr<ntci::Interface>& interface)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+
+    if (s_interface_p != 0) {
+        deregisterInterface();
+    }
+
+    bsl::shared_ptr<ntci::Interface>                  temp = interface;
+    bsl::pair<ntci::Interface*, bslma::SharedPtrRep*> pair = temp.release();
+
+    BSLS_ASSERT_OPT(!temp);
+
+    registerInterface(pair.first, pair.second);
+}
+
+void Global::setDefault(const bsl::shared_ptr<ntci::Resolver>& resolver)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+
+    if (s_resolver_p != 0) {
+        deregisterResolver();
+    }
+
+    bsl::shared_ptr<ntci::Resolver>                  temp = resolver;
+    bsl::pair<ntci::Resolver*, bslma::SharedPtrRep*> pair = temp.release();
+
+    BSLS_ASSERT_OPT(!temp);
+
+    registerResolver(pair.first, pair.second);
+}
+
+void Global::getDefault(bsl::shared_ptr<ntci::Executor>* result)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+
+    if (NTSCFG_UNLIKELY(s_executor_p == 0)) {
+        BSLS_ASSERT_OPT(s_allocator_p);
+
+        bsl::shared_ptr<ntci::Executor> executor;
+        if (s_executorProvider) {
+            s_executorProvider(&executor, s_allocator_p);
+        }
+        
+        bsl::pair<ntci::Executor*, bslma::SharedPtrRep*> pair =
+            executor.release();
+
+        BSLS_ASSERT_OPT(!executor);
+
+        registerExecutor(pair.first, pair.second);
+    }
+
+    BSLS_ASSERT_OPT(s_executor_p);
+    BSLS_ASSERT_OPT(s_executorRep_p);
+
+    s_executorRep_p->acquireRef();
+
+    *result = bsl::shared_ptr<ntci::Executor>(s_executor_p,
+                                              s_executorRep_p);
+    BSLS_ASSERT_OPT(*result);
+}
+
+void Global::getDefault(bsl::shared_ptr<ntci::Strand>* result)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+
+    if (NTSCFG_UNLIKELY(s_strand_p == 0)) {
+        BSLS_ASSERT_OPT(s_allocator_p);
+
+        bsl::shared_ptr<ntci::Strand> strand;
+
+        if (s_driver_p != 0) {
+            strand = s_driver_p->createStrand(s_allocator_p);
+        }
+        else if (s_reactor_p != 0) {
+            strand = s_reactor_p->createStrand(s_allocator_p);
+        }
+        else if (s_proactor_p != 0) {
+            strand = s_proactor_p->createStrand(s_allocator_p);
+        }
+        else if (s_interface_p != 0) {
+            strand = s_interface_p->createStrand(s_allocator_p);
+        }
+        else {
+            bsl::shared_ptr<ntci::Interface> interface;
+            if (s_interfaceProvider) {
+                s_interfaceProvider(&interface, s_allocator_p);
+            }
+            
+            bsl::pair<ntci::Interface*, bslma::SharedPtrRep*> pair =
+                interface.release();
+
+            BSLS_ASSERT_OPT(!interface);
+
+            registerInterface(pair.first, pair.second);
+        }
+        
+        bsl::pair<ntci::Strand*, bslma::SharedPtrRep*> pair =
+            strand.release();
+
+        BSLS_ASSERT_OPT(!strand);
+
+        registerStrand(pair.first, pair.second);
+    }
+
+    BSLS_ASSERT_OPT(s_strand_p);
+    BSLS_ASSERT_OPT(s_strandRep_p);
+
+    s_strandRep_p->acquireRef();
+
+    *result = bsl::shared_ptr<ntci::Strand>(s_strand_p,
+                                              s_strandRep_p);
+    BSLS_ASSERT_OPT(*result);
+}
+
+void Global::getDefault(bsl::shared_ptr<ntci::Driver>* result)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+
+    if (NTSCFG_UNLIKELY(s_driver_p == 0)) {
+        BSLS_ASSERT_OPT(s_allocator_p);
+
+        bsl::shared_ptr<ntci::Driver> driver;
+        if (s_driverProvider) {
+            s_driverProvider(&driver, s_allocator_p);
+        }
+        
+        bsl::pair<ntci::Driver*, bslma::SharedPtrRep*> pair =
+            driver.release();
+
+        BSLS_ASSERT_OPT(!driver);
+
+        registerDriver(pair.first, pair.second);
+    }
+
+    BSLS_ASSERT_OPT(s_driver_p);
+    BSLS_ASSERT_OPT(s_driverRep_p);
+
+    s_driverRep_p->acquireRef();
+
+    *result = bsl::shared_ptr<ntci::Driver>(s_driver_p,
+                                              s_driverRep_p);
+    BSLS_ASSERT_OPT(*result);
+}
+
+void Global::getDefault(bsl::shared_ptr<ntci::Reactor>* result)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+
+    if (NTSCFG_UNLIKELY(s_reactor_p == 0)) {
+        BSLS_ASSERT_OPT(s_allocator_p);
+
+        bsl::shared_ptr<ntci::Reactor> reactor;
+        if (s_reactorProvider) {
+            s_reactorProvider(&reactor, s_allocator_p);
+        }
+        
+        bsl::pair<ntci::Reactor*, bslma::SharedPtrRep*> pair =
+            reactor.release();
+
+        BSLS_ASSERT_OPT(!reactor);
+
+        registerReactor(pair.first, pair.second);
+    }
+
+    BSLS_ASSERT_OPT(s_reactor_p);
+    BSLS_ASSERT_OPT(s_reactorRep_p);
+
+    s_reactorRep_p->acquireRef();
+
+    *result = bsl::shared_ptr<ntci::Reactor>(s_reactor_p,
+                                              s_reactorRep_p);
+    BSLS_ASSERT_OPT(*result);
+}
+
+void Global::getDefault(bsl::shared_ptr<ntci::Proactor>* result)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+
+    if (NTSCFG_UNLIKELY(s_proactor_p == 0)) {
+        BSLS_ASSERT_OPT(s_allocator_p);
+
+        bsl::shared_ptr<ntci::Proactor> proactor;
+        if (s_proactorProvider) {
+            s_proactorProvider(&proactor, s_allocator_p);
+        }
+        
+        bsl::pair<ntci::Proactor*, bslma::SharedPtrRep*> pair =
+            proactor.release();
+
+        BSLS_ASSERT_OPT(!proactor);
+
+        registerProactor(pair.first, pair.second);
+    }
+
+    BSLS_ASSERT_OPT(s_proactor_p);
+    BSLS_ASSERT_OPT(s_proactorRep_p);
+
+    s_proactorRep_p->acquireRef();
+
+    *result = bsl::shared_ptr<ntci::Proactor>(s_proactor_p,
+                                              s_proactorRep_p);
+    BSLS_ASSERT_OPT(*result);
+}
+
+void Global::getDefault(bsl::shared_ptr<ntci::Interface>* result)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+
+    if (NTSCFG_UNLIKELY(s_interface_p == 0)) {
+        BSLS_ASSERT_OPT(s_allocator_p);
+
+        bsl::shared_ptr<ntci::Interface> interface;
+        if (s_interfaceProvider) {
+            s_interfaceProvider(&interface, s_allocator_p);
+        }
+        
+        bsl::pair<ntci::Interface*, bslma::SharedPtrRep*> pair =
+            interface.release();
+
+        BSLS_ASSERT_OPT(!interface);
+
+        registerInterface(pair.first, pair.second);
+    }
+
+    BSLS_ASSERT_OPT(s_interface_p);
+    BSLS_ASSERT_OPT(s_interfaceRep_p);
+
+    s_interfaceRep_p->acquireRef();
+
+    *result = bsl::shared_ptr<ntci::Interface>(s_interface_p,
+                                               s_interfaceRep_p);
+    BSLS_ASSERT_OPT(*result);
+}
+
+void Global::getDefault(bsl::shared_ptr<ntci::Resolver>* result)
+{
+    Global::initialize();
+
+    LockGuard lock(s_mutex_p);
+
+    if (NTSCFG_UNLIKELY(s_resolver_p == 0)) {
+        BSLS_ASSERT_OPT(s_allocator_p);
+
+        bsl::shared_ptr<ntci::Resolver> resolver;
+        if (s_resolverProvider) {
+            s_resolverProvider(&resolver, s_allocator_p);
+        }
+        
+        bsl::pair<ntci::Resolver*, bslma::SharedPtrRep*> pair =
+            resolver.release();
+
+        BSLS_ASSERT_OPT(!resolver);
+
+        registerResolver(pair.first, pair.second);
+    }
+
+    BSLS_ASSERT_OPT(s_resolver_p);
+    BSLS_ASSERT_OPT(s_resolverRep_p);
+
+    s_resolverRep_p->acquireRef();
+
+    *result = bsl::shared_ptr<ntci::Resolver>(s_resolver_p,
+                                              s_resolverRep_p);
+    BSLS_ASSERT_OPT(*result);
+}
+
+void Global::exit()
+{
+    BSLMT_ONCE_DO
+    {
+        if (s_resolver_p != 0) {
+            deregisterResolver();
+        }
+
+        s_resolverProvider = 0;
+
+        if (s_interface_p != 0) {
+            deregisterInterface();
+        }
+
+        s_interfaceProvider = 0;
+
+        if (s_proactor_p != 0) {
+            deregisterProactor();
+        }
+
+        s_proactorProvider = 0;
+
+        if (s_reactor_p != 0) {
+            deregisterReactor();
+        }
+
+        s_reactorProvider = 0;
+
+        if (s_driver_p != 0) {
+            deregisterDriver();
+        }
+
+        s_driverProvider = 0;
+
+        if (s_strand_p != 0) {
+            deregisterStrand();
+        }
+
+        s_strandProvider = 0;
+
+        if (s_executor_p != 0) {
+            deregisterExecutor();
+        }
+
+        s_executorProvider = 0;
+
+        if (s_mutex_p != 0) {
+            BSLS_ASSERT_OPT(s_allocator_p);
+            s_allocator_p->deleteObject(s_mutex_p);
+            s_mutex_p = 0;
+        }
+
+        s_allocator_p = 0;
+
+        BSLS_ASSERT_OPT(s_allocator_p == 0);
+        BSLS_ASSERT_OPT(s_mutex_p == 0);
+        BSLS_ASSERT_OPT(s_executor_p == 0);
+        BSLS_ASSERT_OPT(s_executorRep_p == 0);
+        BSLS_ASSERT_OPT(s_strand_p == 0);
+        BSLS_ASSERT_OPT(s_strandRep_p == 0);
+        BSLS_ASSERT_OPT(s_driver_p == 0);
+        BSLS_ASSERT_OPT(s_driverRep_p == 0);
+        BSLS_ASSERT_OPT(s_reactor_p == 0);
+        BSLS_ASSERT_OPT(s_reactorRep_p == 0);
+        BSLS_ASSERT_OPT(s_proactor_p == 0);
+        BSLS_ASSERT_OPT(s_proactorRep_p == 0);
+        BSLS_ASSERT_OPT(s_interface_p == 0);
+        BSLS_ASSERT_OPT(s_interfaceRep_p == 0);
+        BSLS_ASSERT_OPT(s_resolver_p == 0);
+        BSLS_ASSERT_OPT(s_resolverRep_p == 0);
+    }
+}
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/groups/ntc/ntcs/ntcs_global.h
+++ b/groups/ntc/ntcs/ntcs_global.h
@@ -20,6 +20,12 @@
 BSLS_IDENT("$Id: $")
 
 #include <ntccfg_platform.h>
+#include <ntci_interface.h>
+#include <ntci_executor.h>
+#include <ntci_strand.h>
+#include <ntci_reactor.h>
+#include <ntci_proactor.h>
+#include <ntci_resolver.h>
 #include <ntcs_globalallocator.h>
 #include <ntcs_globalexecutor.h>
 #include <ntcscm_version.h>
@@ -36,11 +42,136 @@ namespace ntcs {
 ///
 /// @ingroup module_ntcs
 struct Global {
+    /// Define a type alias for a function that creates an executor suitable
+    /// for installing as the default executor.
+    typedef void (*ExecutorProvider)(
+        bsl::shared_ptr<ntci::Executor>* result, bslma::Allocator* allocator);
+
+    /// Define a type alias for a function that creates a strand suitable
+    /// for installing as the default strand.
+    typedef void (*StrandProvider)(
+        bsl::shared_ptr<ntci::Strand>* result, bslma::Allocator* allocator);
+
+    /// Define a type alias for a function that creates a driver suitable
+    /// for installing as the default driver.
+    typedef void (*DriverProvider)(
+        bsl::shared_ptr<ntci::Driver>* result, bslma::Allocator* allocator);
+
+    /// Define a type alias for a function that creates a reactor suitable
+    /// for installing as the default reactor.
+    typedef void (*ReactorProvider)(
+        bsl::shared_ptr<ntci::Reactor>* result, bslma::Allocator* allocator);
+
+    /// Define a type alias for a function that creates a proactor suitable
+    /// for installing as the default proactor.
+    typedef void (*ProactorProvider)(
+        bsl::shared_ptr<ntci::Proactor>* result, bslma::Allocator* allocator);
+
+    /// Define a type alias for a function that creates an interface suitable
+    /// for installing as the default interface.
+    typedef void (*InterfaceProvider)(
+        bsl::shared_ptr<ntci::Interface>* result, bslma::Allocator* allocator);
+
+    /// Define a type alias for a function that creates a resolver suitable
+    /// for installing as the default resolver.
+    typedef void (*ResolverProvider)(
+        bsl::shared_ptr<ntci::Resolver>* result, bslma::Allocator* allocator);    
+
+    /// Initialize global objects.
+    static void initialize();
+
+    /// Install the specified 'provider' as the function that creates an 
+    /// executor suitable for installing as the default executor.
+    static void setDefault(Global::ExecutorProvider provider);
+
+    /// Install the specified 'provider' as the function that creates a
+    /// strand suitable for installing as the default strand.
+    static void setDefault(Global::StrandProvider provider);
+
+    /// Install the specified 'provider' as the function that creates a
+    /// driver suitable for installing as the default driver.
+    static void setDefault(Global::DriverProvider provider);
+
+    /// Install the specified 'provider' as the function that creates a
+    /// reactor suitable for installing as the default reactor.
+    static void setDefault(Global::ReactorProvider provider);
+
+    /// Install the specified 'provider' as the function that creates a
+    /// reactor suitable for installing as the default reactor.
+    static void setDefault(Global::ProactorProvider provider);
+
+    /// Install the specified 'provider' as the function that creates an 
+    /// interface suitable for installing as the default interface.
+    static void setDefault(Global::InterfaceProvider provider);
+
+    /// Install the specified 'provider' as the function that creates a
+    /// resolver suitable for installing as the default resolver.
+    static void setDefault(Global::ResolverProvider provider);
+
+    // Install the specified 'executor' as the default executor.
+    static void setDefault(const bsl::shared_ptr<ntci::Executor>& executor);
+
+    // Install the specified 'strand' as the default strand.
+    static void setDefault(const bsl::shared_ptr<ntci::Strand>& strand);
+
+    // Install the specified 'driver' as the default driver.
+    static void setDefault(const bsl::shared_ptr<ntci::Driver>& driver);
+
+    // Install the specified 'reactor' as the default reactor.
+    static void setDefault(const bsl::shared_ptr<ntci::Reactor>& reactor);
+
+    // Install the specified 'proactor' as the default proactor.
+    static void setDefault(const bsl::shared_ptr<ntci::Proactor>& proactor);
+
+    // Install the specified 'interface' as the default interface.
+    static void setDefault(const bsl::shared_ptr<ntci::Interface>& interface);
+
+    // Install the specified 'resolver' as the default resolver.
+    static void setDefault(const bsl::shared_ptr<ntci::Resolver>& resolver);
+
+    // Load into the specified 'result' the default executor. If no default
+    // executor is explicitly installed, automatically create install a default
+    // executor with a default configuration.
+    static void getDefault(bsl::shared_ptr<ntci::Executor>* result);
+
+    // Load into the specified 'result' the default strand. If no default
+    // strand is explicitly installed, automatically create install a default
+    // strand with a default configuration.
+    static void getDefault(bsl::shared_ptr<ntci::Strand>* result);
+
+    // Load into the specified 'result' the default driver. If no default
+    // driver is explicitly installed, automatically create install a default
+    // driver with a default configuration.
+    static void getDefault(bsl::shared_ptr<ntci::Driver>* result);
+
+    // Load into the specified 'result' the default reactor. If no default
+    // reactor is explicitly installed, automatically create install a default
+    // reactor with a default configuration.
+    static void getDefault(bsl::shared_ptr<ntci::Reactor>* result);
+
+    // Load into the specified 'result' the default proactor. If no default
+    // proactor is explicitly installed, automatically create install a default
+    // proactor with a default configuration.
+    static void getDefault(bsl::shared_ptr<ntci::Proactor>* result);
+
+    // Load into the specified 'result' the default interface. If no default
+    // interface is explicitly installed, automatically create install a default
+    // interface with a default configuration.
+    static void getDefault(bsl::shared_ptr<ntci::Interface>* result);
+
+    // Load into the specified 'result' the default resolver. If no default
+    // resolver is explicitly installed, automatically create install a default
+    // resolver with a default configuration.
+    static void getDefault(bsl::shared_ptr<ntci::Resolver>* result);
+
     /// Return the global allocator.
     static bslma::Allocator* allocator();
 
     /// Return the global executor.
     static bsl::shared_ptr<ntci::Executor> executor();
+
+    // Stop and destroy all global objects.
+    static void exit();
 };
 
 NTCCFG_INLINE


### PR DESCRIPTION
This PR adds support for the notion of default, globally-accessible NTC mechanisms, such as `ntci::Interface` and `ntci::Resolver`.