### PR TITLE
Increase ntcs::Event::d_address size to >= _SS_MAXSIZE on all supported Unix platforms, by platform

### DIFF
--- a/groups/ntc/ntcs/ntcs_event.h
+++ b/groups/ntc/ntcs/ntcs_event.h
@@ -265,7 +265,15 @@ class Event
 #if defined(BSLS_PLATFORM_OS_UNIX)
 
     char                                  d_message[64];
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
+    char                                  d_address[192];
+#elif defined(BSLS_PLATFORM_OS_SOLARIS)
     char                                  d_address[256];
+#elif defined(BSLS_PLATFORM_OS_AIX)
+    char                                  d_address[2048];
+#else
+#error Not implemented
+#endif
     char                                  d_control[256];
     char                                  d_buffers[1024 * 16];
 


### PR DESCRIPTION
Set the `sizeof(ntcs::Event::d_address)` to something greater than or equal to `sizeof(struct sockaddr_storage)` on each platform.