### PR TITLE
Generate CLion CMake configuration file with help of configure script

### DIFF
--- a/configure
+++ b/configure
@@ -521,6 +521,8 @@ usage()
     echo "    --verbose                          Enable verbose build"
     echo "    --what                             Print what is being configured"
     echo "    --dry-run                          Print commands but do not execute them"
+
+    echo "    --clion_config      <clean|add>    Generate .idea/cmake.xml with CLion CMake configuration. Generate the file either from scratch or add configuration into the existing one"
     echo ""
     echo "example:"
     echo "    Build in debug mode:"
@@ -528,6 +530,12 @@ usage()
     echo ""
     echo "    Build with some features and without others:"
     echo "        ./configure --with-poll --without-select"
+    echo ""
+    echo "    Generate CLion cmake.xml for the debug build:"
+    echo "        ./configure --clion_config clean --debug"
+    echo ""
+    echo "    Add to the existing CLion cmake.xml release build configuration with warnings enabled:"
+    echo "        ./configure --with-warnings --clion_config add --release"
     exit 1
 }
 
@@ -780,7 +788,7 @@ while true ; do
             NTF_CONFIGURE_VERBOSE=1 ; shift ;;
         --what)
             NTF_CONFIGURE_WHAT=1 ; shift ;;
-        --clion)
+        --clion_config)
             NTF_GENERATE_CLION_CONFIG=$2 ; shift 2 ;;
         --*)
             echo "Invalid option: ${1}"

--- a/configure
+++ b/configure
@@ -15,6 +15,123 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+process_env() {
+  if [ -n "${!1}" ]; then
+    echo "            <env name=\"${1}\" value=\"${!1}\" />" >> "${NTF_CLION_XML}"
+  fi
+}
+
+generate_clion_toolchain () {
+  NTF_CLION_STORAGE="testFolder"
+  NTF_CLION_XML="${NTF_CLION_STORAGE}/cmake.xml"
+
+  mkdir -p ${NTF_CLION_STORAGE}
+
+  if test -f "$NTF_CLION_XML"; then
+    echo "cmake.xml exists, it will be overwritten"
+  fi
+
+  num_threads=$(grep ^processor /proc/cpuinfo | uniq | wc -l)
+
+  {
+    echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    echo "<project version=\"4\">"
+    echo "  <component name=\"CMakeSharedSettings\">"
+    echo "    <configurations>"
+
+    echo -n "      <configuration PROFILE_NAME=\"${NTF_CONFIGURE_UFID_CANONICAL}\" ENABLED=\"true\""
+    echo -n " GENERATION_DIR=\"${NTF_CONFIGURE_OUTPUT}\" CONFIG_NAME=\"${NTF_CONFIGURE_UFID_CANONICAL}\""
+    echo -n " GENERATION_OPTIONS=\""
+    if [[ "${NTF_CONFIGURE_CMAKE_OPTION_DISTRIBUTION_REFROOT}" != "" ]]; then
+      echo -n " ${NTF_CONFIGURE_CMAKE_OPTION_DISTRIBUTION_REFROOT}"
+    fi
+    echo -n " ${NTF_CONFIGURE_CMAKE_OPTION_UFID} ${NTF_CONFIGURE_CMAKE_OPTION_BUILD_TYPE}"
+    echo -n " ${NTF_CONFIGURE_CMAKE_OPTION_INSTALL_PREFIX} -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF"
+    echo -n " ${NTF_CONFIGURE_CMAKE_OPTION_PREFIX_PATH}"
+    echo -n " -DCMAKE_TOOLCHAIN_FILE:PATH=${NTF_CONFIGURE_REPOSITORY}/toolchain.cmake"
+    echo -n " -G &quot;${NTF_CONFIGURE_GENERATOR}&quot; -S ${NTF_CONFIGURE_REPOSITORY}\""
+    echo " BUILD_OPTIONS=\"-j ${num_threads}\">"
+
+    echo "        <ADDITIONAL_GENERATION_ENVIRONMENT>"
+    echo "          <envs>"
+  } > ${NTF_CLION_XML}
+
+  process_env "CC"
+  process_env "CXX"
+
+  #    export NTF_CONFIGURE_UNAME
+  #    export NTF_CONFIGURE_UFID
+  #    export NTF_CONFIGURE_PREFIX
+  #    export NTF_CONFIGURE_REFROOT
+
+  process_env "NTF_CONFIGURE_SANITIZER"
+
+  process_env "NTF_CONFIGURE_WITH_WARNINGS"
+  process_env "NTF_CONFIGURE_WITH_WARNINGS_AS_ERRORS"
+  process_env "NTF_CONFIGURE_WITH_TIME_TRACE"
+  process_env "NTF_CONFIGURE_WITH_TIME_REPORT"
+  process_env "NTF_CONFIGURE_WITH_COVERAGE"
+
+  process_env "NTF_CONFIGURE_WITH_BSL"
+  process_env "NTF_CONFIGURE_WITH_BDL"
+  process_env "NTF_CONFIGURE_WITH_BAL"
+  process_env "NTF_CONFIGURE_WITH_NTS"
+  process_env "NTF_CONFIGURE_WITH_NTC"
+
+  process_env "NTF_CONFIGURE_WITH_ADDRESS_FAMILY_IPV4"
+  process_env "NTF_CONFIGURE_WITH_ADDRESS_FAMILY_IPV6"
+  process_env "NTF_CONFIGURE_WITH_ADDRESS_FAMILY_LOCAL"
+
+  process_env "NTF_CONFIGURE_WITH_TRANSPORT_PROTOCOL_TCP"
+  process_env "NTF_CONFIGURE_WITH_TRANSPORT_PROTOCOL_UDP"
+  process_env "NTF_CONFIGURE_WITH_TRANSPORT_PROTOCOL_LOCAL"
+
+  process_env "NTF_CONFIGURE_WITH_SELECT"
+  process_env "NTF_CONFIGURE_WITH_POLL"
+  process_env "NTF_CONFIGURE_WITH_EPOLL"
+  process_env "NTF_CONFIGURE_WITH_DEVPOLL"
+  process_env "NTF_CONFIGURE_WITH_EVENTPORT"
+  process_env "NTF_CONFIGURE_WITH_POLLSET"
+  process_env "NTF_CONFIGURE_WITH_KQUEUE"
+  process_env "NTF_CONFIGURE_WITH_IOCP"
+  process_env "NTF_CONFIGURE_WITH_IORING"
+
+  process_env "NTF_CONFIGURE_WITH_DYNAMIC_LOAD_BALANCING"
+  process_env "NTF_CONFIGURE_WITH_THREAD_SCALING"
+  process_env "NTF_CONFIGURE_WITH_DEPRECATED_FEATURES"
+
+  process_env "NTF_CONFIGURE_WITH_LOGGING"
+  process_env "NTF_CONFIGURE_WITH_METRICS"
+  process_env "NTF_CONFIGURE_WITH_BRANCH_PREDICTION"
+
+  process_env "NTF_CONFIGURE_WITH_SPIN_LOCKS"
+  process_env "NTF_CONFIGURE_WITH_RECURSIVE_MUTEXES"
+
+  process_env "NTF_CONFIGURE_WITH_STACK_TRACE_LEAK_REPORT"
+  process_env "NTF_CONFIGURE_WITH_STACK_TRACE_TEST_ALLOCATOR"
+
+  process_env "NTF_CONFIGURE_WITH_APPLICATIONS"
+  process_env "NTF_CONFIGURE_WITH_USAGE_EXAMPLES"
+  process_env "NTF_CONFIGURE_WITH_MOCKS"
+  process_env "NTF_CONFIGURE_WITH_INTEGRATION_TESTS"
+
+  process_env "NTF_CONFIGURE_WITH_DOCUMENTATION"
+  process_env "NTF_CONFIGURE_WITH_DOCUMENTATION_INTERNAL"
+
+  process_env "NTF_CONFIGURE_FROM_CONTINUOUS_INTEGRATION"
+  process_env "NTF_CONFIGURE_FROM_PACKAGING"
+
+  {
+    echo "          </envs>"
+    echo "        </ADDITIONAL_GENERATION_ENVIRONMENT>"
+
+    echo "      </configuration>"
+    echo "    </configurations>"
+    echo "  </component>"
+    echo "</project>"
+  } >> ${NTF_CLION_XML}
+}
+
 set -o pipefail
 
 NTF_CONFIGURE_REPOSITORY=$(dirname ${0})
@@ -287,6 +404,7 @@ fi
 NTF_CONFIGURE_VERBOSE=0
 NTF_CONFIGURE_WHAT=0
 NTF_CONFIGURE_CLEAN=1
+NTF_GENERATE_CLION_CONFIG=0
 
 usage()
 {
@@ -626,6 +744,8 @@ while true ; do
             NTF_CONFIGURE_VERBOSE=1 ; shift ;;
         --what)
             NTF_CONFIGURE_WHAT=1 ; shift ;;
+        --clion)
+            NTF_GENERATE_CLION_CONFIG=1 ; shift ;;
         --*)
             echo "Invalid option: ${1}"
             usage ;;
@@ -815,7 +935,14 @@ fi
 
 NTF_CONFIGURE_CMAKE_OPTION_UFID=" -DUFID:STRING=${NTF_CONFIGURE_UFID_CANONICAL}"
 
+if [ ${NTF_GENERATE_CLION_CONFIG} -ne 0 ]; then
+  generate_clion_toolchain
+  exit 0
+fi
+
+
 cd ${NTF_CONFIGURE_OUTPUT}
+
 
 echo "${NTF_CONFIGURE_CMAKE}${NTF_CONFIGURE_CMAKE_OPTION_DISTRIBUTION_REFROOT}${NTF_CONFIGURE_CMAKE_OPTION_UFID}${NTF_CONFIGURE_CMAKE_OPTION_BUILD_TYPE}${NTF_CONFIGURE_CMAKE_OPTION_INSTALL_PREFIX}${NTF_CONFIGURE_CMAKE_OPTION_PREFIX_PATH}${NTF_CONFIGURE_CMAKE_OPTION_VERBOSE_MAKEFILE} -DCMAKE_TOOLCHAIN_FILE:PATH=${NTF_CONFIGURE_REPOSITORY}/toolchain.cmake -G \"${NTF_CONFIGURE_GENERATOR}\" -S ${NTF_CONFIGURE_REPOSITORY}"
 

--- a/configure
+++ b/configure
@@ -15,30 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-process_env() {
-  if [ -n "${!1}" ]; then
-    echo "            <env name=\"${1}\" value=\"${!1}\" />" >> "${NTF_CLION_XML}"
-  fi
-}
-
-generate_clion_toolchain () {
-  NTF_CLION_STORAGE="testFolder"
-  NTF_CLION_XML="${NTF_CLION_STORAGE}/cmake.xml"
-
-  mkdir -p ${NTF_CLION_STORAGE}
-
-  if test -f "$NTF_CLION_XML"; then
-    echo "cmake.xml exists, it will be overwritten"
-  fi
-
-  num_threads=$(grep ^processor /proc/cpuinfo | uniq | wc -l)
-
+write_config_header() {
   {
-    echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-    echo "<project version=\"4\">"
-    echo "  <component name=\"CMakeSharedSettings\">"
-    echo "    <configurations>"
-
     echo -n "      <configuration PROFILE_NAME=\"${NTF_CONFIGURE_UFID_CANONICAL}\" ENABLED=\"true\""
     echo -n " GENERATION_DIR=\"${NTF_CONFIGURE_OUTPUT}\" CONFIG_NAME=\"${NTF_CONFIGURE_UFID_CANONICAL}\""
     echo -n " GENERATION_OPTIONS=\""
@@ -54,7 +32,59 @@ generate_clion_toolchain () {
 
     echo "        <ADDITIONAL_GENERATION_ENVIRONMENT>"
     echo "          <envs>"
-  } > ${NTF_CLION_XML}
+  } >> "${NTF_CLION_XML}"
+}
+
+process_env() {
+  if [ -n "${!1}" ]; then
+    echo "            <env name=\"${1}\" value=\"${!1}\" />" >> "${NTF_CLION_XML}"
+  fi
+}
+
+generate_clion_toolchain () {
+  echo "Generating Clion cmake.xml..."
+
+  NTF_CLION_STORAGE="testFolder"
+  NTF_CLION_XML="${NTF_CLION_STORAGE}/cmake.xml"
+
+  CLION_XML_GENERATION=$1
+  echo "CLION_XML_GENERATION = ${CLION_XML_GENERATION}"
+
+  mkdir -p ${NTF_CLION_STORAGE}
+
+  num_threads=$(grep ^processor /proc/cpuinfo | uniq | wc -l)
+
+  if [[ ${CLION_XML_GENERATION} == "clean" ]]; then
+    if test -f "$NTF_CLION_XML"; then
+      echo "cmake.xml exists, it will be overwritten"
+    fi
+
+    {
+      echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      echo "<project version=\"4\">"
+      echo "  <component name=\"CMakeSharedSettings\">"
+      echo "    <configurations>"
+    } > ${NTF_CLION_XML}
+
+    write_config_header
+
+  elif [[ ${CLION_XML_GENERATION} == "add" ]]; then
+    echo "Additional generation"
+
+    if ! test -f "${NTF_CLION_XML}"; then
+      echo "cmake.xml does not exist, aborting"
+      exit -1
+    fi
+
+    #save previously available configurations, remove only the end of the cmake.xml
+    num_lines=$(grep -n '</configurations>' ${NTF_CLION_XML} | awk '{print $1}')
+    num_lines=${num_lines:0:${#num_lines}-1}
+    num_lines=$(($((num_lines))-1))
+    head -"${num_lines}" ${NTF_CLION_XML} > clion_tmpfile && mv clion_tmpfile ${NTF_CLION_XML}
+
+    write_config_header
+
+  fi
 
   process_env "CC"
   process_env "CXX"
@@ -130,7 +160,12 @@ generate_clion_toolchain () {
     echo "  </component>"
     echo "</project>"
   } >> ${NTF_CLION_XML}
+
+  echo "Generating Clion cmake.xml done"
 }
+
+
+
 
 set -o pipefail
 
@@ -404,7 +439,7 @@ fi
 NTF_CONFIGURE_VERBOSE=0
 NTF_CONFIGURE_WHAT=0
 NTF_CONFIGURE_CLEAN=1
-NTF_GENERATE_CLION_CONFIG=0
+#NTF_GENERATE_CLION_CONFIG="NO"
 
 usage()
 {
@@ -745,7 +780,7 @@ while true ; do
         --what)
             NTF_CONFIGURE_WHAT=1 ; shift ;;
         --clion)
-            NTF_GENERATE_CLION_CONFIG=1 ; shift ;;
+            NTF_GENERATE_CLION_CONFIG=$2 ; shift 2 ;;
         --*)
             echo "Invalid option: ${1}"
             usage ;;
@@ -935,14 +970,13 @@ fi
 
 NTF_CONFIGURE_CMAKE_OPTION_UFID=" -DUFID:STRING=${NTF_CONFIGURE_UFID_CANONICAL}"
 
-if [ ${NTF_GENERATE_CLION_CONFIG} -ne 0 ]; then
-  generate_clion_toolchain
+if [ -n "${NTF_GENERATE_CLION_CONFIG}" ]; then
+  generate_clion_toolchain "${NTF_GENERATE_CLION_CONFIG}"
   exit 0
 fi
 
 
 cd ${NTF_CONFIGURE_OUTPUT}
-
 
 echo "${NTF_CONFIGURE_CMAKE}${NTF_CONFIGURE_CMAKE_OPTION_DISTRIBUTION_REFROOT}${NTF_CONFIGURE_CMAKE_OPTION_UFID}${NTF_CONFIGURE_CMAKE_OPTION_BUILD_TYPE}${NTF_CONFIGURE_CMAKE_OPTION_INSTALL_PREFIX}${NTF_CONFIGURE_CMAKE_OPTION_PREFIX_PATH}${NTF_CONFIGURE_CMAKE_OPTION_VERBOSE_MAKEFILE} -DCMAKE_TOOLCHAIN_FILE:PATH=${NTF_CONFIGURE_REPOSITORY}/toolchain.cmake -G \"${NTF_CONFIGURE_GENERATOR}\" -S ${NTF_CONFIGURE_REPOSITORY}"
 

--- a/configure
+++ b/configure
@@ -41,14 +41,13 @@ process_env() {
   fi
 }
 
-generate_clion_toolchain () {
+generate_clion_cmake_xml () {
   echo "Generating Clion cmake.xml..."
 
   NTF_CLION_STORAGE="testFolder"
   NTF_CLION_XML="${NTF_CLION_STORAGE}/cmake.xml"
 
   CLION_XML_GENERATION=$1
-  echo "CLION_XML_GENERATION = ${CLION_XML_GENERATION}"
 
   mkdir -p ${NTF_CLION_STORAGE}
 
@@ -69,15 +68,18 @@ generate_clion_toolchain () {
     write_config_header
 
   elif [[ ${CLION_XML_GENERATION} == "add" ]]; then
-    echo "Additional generation"
+    echo "Adding new configuration to existing cmake.xml"
 
     if ! test -f "${NTF_CLION_XML}"; then
       echo "cmake.xml does not exist, aborting"
-      exit -1
+      exit 1
     fi
 
     #save previously available configurations, remove only the end of the cmake.xml
     num_lines=$(grep -n '</configurations>' ${NTF_CLION_XML} | awk '{print $1}')
+    if [[-z ${num_lines} ]]; then
+      echo "Failed to find </configurations> inside ${NTF_CLION_XML}, aborting"
+    fi
     num_lines=${num_lines:0:${#num_lines}-1}
     num_lines=$(($((num_lines))-1))
     head -"${num_lines}" ${NTF_CLION_XML} > clion_tmpfile && mv clion_tmpfile ${NTF_CLION_XML}
@@ -439,7 +441,6 @@ fi
 NTF_CONFIGURE_VERBOSE=0
 NTF_CONFIGURE_WHAT=0
 NTF_CONFIGURE_CLEAN=1
-#NTF_GENERATE_CLION_CONFIG="NO"
 
 usage()
 {
@@ -971,7 +972,7 @@ fi
 NTF_CONFIGURE_CMAKE_OPTION_UFID=" -DUFID:STRING=${NTF_CONFIGURE_UFID_CANONICAL}"
 
 if [ -n "${NTF_GENERATE_CLION_CONFIG}" ]; then
-  generate_clion_toolchain "${NTF_GENERATE_CLION_CONFIG}"
+  generate_clion_cmake_xml "${NTF_GENERATE_CLION_CONFIG}"
   exit 0
 fi
 


### PR DESCRIPTION
CLion has a notion of so called build profiles which must be configured to be able to work with this IDE.  Build profiles are stored in a dedicated file `./idea/cmake.xml`

This PR bring new option to `configure` script: `--clion_config` which instead of executing cmake directly generates `cmake.xml` for CLion.

`.idea/cmake.xml`  must contain the exact way CMake must be executed and all environment variables which impact project configuration.

There are two way of executing such cmake.xml generation:
1) `./configure --clion_config clean` will erase existing cmake.xml and create a new one
2) `./configure --clion_config add` will expect existing cmake.xml to be available and then add a new build profile there.

So workflow can look like this:
`./configure  --refroot /home/some_user/bloomberg/refroot_clang --clion_config clean --debug` - it will create default debug profile, then
`./configure  --refroot /home/kot/bloomberg/refroot_clang --with-ioring --clion_config add --release` - it will add one more build profile with release type and enabled IO_URING backend.

