### PR TITLE
Implement all less-than comparator operators in terms of only less-then comparator operators

### DIFF
--- a/groups/ntc/ntca/ntca_acceptevent.cpp
+++ b/groups/ntc/ntca/ntca_acceptevent.cpp
@@ -34,7 +34,7 @@ bool AcceptEvent::less(const AcceptEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_acceptoptions.cpp
+++ b/groups/ntc/ntca/ntca_acceptoptions.cpp
@@ -43,7 +43,7 @@ bool AcceptOptions::less(const AcceptOptions& other) const
         return true;
     }
 
-    if (d_deadline > other.d_deadline) {
+    if (other.d_deadline < d_deadline) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_acceptqueuecontext.cpp
+++ b/groups/ntc/ntca/ntca_acceptqueuecontext.cpp
@@ -35,7 +35,7 @@ bool AcceptQueueContext::less(const AcceptQueueContext& other) const
         return true;
     }
 
-    if (d_size > other.d_size) {
+    if (other.d_size < d_size) {
         return false;
     }
 
@@ -43,7 +43,7 @@ bool AcceptQueueContext::less(const AcceptQueueContext& other) const
         return true;
     }
 
-    if (d_lowWatermark > other.d_lowWatermark) {
+    if (other.d_lowWatermark < d_lowWatermark) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_acceptqueueevent.cpp
+++ b/groups/ntc/ntca/ntca_acceptqueueevent.cpp
@@ -34,7 +34,7 @@ bool AcceptQueueEvent::less(const AcceptQueueEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_bindcontext.cpp
+++ b/groups/ntc/ntca/ntca_bindcontext.cpp
@@ -52,7 +52,7 @@ bool BindContext::less(const BindContext& other) const
         return true;
     }
 
-    if (d_latency > other.d_latency) {
+    if (other.d_latency < d_latency) {
         return false;
     }
 
@@ -60,7 +60,7 @@ bool BindContext::less(const BindContext& other) const
         return true;
     }
 
-    if (d_source > other.d_source) {
+    if (other.d_source < d_source) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_bindevent.cpp
+++ b/groups/ntc/ntca/ntca_bindevent.cpp
@@ -34,7 +34,7 @@ bool BindEvent::less(const BindEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_bindoptions.cpp
+++ b/groups/ntc/ntca/ntca_bindoptions.cpp
@@ -49,7 +49,7 @@ bool BindOptions::less(const BindOptions& other) const
         return true;
     }
 
-    if (d_ipAddressFallback > other.d_ipAddressFallback) {
+    if (other.d_ipAddressFallback < d_ipAddressFallback) {
         return false;
     }
 
@@ -57,7 +57,7 @@ bool BindOptions::less(const BindOptions& other) const
         return true;
     }
 
-    if (d_ipAddressType > other.d_ipAddressType) {
+    if (other.d_ipAddressType < d_ipAddressType) {
         return false;
     }
 
@@ -65,7 +65,7 @@ bool BindOptions::less(const BindOptions& other) const
         return true;
     }
 
-    if (d_ipAddressSelector > other.d_ipAddressSelector) {
+    if (other.d_ipAddressSelector < d_ipAddressSelector) {
         return false;
     }
 
@@ -73,7 +73,7 @@ bool BindOptions::less(const BindOptions& other) const
         return true;
     }
 
-    if (d_portFallback > other.d_portFallback) {
+    if (other.d_portFallback < d_portFallback) {
         return false;
     }
 
@@ -81,7 +81,7 @@ bool BindOptions::less(const BindOptions& other) const
         return true;
     }
 
-    if (d_portSelector > other.d_portSelector) {
+    if (other.d_portSelector < d_portSelector) {
         return false;
     }
 
@@ -89,7 +89,7 @@ bool BindOptions::less(const BindOptions& other) const
         return true;
     }
 
-    if (d_transport > other.d_transport) {
+    if (other.d_transport < d_transport) {
         return false;
     }
 
@@ -97,7 +97,7 @@ bool BindOptions::less(const BindOptions& other) const
         return true;
     }
 
-    if (d_deadline > other.d_deadline) {
+    if (other.d_deadline < d_deadline) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_connectcontext.cpp
+++ b/groups/ntc/ntca/ntca_connectcontext.cpp
@@ -54,7 +54,7 @@ bool ConnectContext::less(const ConnectContext& other) const
         return true;
     }
 
-    if (d_latency > other.d_latency) {
+    if (other.d_latency < d_latency) {
         return false;
     }
 
@@ -62,7 +62,7 @@ bool ConnectContext::less(const ConnectContext& other) const
         return true;
     }
 
-    if (d_source > other.d_source) {
+    if (other.d_source < d_source) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_connectevent.cpp
+++ b/groups/ntc/ntca/ntca_connectevent.cpp
@@ -34,7 +34,7 @@ bool ConnectEvent::less(const ConnectEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_connectoptions.cpp
+++ b/groups/ntc/ntca/ntca_connectoptions.cpp
@@ -66,7 +66,7 @@ bool ConnectOptions::less(const ConnectOptions& other) const
         return true;
     }
 
-    if (d_ipAddressFallback > other.d_ipAddressFallback) {
+    if (other.d_ipAddressFallback < d_ipAddressFallback) {
         return false;
     }
 
@@ -74,7 +74,7 @@ bool ConnectOptions::less(const ConnectOptions& other) const
         return true;
     }
 
-    if (d_ipAddressType > other.d_ipAddressType) {
+    if (other.d_ipAddressType < d_ipAddressType) {
         return false;
     }
 
@@ -82,7 +82,7 @@ bool ConnectOptions::less(const ConnectOptions& other) const
         return true;
     }
 
-    if (d_ipAddressSelector > other.d_ipAddressSelector) {
+    if (other.d_ipAddressSelector < d_ipAddressSelector) {
         return false;
     }
 
@@ -90,7 +90,7 @@ bool ConnectOptions::less(const ConnectOptions& other) const
         return true;
     }
 
-    if (d_portFallback > other.d_portFallback) {
+    if (other.d_portFallback < d_portFallback) {
         return false;
     }
 
@@ -98,7 +98,7 @@ bool ConnectOptions::less(const ConnectOptions& other) const
         return true;
     }
 
-    if (d_portSelector > other.d_portSelector) {
+    if (other.d_portSelector < d_portSelector) {
         return false;
     }
 
@@ -110,7 +110,7 @@ bool ConnectOptions::less(const ConnectOptions& other) const
         return true;
     }
 
-    if (d_deadline > other.d_deadline) {
+    if (other.d_deadline < d_deadline) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_downgradecontext.cpp
+++ b/groups/ntc/ntca/ntca_downgradecontext.cpp
@@ -36,7 +36,7 @@ bool DowngradeContext::less(const DowngradeContext& other) const
         return true;
     }
 
-    if (d_send > other.d_send) {
+    if (other.d_send < d_send) {
         return false;
     }
 
@@ -44,7 +44,7 @@ bool DowngradeContext::less(const DowngradeContext& other) const
         return true;
     }
 
-    if (d_receive > other.d_receive) {
+    if (other.d_receive < d_receive) {
         return false;
     }
 
@@ -52,7 +52,7 @@ bool DowngradeContext::less(const DowngradeContext& other) const
         return true;
     }
 
-    if (d_error > other.d_error) {
+    if (other.d_error < d_error) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_downgradeevent.cpp
+++ b/groups/ntc/ntca/ntca_downgradeevent.cpp
@@ -34,7 +34,7 @@ bool DowngradeEvent::less(const DowngradeEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_driverconfig.cpp
+++ b/groups/ntc/ntca/ntca_driverconfig.cpp
@@ -234,7 +234,7 @@ bool DriverConfig::less(const DriverConfig& other) const
         return true;
     }
 
-    if (d_driverName > other.d_driverName) {
+    if (other.d_driverName < d_driverName) {
         return false;
     }
 
@@ -242,7 +242,7 @@ bool DriverConfig::less(const DriverConfig& other) const
         return true;
     }
 
-    if (d_metricName > other.d_metricName) {
+    if (other.d_metricName < d_metricName) {
         return false;
     }
 
@@ -250,7 +250,7 @@ bool DriverConfig::less(const DriverConfig& other) const
         return true;
     }
 
-    if (d_minThreads > other.d_minThreads) {
+    if (other.d_minThreads < d_minThreads) {
         return false;
     }
 
@@ -258,7 +258,7 @@ bool DriverConfig::less(const DriverConfig& other) const
         return true;
     }
 
-    if (d_maxThreads > other.d_maxThreads) {
+    if (other.d_maxThreads < d_maxThreads) {
         return false;
     }
 
@@ -266,7 +266,7 @@ bool DriverConfig::less(const DriverConfig& other) const
         return true;
     }
 
-    if (d_maxEventsPerWait > other.d_maxEventsPerWait) {
+    if (other.d_maxEventsPerWait < d_maxEventsPerWait) {
         return false;
     }
 
@@ -274,7 +274,7 @@ bool DriverConfig::less(const DriverConfig& other) const
         return true;
     }
 
-    if (d_maxTimersPerWait > other.d_maxTimersPerWait) {
+    if (other.d_maxTimersPerWait < d_maxTimersPerWait) {
         return false;
     }
 
@@ -282,7 +282,7 @@ bool DriverConfig::less(const DriverConfig& other) const
         return true;
     }
 
-    if (d_maxCyclesPerWait > other.d_maxCyclesPerWait) {
+    if (other.d_maxCyclesPerWait < d_maxCyclesPerWait) {
         return false;
     }
 
@@ -290,7 +290,7 @@ bool DriverConfig::less(const DriverConfig& other) const
         return true;
     }
 
-    if (d_metricCollection > other.d_metricCollection) {
+    if (other.d_metricCollection < d_metricCollection) {
         return false;
     }
 
@@ -298,7 +298,7 @@ bool DriverConfig::less(const DriverConfig& other) const
         return true;
     }
 
-    if (d_metricCollectionPerWaiter > other.d_metricCollectionPerWaiter) {
+    if (other.d_metricCollectionPerWaiter < d_metricCollectionPerWaiter) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_errorcontext.cpp
+++ b/groups/ntc/ntca/ntca_errorcontext.cpp
@@ -35,7 +35,7 @@ bool ErrorContext::less(const ErrorContext& other) const
         return true;
     }
 
-    if (d_error > other.d_error) {
+    if (other.d_error < d_error) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_errorevent.cpp
+++ b/groups/ntc/ntca/ntca_errorevent.cpp
@@ -34,7 +34,7 @@ bool ErrorEvent::less(const ErrorEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_getdomainnamecontext.cpp
+++ b/groups/ntc/ntca/ntca_getdomainnamecontext.cpp
@@ -44,7 +44,7 @@ bool GetDomainNameContext::less(const GetDomainNameContext& other) const
         return true;
     }
 
-    if (d_latency > other.d_latency) {
+    if (other.d_latency < d_latency) {
         return false;
     }
 
@@ -52,7 +52,7 @@ bool GetDomainNameContext::less(const GetDomainNameContext& other) const
         return true;
     }
 
-    if (d_source > other.d_source) {
+    if (other.d_source < d_source) {
         return false;
     }
 
@@ -68,7 +68,7 @@ bool GetDomainNameContext::less(const GetDomainNameContext& other) const
         return true;
     }
 
-    if (d_timeToLive > other.d_timeToLive) {
+    if (other.d_timeToLive < d_timeToLive) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_getdomainnameevent.cpp
+++ b/groups/ntc/ntca/ntca_getdomainnameevent.cpp
@@ -34,7 +34,7 @@ bool GetDomainNameEvent::less(const GetDomainNameEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_getendpointcontext.cpp
+++ b/groups/ntc/ntca/ntca_getendpointcontext.cpp
@@ -36,7 +36,7 @@ bool GetEndpointContext::less(const GetEndpointContext& other) const
         return true;
     }
 
-    if (d_authority > other.d_authority) {
+    if (other.d_authority < d_authority) {
         return false;
     }
 
@@ -44,7 +44,7 @@ bool GetEndpointContext::less(const GetEndpointContext& other) const
         return true;
     }
 
-    if (d_latency > other.d_latency) {
+    if (other.d_latency < d_latency) {
         return false;
     }
 
@@ -52,7 +52,7 @@ bool GetEndpointContext::less(const GetEndpointContext& other) const
         return true;
     }
 
-    if (d_source > other.d_source) {
+    if (other.d_source < d_source) {
         return false;
     }
 
@@ -68,7 +68,7 @@ bool GetEndpointContext::less(const GetEndpointContext& other) const
         return true;
     }
 
-    if (d_timeToLive > other.d_timeToLive) {
+    if (other.d_timeToLive < d_timeToLive) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_getendpointevent.cpp
+++ b/groups/ntc/ntca/ntca_getendpointevent.cpp
@@ -34,7 +34,7 @@ bool GetEndpointEvent::less(const GetEndpointEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_getendpointoptions.cpp
+++ b/groups/ntc/ntca/ntca_getendpointoptions.cpp
@@ -40,7 +40,7 @@ bool GetEndpointOptions::less(const GetEndpointOptions& other) const
         return true;
     }
 
-    if (d_ipAddressFallback > other.d_ipAddressFallback) {
+    if (other.d_ipAddressFallback < d_ipAddressFallback) {
         return false;
     }
 
@@ -48,7 +48,7 @@ bool GetEndpointOptions::less(const GetEndpointOptions& other) const
         return true;
     }
 
-    if (d_ipAddressType > other.d_ipAddressType) {
+    if (other.d_ipAddressType < d_ipAddressType) {
         return false;
     }
 
@@ -56,7 +56,7 @@ bool GetEndpointOptions::less(const GetEndpointOptions& other) const
         return true;
     }
 
-    if (d_ipAddressSelector > other.d_ipAddressSelector) {
+    if (other.d_ipAddressSelector < d_ipAddressSelector) {
         return false;
     }
 
@@ -64,7 +64,7 @@ bool GetEndpointOptions::less(const GetEndpointOptions& other) const
         return true;
     }
 
-    if (d_portFallback > other.d_portFallback) {
+    if (other.d_portFallback < d_portFallback) {
         return false;
     }
 
@@ -72,7 +72,7 @@ bool GetEndpointOptions::less(const GetEndpointOptions& other) const
         return true;
     }
 
-    if (d_portSelector > other.d_portSelector) {
+    if (other.d_portSelector < d_portSelector) {
         return false;
     }
 
@@ -80,7 +80,7 @@ bool GetEndpointOptions::less(const GetEndpointOptions& other) const
         return true;
     }
 
-    if (d_transport > other.d_transport) {
+    if (other.d_transport < d_transport) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_getipaddresscontext.cpp
+++ b/groups/ntc/ntca/ntca_getipaddresscontext.cpp
@@ -37,7 +37,7 @@ bool GetIpAddressContext::less(const GetIpAddressContext& other) const
         return true;
     }
 
-    if (d_domainName > other.d_domainName) {
+    if (other.d_domainName < d_domainName) {
         return false;
     }
 
@@ -45,7 +45,7 @@ bool GetIpAddressContext::less(const GetIpAddressContext& other) const
         return true;
     }
 
-    if (d_latency > other.d_latency) {
+    if (other.d_latency < d_latency) {
         return false;
     }
 
@@ -53,7 +53,7 @@ bool GetIpAddressContext::less(const GetIpAddressContext& other) const
         return true;
     }
 
-    if (d_source > other.d_source) {
+    if (other.d_source < d_source) {
         return false;
     }
 
@@ -69,7 +69,7 @@ bool GetIpAddressContext::less(const GetIpAddressContext& other) const
         return true;
     }
 
-    if (d_timeToLive > other.d_timeToLive) {
+    if (other.d_timeToLive < d_timeToLive) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_getipaddressevent.cpp
+++ b/groups/ntc/ntca/ntca_getipaddressevent.cpp
@@ -34,7 +34,7 @@ bool GetIpAddressEvent::less(const GetIpAddressEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_getipaddressoptions.cpp
+++ b/groups/ntc/ntca/ntca_getipaddressoptions.cpp
@@ -38,7 +38,7 @@ bool GetIpAddressOptions::less(const GetIpAddressOptions& other) const
         return true;
     }
 
-    if (d_ipAddressFallback > other.d_ipAddressFallback) {
+    if (other.d_ipAddressFallback < d_ipAddressFallback) {
         return false;
     }
 
@@ -46,7 +46,7 @@ bool GetIpAddressOptions::less(const GetIpAddressOptions& other) const
         return true;
     }
 
-    if (d_ipAddressType > other.d_ipAddressType) {
+    if (other.d_ipAddressType < d_ipAddressType) {
         return false;
     }
 
@@ -54,7 +54,7 @@ bool GetIpAddressOptions::less(const GetIpAddressOptions& other) const
         return true;
     }
 
-    if (d_ipAddressSelector > other.d_ipAddressSelector) {
+    if (other.d_ipAddressSelector < d_ipAddressSelector) {
         return false;
     }
 
@@ -62,7 +62,7 @@ bool GetIpAddressOptions::less(const GetIpAddressOptions& other) const
         return true;
     }
 
-    if (d_transport > other.d_transport) {
+    if (other.d_transport < d_transport) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_getportcontext.cpp
+++ b/groups/ntc/ntca/ntca_getportcontext.cpp
@@ -37,7 +37,7 @@ bool GetPortContext::less(const GetPortContext& other) const
         return true;
     }
 
-    if (d_serviceName > other.d_serviceName) {
+    if (other.d_serviceName < d_serviceName) {
         return false;
     }
 
@@ -45,7 +45,7 @@ bool GetPortContext::less(const GetPortContext& other) const
         return true;
     }
 
-    if (d_latency > other.d_latency) {
+    if (other.d_latency < d_latency) {
         return false;
     }
 
@@ -53,7 +53,7 @@ bool GetPortContext::less(const GetPortContext& other) const
         return true;
     }
 
-    if (d_source > other.d_source) {
+    if (other.d_source < d_source) {
         return false;
     }
 
@@ -69,7 +69,7 @@ bool GetPortContext::less(const GetPortContext& other) const
         return true;
     }
 
-    if (d_timeToLive > other.d_timeToLive) {
+    if (other.d_timeToLive < d_timeToLive) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_getportevent.cpp
+++ b/groups/ntc/ntca/ntca_getportevent.cpp
@@ -34,7 +34,7 @@ bool GetPortEvent::less(const GetPortEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_getportoptions.cpp
+++ b/groups/ntc/ntca/ntca_getportoptions.cpp
@@ -37,7 +37,7 @@ bool GetPortOptions::less(const GetPortOptions& other) const
         return true;
     }
 
-    if (d_portFallback > other.d_portFallback) {
+    if (other.d_portFallback < d_portFallback) {
         return false;
     }
 
@@ -45,7 +45,7 @@ bool GetPortOptions::less(const GetPortOptions& other) const
         return true;
     }
 
-    if (d_portSelector > other.d_portSelector) {
+    if (other.d_portSelector < d_portSelector) {
         return false;
     }
 
@@ -53,7 +53,7 @@ bool GetPortOptions::less(const GetPortOptions& other) const
         return true;
     }
 
-    if (d_transport > other.d_transport) {
+    if (other.d_transport < d_transport) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_getservicenamecontext.cpp
+++ b/groups/ntc/ntca/ntca_getservicenamecontext.cpp
@@ -44,7 +44,7 @@ bool GetServiceNameContext::less(const GetServiceNameContext& other) const
         return true;
     }
 
-    if (d_latency > other.d_latency) {
+    if (other.d_latency < d_latency) {
         return false;
     }
 
@@ -52,7 +52,7 @@ bool GetServiceNameContext::less(const GetServiceNameContext& other) const
         return true;
     }
 
-    if (d_source > other.d_source) {
+    if (other.d_source < d_source) {
         return false;
     }
 
@@ -68,7 +68,7 @@ bool GetServiceNameContext::less(const GetServiceNameContext& other) const
         return true;
     }
 
-    if (d_timeToLive > other.d_timeToLive) {
+    if (other.d_timeToLive < d_timeToLive) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_getservicenameevent.cpp
+++ b/groups/ntc/ntca/ntca_getservicenameevent.cpp
@@ -34,7 +34,7 @@ bool GetServiceNameEvent::less(const GetServiceNameEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_getservicenameoptions.cpp
+++ b/groups/ntc/ntca/ntca_getservicenameoptions.cpp
@@ -35,7 +35,7 @@ bool GetServiceNameOptions::less(const GetServiceNameOptions& other) const
         return true;
     }
 
-    if (d_transport > other.d_transport) {
+    if (other.d_transport < d_transport) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_proactorconfig.cpp
+++ b/groups/ntc/ntca/ntca_proactorconfig.cpp
@@ -237,7 +237,7 @@ bool ProactorConfig::less(const ProactorConfig& other) const
         return true;
     }
 
-    if (d_driverName > other.d_driverName) {
+    if (other.d_driverName < d_driverName) {
         return false;
     }
 
@@ -245,7 +245,7 @@ bool ProactorConfig::less(const ProactorConfig& other) const
         return true;
     }
 
-    if (d_metricName > other.d_metricName) {
+    if (other.d_metricName < d_metricName) {
         return false;
     }
 
@@ -253,7 +253,7 @@ bool ProactorConfig::less(const ProactorConfig& other) const
         return true;
     }
 
-    if (d_minThreads > other.d_minThreads) {
+    if (other.d_minThreads < d_minThreads) {
         return false;
     }
 
@@ -261,7 +261,7 @@ bool ProactorConfig::less(const ProactorConfig& other) const
         return true;
     }
 
-    if (d_maxEventsPerWait > other.d_maxEventsPerWait) {
+    if (other.d_maxEventsPerWait < d_maxEventsPerWait) {
         return false;
     }
 
@@ -269,7 +269,7 @@ bool ProactorConfig::less(const ProactorConfig& other) const
         return true;
     }
 
-    if (d_maxTimersPerWait > other.d_maxTimersPerWait) {
+    if (other.d_maxTimersPerWait < d_maxTimersPerWait) {
         return false;
     }
 
@@ -277,7 +277,7 @@ bool ProactorConfig::less(const ProactorConfig& other) const
         return true;
     }
 
-    if (d_maxCyclesPerWait > other.d_maxCyclesPerWait) {
+    if (other.d_maxCyclesPerWait < d_maxCyclesPerWait) {
         return false;
     }
 
@@ -285,7 +285,7 @@ bool ProactorConfig::less(const ProactorConfig& other) const
         return true;
     }
 
-    if (d_metricCollection > other.d_metricCollection) {
+    if (other.d_metricCollection < d_metricCollection) {
         return false;
     }
 
@@ -293,7 +293,7 @@ bool ProactorConfig::less(const ProactorConfig& other) const
         return true;
     }
 
-    if (d_metricCollectionPerWaiter > other.d_metricCollectionPerWaiter) {
+    if (other.d_metricCollectionPerWaiter < d_metricCollectionPerWaiter) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_ratelimiterconfig.cpp
+++ b/groups/ntc/ntca/ntca_ratelimiterconfig.cpp
@@ -137,7 +137,7 @@ bool RateLimiterConfig::less(const RateLimiterConfig& other) const
         return true;
     }
 
-    if (d_sustainedRateLimit > other.d_sustainedRateLimit) {
+    if (other.d_sustainedRateLimit < d_sustainedRateLimit) {
         return false;
     }
 
@@ -145,7 +145,7 @@ bool RateLimiterConfig::less(const RateLimiterConfig& other) const
         return true;
     }
 
-    if (d_sustainedRateWindow > other.d_sustainedRateWindow) {
+    if (other.d_sustainedRateWindow < d_sustainedRateWindow) {
         return false;
     }
 
@@ -153,7 +153,7 @@ bool RateLimiterConfig::less(const RateLimiterConfig& other) const
         return true;
     }
 
-    if (d_peakRateLimit > other.d_peakRateLimit) {
+    if (other.d_peakRateLimit < d_peakRateLimit) {
         return false;
     }
 
@@ -161,7 +161,7 @@ bool RateLimiterConfig::less(const RateLimiterConfig& other) const
         return true;
     }
 
-    if (d_peakRateWindow > other.d_peakRateWindow) {
+    if (other.d_peakRateWindow < d_peakRateWindow) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_reactorconfig.cpp
+++ b/groups/ntc/ntca/ntca_reactorconfig.cpp
@@ -294,7 +294,7 @@ bool ReactorConfig::less(const ReactorConfig& other) const
         return true;
     }
 
-    if (d_driverName > other.d_driverName) {
+    if (other.d_driverName < d_driverName) {
         return false;
     }
 
@@ -302,7 +302,7 @@ bool ReactorConfig::less(const ReactorConfig& other) const
         return true;
     }
 
-    if (d_metricName > other.d_metricName) {
+    if (other.d_metricName < d_metricName) {
         return false;
     }
 
@@ -310,7 +310,7 @@ bool ReactorConfig::less(const ReactorConfig& other) const
         return true;
     }
 
-    if (d_minThreads > other.d_minThreads) {
+    if (other.d_minThreads < d_minThreads) {
         return false;
     }
 
@@ -318,7 +318,7 @@ bool ReactorConfig::less(const ReactorConfig& other) const
         return true;
     }
 
-    if (d_maxThreads > other.d_maxThreads) {
+    if (other.d_maxThreads < d_maxThreads) {
         return false;
     }
 
@@ -326,7 +326,7 @@ bool ReactorConfig::less(const ReactorConfig& other) const
         return true;
     }
 
-    if (d_maxEventsPerWait > other.d_maxEventsPerWait) {
+    if (other.d_maxEventsPerWait < d_maxEventsPerWait) {
         return false;
     }
 
@@ -334,7 +334,7 @@ bool ReactorConfig::less(const ReactorConfig& other) const
         return true;
     }
 
-    if (d_maxTimersPerWait > other.d_maxTimersPerWait) {
+    if (other.d_maxTimersPerWait < d_maxTimersPerWait) {
         return false;
     }
 
@@ -342,7 +342,7 @@ bool ReactorConfig::less(const ReactorConfig& other) const
         return true;
     }
 
-    if (d_maxCyclesPerWait > other.d_maxCyclesPerWait) {
+    if (other.d_maxCyclesPerWait < d_maxCyclesPerWait) {
         return false;
     }
 
@@ -350,7 +350,7 @@ bool ReactorConfig::less(const ReactorConfig& other) const
         return true;
     }
 
-    if (d_metricCollection > other.d_metricCollection) {
+    if (other.d_metricCollection < d_metricCollection) {
         return false;
     }
 
@@ -358,7 +358,7 @@ bool ReactorConfig::less(const ReactorConfig& other) const
         return true;
     }
 
-    if (d_metricCollectionPerWaiter > other.d_metricCollectionPerWaiter) {
+    if (other.d_metricCollectionPerWaiter < d_metricCollectionPerWaiter) {
         return false;
     }
 
@@ -366,7 +366,7 @@ bool ReactorConfig::less(const ReactorConfig& other) const
         return true;
     }
 
-    if (d_metricCollectionPerSocket > other.d_metricCollectionPerSocket) {
+    if (other.d_metricCollectionPerSocket < d_metricCollectionPerSocket) {
         return false;
     }
 
@@ -374,7 +374,7 @@ bool ReactorConfig::less(const ReactorConfig& other) const
         return true;
     }
 
-    if (d_autoAttach > other.d_autoAttach) {
+    if (other.d_autoAttach < d_autoAttach) {
         return false;
     }
 
@@ -382,7 +382,7 @@ bool ReactorConfig::less(const ReactorConfig& other) const
         return true;
     }
 
-    if (d_autoDetach > other.d_autoDetach) {
+    if (other.d_autoDetach < d_autoDetach) {
         return false;
     }
 
@@ -390,7 +390,7 @@ bool ReactorConfig::less(const ReactorConfig& other) const
         return true;
     }
 
-    if (d_trigger > other.d_trigger) {
+    if (other.d_trigger < d_trigger) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_reactorevent.cpp
+++ b/groups/ntc/ntca/ntca_reactorevent.cpp
@@ -35,7 +35,7 @@ bool ReactorEvent::less(const ReactorEvent& other) const
         return true;
     }
 
-    if (d_handle > other.d_handle) {
+    if (other.d_handle < d_handle) {
         return false;
     }
 
@@ -43,7 +43,7 @@ bool ReactorEvent::less(const ReactorEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_reactoreventoptions.cpp
+++ b/groups/ntc/ntca/ntca_reactoreventoptions.cpp
@@ -34,7 +34,7 @@ bool ReactorEventOptions::less(const ReactorEventOptions& other) const
         return true;
     }
 
-    if (d_trigger > other.d_trigger) {
+    if (other.d_trigger < d_trigger) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_readqueuecontext.cpp
+++ b/groups/ntc/ntca/ntca_readqueuecontext.cpp
@@ -35,7 +35,7 @@ bool ReadQueueContext::less(const ReadQueueContext& other) const
         return true;
     }
 
-    if (d_size > other.d_size) {
+    if (other.d_size < d_size) {
         return false;
     }
 
@@ -43,7 +43,7 @@ bool ReadQueueContext::less(const ReadQueueContext& other) const
         return true;
     }
 
-    if (d_lowWatermark > other.d_lowWatermark) {
+    if (other.d_lowWatermark < d_lowWatermark) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_readqueueevent.cpp
+++ b/groups/ntc/ntca/ntca_readqueueevent.cpp
@@ -34,7 +34,7 @@ bool ReadQueueEvent::less(const ReadQueueEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_receiveevent.cpp
+++ b/groups/ntc/ntca/ntca_receiveevent.cpp
@@ -34,7 +34,7 @@ bool ReceiveEvent::less(const ReceiveEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_receiveoptions.cpp
+++ b/groups/ntc/ntca/ntca_receiveoptions.cpp
@@ -44,7 +44,7 @@ bool ReceiveOptions::less(const ReceiveOptions& other) const
         return true;
     }
 
-    if (d_minSize > other.d_minSize) {
+    if (other.d_minSize < d_minSize) {
         return false;
     }
 
@@ -52,7 +52,7 @@ bool ReceiveOptions::less(const ReceiveOptions& other) const
         return true;
     }
 
-    if (d_maxSize > other.d_maxSize) {
+    if (other.d_maxSize < d_maxSize) {
         return false;
     }
 
@@ -60,7 +60,7 @@ bool ReceiveOptions::less(const ReceiveOptions& other) const
         return true;
     }
 
-    if (d_deadline > other.d_deadline) {
+    if (other.d_deadline < d_deadline) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_sendevent.cpp
+++ b/groups/ntc/ntca/ntca_sendevent.cpp
@@ -34,7 +34,7 @@ bool SendEvent::less(const SendEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_sendoptions.cpp
+++ b/groups/ntc/ntca/ntca_sendoptions.cpp
@@ -53,7 +53,7 @@ bool SendOptions::less(const SendOptions& other) const
         return true;
     }
 
-    if (d_priority > other.d_priority) {
+    if (other.d_priority < d_priority) {
         return false;
     }
 
@@ -61,7 +61,7 @@ bool SendOptions::less(const SendOptions& other) const
         return true;
     }
 
-    if (d_highWatermark > other.d_highWatermark) {
+    if (other.d_highWatermark < d_highWatermark) {
         return false;
     }
 
@@ -69,7 +69,7 @@ bool SendOptions::less(const SendOptions& other) const
         return true;
     }
 
-    if (d_deadline > other.d_deadline) {
+    if (other.d_deadline < d_deadline) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_shutdowncontext.cpp
+++ b/groups/ntc/ntca/ntca_shutdowncontext.cpp
@@ -35,7 +35,7 @@ bool ShutdownContext::less(const ShutdownContext& other) const
         return true;
     }
 
-    if (d_origin > other.d_origin) {
+    if (other.d_origin < d_origin) {
         return false;
     }
 
@@ -43,7 +43,7 @@ bool ShutdownContext::less(const ShutdownContext& other) const
         return true;
     }
 
-    if (d_send > other.d_send) {
+    if (other.d_send < d_send) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_shutdownevent.cpp
+++ b/groups/ntc/ntca/ntca_shutdownevent.cpp
@@ -34,7 +34,7 @@ bool ShutdownEvent::less(const ShutdownEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_timerevent.cpp
+++ b/groups/ntc/ntca/ntca_timerevent.cpp
@@ -34,7 +34,7 @@ bool TimerEvent::less(const TimerEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_timeroptions.cpp
+++ b/groups/ntc/ntca/ntca_timeroptions.cpp
@@ -47,7 +47,7 @@ bool TimerOptions::less(const TimerOptions& other) const
         return true;
     }
 
-    if (d_id > other.d_id) {
+    if (other.d_id < d_id) {
         return false;
     }
 
@@ -55,7 +55,7 @@ bool TimerOptions::less(const TimerOptions& other) const
         return true;
     }
 
-    if (d_flags > other.d_flags) {
+    if (other.d_flags < d_flags) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_upgradecontext.cpp
+++ b/groups/ntc/ntca/ntca_upgradecontext.cpp
@@ -35,7 +35,7 @@ bool UpgradeContext::less(const UpgradeContext& other) const
         return true;
     }
 
-    if (d_error > other.d_error) {
+    if (other.d_error < d_error) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_upgradeevent.cpp
+++ b/groups/ntc/ntca/ntca_upgradeevent.cpp
@@ -34,7 +34,7 @@ bool UpgradeEvent::less(const UpgradeEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_upgradeoptions.cpp
+++ b/groups/ntc/ntca/ntca_upgradeoptions.cpp
@@ -43,7 +43,7 @@ bool UpgradeOptions::less(const UpgradeOptions& other) const
         return true;
     }
 
-    if (d_deadline > other.d_deadline) {
+    if (other.d_deadline < d_deadline) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_writequeuecontext.cpp
+++ b/groups/ntc/ntca/ntca_writequeuecontext.cpp
@@ -35,7 +35,7 @@ bool WriteQueueContext::less(const WriteQueueContext& other) const
         return true;
     }
 
-    if (d_size > other.d_size) {
+    if (other.d_size < d_size) {
         return false;
     }
 
@@ -43,7 +43,7 @@ bool WriteQueueContext::less(const WriteQueueContext& other) const
         return true;
     }
 
-    if (d_lowWatermark > other.d_lowWatermark) {
+    if (other.d_lowWatermark < d_lowWatermark) {
         return false;
     }
 

--- a/groups/ntc/ntca/ntca_writequeueevent.cpp
+++ b/groups/ntc/ntca/ntca_writequeueevent.cpp
@@ -34,7 +34,7 @@ bool WriteQueueEvent::less(const WriteQueueEvent& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 

--- a/groups/ntc/ntcdns/ntcdns_client.cpp
+++ b/groups/ntc/ntcdns/ntcdns_client.cpp
@@ -1259,11 +1259,13 @@ ntsa::Error ClientNameServer::createDatagramSocket()
 
     error = datagramSocket->registerSession(self);
     if (error) {
+        d_datagramSocket_sp->close();
         return error;
     }
 
     error = datagramSocket->open();
     if (error) {
+        datagramSocket->close();
         return error;
     }
 
@@ -1280,6 +1282,7 @@ ntsa::Error ClientNameServer::createDatagramSocket()
     error =
         datagramSocket->connect(d_endpoint, connectOptions, connectCallback);
     if (error) {
+        datagramSocket->close();
         return error;
     }
 

--- a/groups/ntc/ntcs/ntcs_flowcontrolcontext.cpp
+++ b/groups/ntc/ntcs/ntcs_flowcontrolcontext.cpp
@@ -35,7 +35,7 @@ bool FlowControlContext::less(const FlowControlContext& other) const
         return true;
     }
 
-    if (d_enableSend > other.d_enableSend) {
+    if (other.d_enableSend < d_enableSend) {
         return false;
     }
 

--- a/groups/ntc/ntcs/ntcs_shutdowncontext.cpp
+++ b/groups/ntc/ntcs/ntcs_shutdowncontext.cpp
@@ -38,7 +38,7 @@ bool ShutdownContext::less(const ShutdownContext& other) const
         return true;
     }
 
-    if (d_shutdownOrigin > other.d_shutdownOrigin) {
+    if (other.d_shutdownOrigin < d_shutdownOrigin) {
         return false;
     }
 
@@ -46,7 +46,7 @@ bool ShutdownContext::less(const ShutdownContext& other) const
         return true;
     }
 
-    if (d_shutdownInitiated > other.d_shutdownInitiated) {
+    if (other.d_shutdownInitiated < d_shutdownInitiated) {
         return false;
     }
 
@@ -54,7 +54,7 @@ bool ShutdownContext::less(const ShutdownContext& other) const
         return true;
     }
 
-    if (d_shutdownSend > other.d_shutdownSend) {
+    if (other.d_shutdownSend < d_shutdownSend) {
         return false;
     }
 
@@ -62,7 +62,7 @@ bool ShutdownContext::less(const ShutdownContext& other) const
         return true;
     }
 
-    if (d_shutdownReceive > other.d_shutdownReceive) {
+    if (other.d_shutdownReceive < d_shutdownReceive) {
         return false;
     }
 

--- a/groups/ntc/ntcs/ntcs_watermarks.cpp
+++ b/groups/ntc/ntcs/ntcs_watermarks.cpp
@@ -35,7 +35,7 @@ bool Watermarks::less(const Watermarks& other) const
         return true;
     }
 
-    if (d_current > other.d_current) {
+    if (other.d_current < d_current) {
         return false;
     }
 
@@ -43,7 +43,7 @@ bool Watermarks::less(const Watermarks& other) const
         return true;
     }
 
-    if (d_low > other.d_low) {
+    if (other.d_low < d_low) {
         return false;
     }
 

--- a/groups/nts/ntsa/ntsa_endpointoptions.cpp
+++ b/groups/nts/ntsa/ntsa_endpointoptions.cpp
@@ -39,7 +39,7 @@ bool EndpointOptions::less(const EndpointOptions& other) const
         return true;
     }
 
-    if (d_ipAddressFallback > other.d_ipAddressFallback) {
+    if (other.d_ipAddressFallback < d_ipAddressFallback) {
         return false;
     }
 
@@ -47,7 +47,7 @@ bool EndpointOptions::less(const EndpointOptions& other) const
         return true;
     }
 
-    if (d_ipAddressType > other.d_ipAddressType) {
+    if (other.d_ipAddressType < d_ipAddressType) {
         return false;
     }
 
@@ -55,7 +55,7 @@ bool EndpointOptions::less(const EndpointOptions& other) const
         return true;
     }
 
-    if (d_ipAddressSelector > other.d_ipAddressSelector) {
+    if (other.d_ipAddressSelector < d_ipAddressSelector) {
         return false;
     }
 
@@ -63,7 +63,7 @@ bool EndpointOptions::less(const EndpointOptions& other) const
         return true;
     }
 
-    if (d_portFallback > other.d_portFallback) {
+    if (other.d_portFallback < d_portFallback) {
         return false;
     }
 
@@ -71,7 +71,7 @@ bool EndpointOptions::less(const EndpointOptions& other) const
         return true;
     }
 
-    if (d_portSelector > other.d_portSelector) {
+    if (other.d_portSelector < d_portSelector) {
         return false;
     }
 

--- a/groups/nts/ntsa/ntsa_file.cpp
+++ b/groups/nts/ntsa/ntsa_file.cpp
@@ -37,7 +37,7 @@ bool File::less(const File& other) const
         return false;
     }
 
-    if (d_fileDescriptor > other.d_fileDescriptor) {
+    if (other.d_fileDescriptor < d_fileDescriptor) {
         return true;
     }
 
@@ -45,7 +45,7 @@ bool File::less(const File& other) const
         return false;
     }
 
-    if (d_filePosition > other.d_filePosition) {
+    if (other.d_filePosition < d_filePosition) {
         return true;
     }
 
@@ -53,7 +53,7 @@ bool File::less(const File& other) const
         return false;
     }
 
-    if (d_fileBytesRemaining > other.d_fileBytesRemaining) {
+    if (other.d_fileBytesRemaining < d_fileBytesRemaining) {
         return true;
     }
 

--- a/groups/nts/ntsa/ntsa_ipaddressoptions.cpp
+++ b/groups/nts/ntsa/ntsa_ipaddressoptions.cpp
@@ -37,7 +37,7 @@ bool IpAddressOptions::less(const IpAddressOptions& other) const
         return true;
     }
 
-    if (d_ipAddressFallback > other.d_ipAddressFallback) {
+    if (other.d_ipAddressFallback < d_ipAddressFallback) {
         return false;
     }
 
@@ -45,7 +45,7 @@ bool IpAddressOptions::less(const IpAddressOptions& other) const
         return true;
     }
 
-    if (d_ipAddressType > other.d_ipAddressType) {
+    if (other.d_ipAddressType < d_ipAddressType) {
         return false;
     }
 
@@ -53,7 +53,7 @@ bool IpAddressOptions::less(const IpAddressOptions& other) const
         return true;
     }
 
-    if (d_ipAddressSelector > other.d_ipAddressSelector) {
+    if (other.d_ipAddressSelector < d_ipAddressSelector) {
         return false;
     }
 

--- a/groups/nts/ntsa/ntsa_linger.cpp
+++ b/groups/nts/ntsa/ntsa_linger.cpp
@@ -34,7 +34,7 @@ bool Linger::less(const Linger& other) const
         return true;
     }
 
-    if (d_enabled > other.d_enabled) {
+    if (other.d_enabled < d_enabled) {
         return false;
     }
 

--- a/groups/nts/ntsa/ntsa_portoptions.cpp
+++ b/groups/nts/ntsa/ntsa_portoptions.cpp
@@ -36,7 +36,7 @@ bool PortOptions::less(const PortOptions& other) const
         return true;
     }
 
-    if (d_portFallback > other.d_portFallback) {
+    if (other.d_portFallback < d_portFallback) {
         return false;
     }
 
@@ -44,7 +44,7 @@ bool PortOptions::less(const PortOptions& other) const
         return true;
     }
 
-    if (d_portSelector > other.d_portSelector) {
+    if (other.d_portSelector < d_portSelector) {
         return false;
     }
 

--- a/groups/nts/ntsa/ntsa_receivecontext.cpp
+++ b/groups/nts/ntsa/ntsa_receivecontext.cpp
@@ -50,7 +50,7 @@ bool ReceiveContext::less(const ReceiveContext& other) const
         return true;
     }
 
-    if (d_bytesReceivable > other.d_bytesReceivable) {
+    if (other.d_bytesReceivable < d_bytesReceivable) {
         return false;
     }
 
@@ -58,7 +58,7 @@ bool ReceiveContext::less(const ReceiveContext& other) const
         return true;
     }
 
-    if (d_bytesReceived > other.d_bytesReceived) {
+    if (other.d_bytesReceived < d_bytesReceived) {
         return false;
     }
 
@@ -66,7 +66,7 @@ bool ReceiveContext::less(const ReceiveContext& other) const
         return true;
     }
 
-    if (d_buffersReceivable > other.d_buffersReceivable) {
+    if (other.d_buffersReceivable < d_buffersReceivable) {
         return false;
     }
 
@@ -74,7 +74,7 @@ bool ReceiveContext::less(const ReceiveContext& other) const
         return true;
     }
 
-    if (d_buffersReceived > other.d_buffersReceived) {
+    if (other.d_buffersReceived < d_buffersReceived) {
         return false;
     }
 
@@ -82,11 +82,7 @@ bool ReceiveContext::less(const ReceiveContext& other) const
         return true;
     }
 
-    if (d_messagesReceivable > other.d_messagesReceivable) {
-        return false;
-    }
-
-    if (d_softwareTimestamp > other.d_softwareTimestamp) {
+    if (other.d_messagesReceivable < d_messagesReceivable) {
         return false;
     }
 
@@ -94,12 +90,16 @@ bool ReceiveContext::less(const ReceiveContext& other) const
         return true;
     }
 
-    if (d_hardwareTimestamp > other.d_hardwareTimestamp) {
+    if (other.d_softwareTimestamp < d_softwareTimestamp) {
         return false;
     }
 
     if (d_hardwareTimestamp < other.d_hardwareTimestamp) {
         return true;
+    }
+
+    if (other.d_hardwareTimestamp < d_hardwareTimestamp) {
+        return false;
     }
 
     return d_messagesReceived < other.d_messagesReceived;

--- a/groups/nts/ntsa/ntsa_receiveoptions.cpp
+++ b/groups/nts/ntsa/ntsa_receiveoptions.cpp
@@ -33,18 +33,18 @@ bool ReceiveOptions::equals(const ReceiveOptions& other) const
 bool ReceiveOptions::less(const ReceiveOptions& other) const
 {
     if (d_options < other.d_options) {
-        return false;
+        return true;
     }
 
-    if (d_options > other.d_options) {
-        return true;
+    if (other.d_options < d_options) {
+        return false;
     }
 
     if (d_maxBytes < other.d_maxBytes) {
         return true;
     }
 
-    if (d_maxBytes > other.d_maxBytes) {
+    if (other.d_maxBytes < d_maxBytes) {
         return false;
     }
 

--- a/groups/nts/ntsa/ntsa_receiveoptions.t.cpp
+++ b/groups/nts/ntsa/ntsa_receiveoptions.t.cpp
@@ -100,10 +100,10 @@ NTSCFG_TEST_CASE(3)
         NTSCFG_TEST_FALSE(opt1.less(opt2));
 
         opt1.showTimestamp();
-        NTSCFG_TEST_TRUE(opt1.less(opt2));
+        NTSCFG_TEST_FALSE(opt1.less(opt2));
 
         opt2.hideEndpoint();
-        NTSCFG_TEST_FALSE(opt2.less(opt1));
+        NTSCFG_TEST_TRUE(opt2.less(opt1));
     }
     NTSCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }

--- a/groups/nts/ntsa/ntsa_sendcontext.cpp
+++ b/groups/nts/ntsa/ntsa_sendcontext.cpp
@@ -39,7 +39,7 @@ bool SendContext::less(const SendContext& other) const
         return true;
     }
 
-    if (d_bytesSendable > other.d_bytesSendable) {
+    if (other.d_bytesSendable < d_bytesSendable) {
         return false;
     }
 
@@ -47,7 +47,7 @@ bool SendContext::less(const SendContext& other) const
         return true;
     }
 
-    if (d_bytesSent > other.d_bytesSent) {
+    if (other.d_bytesSent < d_bytesSent) {
         return false;
     }
 
@@ -55,7 +55,7 @@ bool SendContext::less(const SendContext& other) const
         return true;
     }
 
-    if (d_buffersSendable > other.d_buffersSendable) {
+    if (other.d_buffersSendable < d_buffersSendable) {
         return false;
     }
 
@@ -63,7 +63,7 @@ bool SendContext::less(const SendContext& other) const
         return true;
     }
 
-    if (d_buffersSent > other.d_buffersSent) {
+    if (other.d_buffersSent < d_buffersSent) {
         return false;
     }
 
@@ -71,7 +71,7 @@ bool SendContext::less(const SendContext& other) const
         return true;
     }
 
-    if (d_messagesSendable > other.d_messagesSendable) {
+    if (other.d_messagesSendable < d_messagesSendable) {
         return false;
     }
 

--- a/groups/nts/ntsa/ntsa_sendoptions.cpp
+++ b/groups/nts/ntsa/ntsa_sendoptions.cpp
@@ -43,7 +43,7 @@ bool SendOptions::less(const SendOptions& other) const
         return true;
     }
 
-    if (d_maxBytes > other.d_maxBytes) {
+    if (other.d_maxBytes < d_maxBytes) {
         return false;
     }
 

--- a/groups/nts/ntsa/ntsa_socketconfig.cpp
+++ b/groups/nts/ntsa/ntsa_socketconfig.cpp
@@ -188,7 +188,7 @@ bool SocketConfig::less(const SocketConfig& other) const
         return true;
     }
 
-    if (d_reuseAddress > other.d_reuseAddress) {
+    if (other.d_reuseAddress < d_reuseAddress) {
         return false;
     }
 
@@ -196,7 +196,7 @@ bool SocketConfig::less(const SocketConfig& other) const
         return true;
     }
 
-    if (d_keepAlive > other.d_keepAlive) {
+    if (other.d_keepAlive < d_keepAlive) {
         return false;
     }
 
@@ -204,7 +204,7 @@ bool SocketConfig::less(const SocketConfig& other) const
         return true;
     }
 
-    if (d_cork > other.d_cork) {
+    if (other.d_cork < d_cork) {
         return false;
     }
 
@@ -212,7 +212,7 @@ bool SocketConfig::less(const SocketConfig& other) const
         return true;
     }
 
-    if (d_delayTransmission > other.d_delayTransmission) {
+    if (other.d_delayTransmission < d_delayTransmission) {
         return false;
     }
 
@@ -220,7 +220,7 @@ bool SocketConfig::less(const SocketConfig& other) const
         return true;
     }
 
-    if (d_delayAcknowledgement > other.d_delayAcknowledgement) {
+    if (other.d_delayAcknowledgement < d_delayAcknowledgement) {
         return false;
     }
 
@@ -228,7 +228,7 @@ bool SocketConfig::less(const SocketConfig& other) const
         return true;
     }
 
-    if (d_sendBufferSize > other.d_sendBufferSize) {
+    if (other.d_sendBufferSize < d_sendBufferSize) {
         return false;
     }
 
@@ -236,7 +236,7 @@ bool SocketConfig::less(const SocketConfig& other) const
         return true;
     }
 
-    if (d_sendBufferLowWatermark > other.d_sendBufferLowWatermark) {
+    if (other.d_sendBufferLowWatermark < d_sendBufferLowWatermark) {
         return false;
     }
 
@@ -244,7 +244,7 @@ bool SocketConfig::less(const SocketConfig& other) const
         return true;
     }
 
-    if (d_receiveBufferSize > other.d_receiveBufferSize) {
+    if (other.d_receiveBufferSize < d_receiveBufferSize) {
         return false;
     }
 
@@ -252,7 +252,7 @@ bool SocketConfig::less(const SocketConfig& other) const
         return true;
     }
 
-    if (d_receiveBufferLowWatermark > other.d_receiveBufferLowWatermark) {
+    if (other.d_receiveBufferLowWatermark < d_receiveBufferLowWatermark) {
         return false;
     }
 
@@ -260,7 +260,7 @@ bool SocketConfig::less(const SocketConfig& other) const
         return true;
     }
 
-    if (d_debug > other.d_debug) {
+    if (other.d_debug < d_debug) {
         return false;
     }
 
@@ -268,7 +268,7 @@ bool SocketConfig::less(const SocketConfig& other) const
         return true;
     }
 
-    if (d_linger > other.d_linger) {
+    if (other.d_linger < d_linger) {
         return false;
     }
 
@@ -276,7 +276,7 @@ bool SocketConfig::less(const SocketConfig& other) const
         return true;
     }
 
-    if (d_broadcast > other.d_broadcast) {
+    if (other.d_broadcast < d_broadcast) {
         return false;
     }
 
@@ -284,7 +284,7 @@ bool SocketConfig::less(const SocketConfig& other) const
         return true;
     }
 
-    if (d_bypassRouting > other.d_bypassRouting) {
+    if (other.d_bypassRouting < d_bypassRouting) {
         return false;
     }
 
@@ -292,7 +292,7 @@ bool SocketConfig::less(const SocketConfig& other) const
         return true;
     }
 
-    if (d_inlineOutOfBandData > other.d_inlineOutOfBandData) {
+    if (other.d_inlineOutOfBandData < d_inlineOutOfBandData) {
         return false;
     }
 
@@ -300,7 +300,7 @@ bool SocketConfig::less(const SocketConfig& other) const
         return true;
     }
 
-    if (d_timestampIncomingData > other.d_timestampIncomingData) {
+    if (other.d_timestampIncomingData < d_timestampIncomingData) {
         return false;
     }
 

--- a/groups/nts/ntsd/ntsd_messageheader.cpp
+++ b/groups/nts/ntsd/ntsd_messageheader.cpp
@@ -44,7 +44,7 @@ bool MessageHeader::less(const MessageHeader& other) const
         return true;
     }
 
-    if (d_magic > other.d_magic) {
+    if (other.d_magic < d_magic) {
         return false;
     }
 
@@ -52,7 +52,7 @@ bool MessageHeader::less(const MessageHeader& other) const
         return true;
     }
 
-    if (d_version > other.d_version) {
+    if (other.d_version < d_version) {
         return false;
     }
 
@@ -60,7 +60,7 @@ bool MessageHeader::less(const MessageHeader& other) const
         return true;
     }
 
-    if (d_crc > other.d_crc) {
+    if (other.d_crc < d_crc) {
         return false;
     }
 
@@ -68,7 +68,7 @@ bool MessageHeader::less(const MessageHeader& other) const
         return true;
     }
 
-    if (d_type > other.d_type) {
+    if (other.d_type < d_type) {
         return false;
     }
 
@@ -76,7 +76,7 @@ bool MessageHeader::less(const MessageHeader& other) const
         return true;
     }
 
-    if (d_machineId > other.d_machineId) {
+    if (other.d_machineId < d_machineId) {
         return false;
     }
 
@@ -84,7 +84,7 @@ bool MessageHeader::less(const MessageHeader& other) const
         return true;
     }
 
-    if (d_userId > other.d_userId) {
+    if (other.d_userId < d_userId) {
         return false;
     }
 
@@ -92,7 +92,7 @@ bool MessageHeader::less(const MessageHeader& other) const
         return true;
     }
 
-    if (d_transactionId > other.d_transactionId) {
+    if (other.d_transactionId < d_transactionId) {
         return false;
     }
 
@@ -100,7 +100,7 @@ bool MessageHeader::less(const MessageHeader& other) const
         return true;
     }
 
-    if (d_sequenceNumber > other.d_sequenceNumber) {
+    if (other.d_sequenceNumber < d_sequenceNumber) {
         return false;
     }
 
@@ -108,7 +108,7 @@ bool MessageHeader::less(const MessageHeader& other) const
         return true;
     }
 
-    if (d_requestSize > other.d_requestSize) {
+    if (other.d_requestSize < d_requestSize) {
         return false;
     }
 
@@ -116,7 +116,7 @@ bool MessageHeader::less(const MessageHeader& other) const
         return true;
     }
 
-    if (d_responseSize > other.d_responseSize) {
+    if (other.d_responseSize < d_responseSize) {
         return false;
     }
 
@@ -124,7 +124,7 @@ bool MessageHeader::less(const MessageHeader& other) const
         return true;
     }
 
-    if (d_requestDelay > other.d_requestDelay) {
+    if (other.d_requestDelay < d_requestDelay) {
         return false;
     }
 
@@ -132,7 +132,7 @@ bool MessageHeader::less(const MessageHeader& other) const
         return true;
     }
 
-    if (d_responseDelay > other.d_responseDelay) {
+    if (other.d_responseDelay < d_responseDelay) {
         return false;
     }
 
@@ -140,7 +140,7 @@ bool MessageHeader::less(const MessageHeader& other) const
         return true;
     }
 
-    if (d_requestTimestamp > other.d_requestTimestamp) {
+    if (other.d_requestTimestamp < d_requestTimestamp) {
         return false;
     }
 


### PR DESCRIPTION
This PR changes the implementation of all overloaded `operator<()` functions to be implemented only by other `<` operators. Previously, the implementation used `operator>` in some places when implementing `operator<()` on composite types having data members of type `bdlb::NullableValue<T>`, which implements `operator>` even for types that do not implement `operator>`, which is non-standard in the C++20 standard.