### PR TITLE
Remove wrong branch led to misleading error during compiler detection

### DIFF
--- a/toolchain.cmake
+++ b/toolchain.cmake
@@ -97,8 +97,6 @@ elseif(NOT NTF_TOOLCHAIN_COMPILER_CC_PATH OR NOT NTF_TOOLCHAIN_COMPILER_CXX_PATH
     else()
         message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_NAME}")
     endif()
-else()
-    message(FATAL_ERROR "Failed to determine compiler")
 endif()
 
 get_filename_component(


### PR DESCRIPTION
When `cmake` was called on already configured project there was an error in compiler detection functionality.
`NTF_TOOLCHAIN_COMPILER_CC_PATH` and `NTF_TOOLCHAIN_COMPILER_CXX_PATH` were already cached so that `message(FATAL_ERROR "Failed to determine compiler")` was executed by mistake.