### PR TITLE
Enhance UDS names handling in ntsa::LocalName

### DIFF
--- a/examples/m_ntcu03/ntcu03.m.cpp
+++ b/examples/m_ntcu03/ntcu03.m.cpp
@@ -121,7 +121,11 @@ void execute()
     error = listener->setBlocking(false);
     BSLS_ASSERT_OPT(!error);
 
-    error = listener->bind(ntsa::Endpoint(ntsa::LocalName::generateUnique()),
+    ntsa::LocalName localName;
+    error = ntsa::LocalName::generateUnique(&localName);
+    BSLS_ASSERT_OPT(!error);
+
+    error = listener->bind(ntsa::Endpoint(localName),
                            false);
     BSLS_ASSERT_OPT(!error);
 

--- a/examples/m_ntcu09/ntcu09.m.cpp
+++ b/examples/m_ntcu09/ntcu09.m.cpp
@@ -31,9 +31,9 @@ using namespace BloombergLP;
 
 namespace example {
 
-void processConnect(bslmt::Semaphore                        *semaphore,
-                    const bsl::shared_ptr<ntci::Connector>&  connector,
-                    const ntca::ConnectEvent&                event)
+void processConnect(bslmt::Semaphore*                       semaphore,
+                    const bsl::shared_ptr<ntci::Connector>& connector,
+                    const ntca::ConnectEvent&               event)
 {
     NTCCFG_WARNING_UNUSED(connector);
 
@@ -41,11 +41,11 @@ void processConnect(bslmt::Semaphore                        *semaphore,
     semaphore->post();
 }
 
-void processAccept(bslmt::Semaphore                           *semaphore,
-                   bsl::shared_ptr<ntci::StreamSocket>        *result,
-                   const bsl::shared_ptr<ntci::Acceptor>&      acceptor,
-                   const bsl::shared_ptr<ntci::StreamSocket>&  streamSocket,
-                   const ntca::AcceptEvent&                    event)
+void processAccept(bslmt::Semaphore*                          semaphore,
+                   bsl::shared_ptr<ntci::StreamSocket>*       result,
+                   const bsl::shared_ptr<ntci::Acceptor>&     acceptor,
+                   const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+                   const ntca::AcceptEvent&                   event)
 {
     NTCCFG_WARNING_UNUSED(acceptor);
 
@@ -54,9 +54,9 @@ void processAccept(bslmt::Semaphore                           *semaphore,
     semaphore->post();
 }
 
-void processSend(bslmt::Semaphore                     *semaphore,
-                 const bsl::shared_ptr<ntci::Sender>&  sender,
-                 const ntca::SendEvent&                event)
+void processSend(bslmt::Semaphore*                    semaphore,
+                 const bsl::shared_ptr<ntci::Sender>& sender,
+                 const ntca::SendEvent&               event)
 {
     NTCCFG_WARNING_UNUSED(sender);
 
@@ -64,11 +64,11 @@ void processSend(bslmt::Semaphore                     *semaphore,
     semaphore->post();
 }
 
-void processReceive(bslmt::Semaphore                       *semaphore,
-                    bdlbb::Blob                            *result,
-                    const bsl::shared_ptr<ntci::Receiver>&  receiver,
-                    const bsl::shared_ptr<bdlbb::Blob>&     data,
-                    const ntca::ReceiveEvent&               event)
+void processReceive(bslmt::Semaphore*                      semaphore,
+                    bdlbb::Blob*                           result,
+                    const bsl::shared_ptr<ntci::Receiver>& receiver,
+                    const bsl::shared_ptr<bdlbb::Blob>&    data,
+                    const ntca::ReceiveEvent&              event)
 {
     NTCCFG_WARNING_UNUSED(receiver);
 
@@ -77,14 +77,14 @@ void processReceive(bslmt::Semaphore                       *semaphore,
     semaphore->post();
 }
 
-void processClose(bslmt::Semaphore *semaphore)
+void processClose(bslmt::Semaphore* semaphore)
 {
     semaphore->post();
 }
 
 namespace usage_tcp_ipv4_cpp03 {
 
-void execute(bslma::Allocator *allocator)
+void execute(bslma::Allocator* allocator)
 {
     NTCCFG_WARNING_UNUSED(allocator);
 
@@ -102,7 +102,7 @@ void execute(bslma::Allocator *allocator)
     interfaceConfig.setThreadName("example");
 
     bsl::shared_ptr<ntci::Interface> interface =
-                                ntcf::System::createInterface(interfaceConfig);
+        ntcf::System::createInterface(interfaceConfig);
 
     error = interface->start();
     BSLS_ASSERT_OPT(!error);
@@ -112,10 +112,10 @@ void execute(bslma::Allocator *allocator)
     ntca::ListenerSocketOptions listenerSocketOptions;
     listenerSocketOptions.setTransport(ntsa::Transport::e_TCP_IPV4_STREAM);
     listenerSocketOptions.setSourceEndpoint(
-                             ntsa::Endpoint(ntsa::Ipv4Address::loopback(), 0));
+        ntsa::Endpoint(ntsa::Ipv4Address::loopback(), 0));
 
     bsl::shared_ptr<ntci::ListenerSocket> listenerSocket =
-                        interface->createListenerSocket(listenerSocketOptions);
+        interface->createListenerSocket(listenerSocketOptions);
 
     error = listenerSocket->open();
     BSLS_ASSERT_OPT(!error);
@@ -129,14 +129,14 @@ void execute(bslma::Allocator *allocator)
     streamSocketOptions.setTransport(ntsa::Transport::e_TCP_IPV4_STREAM);
 
     bsl::shared_ptr<ntci::StreamSocket> clientSocket =
-                            interface->createStreamSocket(streamSocketOptions);
+        interface->createStreamSocket(streamSocketOptions);
 
     ntci::ConnectCallback connectCallback =
-                               clientSocket->createConnectCallback(NTCCFG_BIND(
-                                   &processConnect,
-                                   &semaphore,
-                                   NTCCFG_BIND_PLACEHOLDER_1,
-                                   NTCCFG_BIND_PLACEHOLDER_2));
+        clientSocket->createConnectCallback(
+            NTCCFG_BIND(&processConnect,
+                        &semaphore,
+                        NTCCFG_BIND_PLACEHOLDER_1,
+                        NTCCFG_BIND_PLACEHOLDER_2));
 
     error = clientSocket->connect(listenerSocket->sourceEndpoint(),
                                   ntca::ConnectOptions(),
@@ -150,12 +150,12 @@ void execute(bslma::Allocator *allocator)
     bsl::shared_ptr<ntci::StreamSocket> serverSocket;
 
     ntci::AcceptCallback acceptCallback = listenerSocket->createAcceptCallback(
-                                       NTCCFG_BIND(&processAccept,
-                                                   &semaphore,
-                                                   &serverSocket,
-                                                   NTCCFG_BIND_PLACEHOLDER_1,
-                                                   NTCCFG_BIND_PLACEHOLDER_2,
-                                                   NTCCFG_BIND_PLACEHOLDER_3));
+        NTCCFG_BIND(&processAccept,
+                    &semaphore,
+                    &serverSocket,
+                    NTCCFG_BIND_PLACEHOLDER_1,
+                    NTCCFG_BIND_PLACEHOLDER_2,
+                    NTCCFG_BIND_PLACEHOLDER_3));
 
     error = listenerSocket->accept(ntca::AcceptOptions(), acceptCallback);
     BSLS_ASSERT_OPT(!error || error == ntsa::Error::e_WOULD_BLOCK);
@@ -168,10 +168,10 @@ void execute(bslma::Allocator *allocator)
     bdlbb::BlobUtil::append(&clientData, "Hello, world!", 13);
 
     ntci::SendCallback sendCallback = clientSocket->createSendCallback(
-                                       NTCCFG_BIND(&processSend,
-                                                   &semaphore,
-                                                   NTCCFG_BIND_PLACEHOLDER_1,
-                                                   NTCCFG_BIND_PLACEHOLDER_2));
+        NTCCFG_BIND(&processSend,
+                    &semaphore,
+                    NTCCFG_BIND_PLACEHOLDER_1,
+                    NTCCFG_BIND_PLACEHOLDER_2));
 
     error = clientSocket->send(clientData, ntca::SendOptions(), sendCallback);
     BSLS_ASSERT_OPT(!error);
@@ -186,13 +186,13 @@ void execute(bslma::Allocator *allocator)
     bdlbb::Blob serverData;
 
     ntci::ReceiveCallback receiveCallback =
-                               serverSocket->createReceiveCallback(NTCCFG_BIND(
-                                   &processReceive,
-                                   &semaphore,
-                                   &serverData,
-                                   NTCCFG_BIND_PLACEHOLDER_1,
-                                   NTCCFG_BIND_PLACEHOLDER_2,
-                                   NTCCFG_BIND_PLACEHOLDER_3));
+        serverSocket->createReceiveCallback(
+            NTCCFG_BIND(&processReceive,
+                        &semaphore,
+                        &serverData,
+                        NTCCFG_BIND_PLACEHOLDER_1,
+                        NTCCFG_BIND_PLACEHOLDER_2,
+                        NTCCFG_BIND_PLACEHOLDER_3));
 
     error = serverSocket->receive(receiveOptions, receiveCallback);
     BSLS_ASSERT_OPT(!error || error == ntsa::Error::e_WOULD_BLOCK);
@@ -206,21 +206,21 @@ void execute(bslma::Allocator *allocator)
     // Close the client socket.
 
     clientSocket->close(clientSocket->createCloseCallback(
-                                      NTCCFG_BIND(&processClose, &semaphore)));
+        NTCCFG_BIND(&processClose, &semaphore)));
 
     semaphore.wait();
 
     // Close the server socket.
 
     serverSocket->close(serverSocket->createCloseCallback(
-                                      NTCCFG_BIND(&processClose, &semaphore)));
+        NTCCFG_BIND(&processClose, &semaphore)));
 
     semaphore.wait();
 
     // Close the listener socket.
 
     listenerSocket->close(listenerSocket->createCloseCallback(
-                                      NTCCFG_BIND(&processClose, &semaphore)));
+        NTCCFG_BIND(&processClose, &semaphore)));
 
     semaphore.wait();
 
@@ -234,7 +234,7 @@ void execute(bslma::Allocator *allocator)
 
 namespace usage_tcp_ipv4_cpp11 {
 
-void execute(bslma::Allocator *allocator)
+void execute(bslma::Allocator* allocator)
 {
 #if NTCCFG_PLATFORM_COMPILER_SUPPORTS_LAMDAS
 
@@ -254,7 +254,7 @@ void execute(bslma::Allocator *allocator)
     interfaceConfig.setThreadName("example");
 
     bsl::shared_ptr<ntci::Interface> interface =
-                                ntcf::System::createInterface(interfaceConfig);
+        ntcf::System::createInterface(interfaceConfig);
 
     error = interface->start();
     BSLS_ASSERT_OPT(!error);
@@ -264,10 +264,10 @@ void execute(bslma::Allocator *allocator)
     ntca::ListenerSocketOptions listenerSocketOptions;
     listenerSocketOptions.setTransport(ntsa::Transport::e_TCP_IPV4_STREAM);
     listenerSocketOptions.setSourceEndpoint(
-                             ntsa::Endpoint(ntsa::Ipv4Address::loopback(), 0));
+        ntsa::Endpoint(ntsa::Ipv4Address::loopback(), 0));
 
     bsl::shared_ptr<ntci::ListenerSocket> listenerSocket =
-                        interface->createListenerSocket(listenerSocketOptions);
+        interface->createListenerSocket(listenerSocketOptions);
 
     error = listenerSocket->open();
     BSLS_ASSERT_OPT(!error);
@@ -281,11 +281,11 @@ void execute(bslma::Allocator *allocator)
     streamSocketOptions.setTransport(ntsa::Transport::e_TCP_IPV4_STREAM);
 
     bsl::shared_ptr<ntci::StreamSocket> clientSocket =
-                            interface->createStreamSocket(streamSocketOptions);
+        interface->createStreamSocket(streamSocketOptions);
 
     ntci::ConnectCallback connectCallback =
-          clientSocket->createConnectCallback([&](auto connector, auto event) {
-              NTCCFG_WARNING_UNUSED(connector);
+        clientSocket->createConnectCallback([&](auto connector, auto event) {
+            NTCCFG_WARNING_UNUSED(connector);
             BSLS_ASSERT_OPT(event.type() ==
                             ntca::ConnectEventType::e_COMPLETE);
             semaphore.post();
@@ -321,8 +321,8 @@ void execute(bslma::Allocator *allocator)
     bdlbb::BlobUtil::append(&clientData, "Hello, world!", 13);
 
     ntci::SendCallback sendCallback =
-                clientSocket->createSendCallback([&](auto sender, auto event) {
-                    NTCCFG_WARNING_UNUSED(sender);
+        clientSocket->createSendCallback([&](auto sender, auto event) {
+            NTCCFG_WARNING_UNUSED(sender);
             BSLS_ASSERT_OPT(event.type() == ntca::SendEventType::e_COMPLETE);
             semaphore.post();
         });
@@ -340,15 +340,14 @@ void execute(bslma::Allocator *allocator)
     bdlbb::Blob serverData;
 
     ntci::ReceiveCallback receiveCallback =
-                         serverSocket->createReceiveCallback([&](auto receiver,
-                                                                 auto data,
-                                                                 auto event) {
-                             NTCCFG_WARNING_UNUSED(receiver);
-            BSLS_ASSERT_OPT(event.type() ==
-                            ntca::ReceiveEventType::e_COMPLETE);
-            serverData = *data;
-            semaphore.post();
-        });
+        serverSocket->createReceiveCallback(
+            [&](auto receiver, auto data, auto event) {
+                NTCCFG_WARNING_UNUSED(receiver);
+                BSLS_ASSERT_OPT(event.type() ==
+                                ntca::ReceiveEventType::e_COMPLETE);
+                serverData = *data;
+                semaphore.post();
+            });
 
     error = serverSocket->receive(receiveOptions, receiveCallback);
     BSLS_ASSERT_OPT(!error || error == ntsa::Error::e_WOULD_BLOCK);
@@ -395,7 +394,7 @@ void execute(bslma::Allocator *allocator)
 
 namespace usage_local_cpp03 {
 
-void execute(bslma::Allocator *allocator)
+void execute(bslma::Allocator* allocator)
 {
 #if defined(BSLS_PLATFORM_OS_UNIX)
 
@@ -415,7 +414,7 @@ void execute(bslma::Allocator *allocator)
     interfaceConfig.setThreadName("example");
 
     bsl::shared_ptr<ntci::Interface> interface =
-                                ntcf::System::createInterface(interfaceConfig);
+        ntcf::System::createInterface(interfaceConfig);
 
     error = interface->start();
     BSLS_ASSERT_OPT(!error);
@@ -424,11 +423,15 @@ void execute(bslma::Allocator *allocator)
 
     ntca::ListenerSocketOptions listenerSocketOptions;
     listenerSocketOptions.setTransport(ntsa::Transport::e_LOCAL_STREAM);
-    listenerSocketOptions.setSourceEndpoint(
-                            ntsa::Endpoint(ntsa::LocalName::generateUnique()));
+
+    ntsa::LocalName localName;
+    error = ntsa::LocalName::generateUnique(&localName);
+    BSLS_ASSERT_OPT(!error);
+
+    listenerSocketOptions.setSourceEndpoint(ntsa::Endpoint(localName));
 
     bsl::shared_ptr<ntci::ListenerSocket> listenerSocket =
-                        interface->createListenerSocket(listenerSocketOptions);
+        interface->createListenerSocket(listenerSocketOptions);
 
     error = listenerSocket->open();
     BSLS_ASSERT_OPT(!error);
@@ -442,14 +445,14 @@ void execute(bslma::Allocator *allocator)
     streamSocketOptions.setTransport(ntsa::Transport::e_LOCAL_STREAM);
 
     bsl::shared_ptr<ntci::StreamSocket> clientSocket =
-                            interface->createStreamSocket(streamSocketOptions);
+        interface->createStreamSocket(streamSocketOptions);
 
     ntci::ConnectCallback connectCallback =
-                               clientSocket->createConnectCallback(NTCCFG_BIND(
-                                   &processConnect,
-                                   &semaphore,
-                                   NTCCFG_BIND_PLACEHOLDER_1,
-                                   NTCCFG_BIND_PLACEHOLDER_2));
+        clientSocket->createConnectCallback(
+            NTCCFG_BIND(&processConnect,
+                        &semaphore,
+                        NTCCFG_BIND_PLACEHOLDER_1,
+                        NTCCFG_BIND_PLACEHOLDER_2));
 
     error = clientSocket->connect(listenerSocket->sourceEndpoint(),
                                   ntca::ConnectOptions(),
@@ -463,12 +466,12 @@ void execute(bslma::Allocator *allocator)
     bsl::shared_ptr<ntci::StreamSocket> serverSocket;
 
     ntci::AcceptCallback acceptCallback = listenerSocket->createAcceptCallback(
-                                       NTCCFG_BIND(&processAccept,
-                                                   &semaphore,
-                                                   &serverSocket,
-                                                   NTCCFG_BIND_PLACEHOLDER_1,
-                                                   NTCCFG_BIND_PLACEHOLDER_2,
-                                                   NTCCFG_BIND_PLACEHOLDER_3));
+        NTCCFG_BIND(&processAccept,
+                    &semaphore,
+                    &serverSocket,
+                    NTCCFG_BIND_PLACEHOLDER_1,
+                    NTCCFG_BIND_PLACEHOLDER_2,
+                    NTCCFG_BIND_PLACEHOLDER_3));
 
     error = listenerSocket->accept(ntca::AcceptOptions(), acceptCallback);
     BSLS_ASSERT_OPT(!error || error == ntsa::Error::e_WOULD_BLOCK);
@@ -481,10 +484,10 @@ void execute(bslma::Allocator *allocator)
     bdlbb::BlobUtil::append(&clientData, "Hello, world!", 13);
 
     ntci::SendCallback sendCallback = clientSocket->createSendCallback(
-                                       NTCCFG_BIND(&processSend,
-                                                   &semaphore,
-                                                   NTCCFG_BIND_PLACEHOLDER_1,
-                                                   NTCCFG_BIND_PLACEHOLDER_2));
+        NTCCFG_BIND(&processSend,
+                    &semaphore,
+                    NTCCFG_BIND_PLACEHOLDER_1,
+                    NTCCFG_BIND_PLACEHOLDER_2));
 
     error = clientSocket->send(clientData, ntca::SendOptions(), sendCallback);
     BSLS_ASSERT_OPT(!error);
@@ -499,13 +502,13 @@ void execute(bslma::Allocator *allocator)
     bdlbb::Blob serverData;
 
     ntci::ReceiveCallback receiveCallback =
-                               serverSocket->createReceiveCallback(NTCCFG_BIND(
-                                   &processReceive,
-                                   &semaphore,
-                                   &serverData,
-                                   NTCCFG_BIND_PLACEHOLDER_1,
-                                   NTCCFG_BIND_PLACEHOLDER_2,
-                                   NTCCFG_BIND_PLACEHOLDER_3));
+        serverSocket->createReceiveCallback(
+            NTCCFG_BIND(&processReceive,
+                        &semaphore,
+                        &serverData,
+                        NTCCFG_BIND_PLACEHOLDER_1,
+                        NTCCFG_BIND_PLACEHOLDER_2,
+                        NTCCFG_BIND_PLACEHOLDER_3));
 
     error = serverSocket->receive(receiveOptions, receiveCallback);
     BSLS_ASSERT_OPT(!error || error == ntsa::Error::e_WOULD_BLOCK);
@@ -519,21 +522,21 @@ void execute(bslma::Allocator *allocator)
     // Close the client socket.
 
     clientSocket->close(clientSocket->createCloseCallback(
-                                      NTCCFG_BIND(&processClose, &semaphore)));
+        NTCCFG_BIND(&processClose, &semaphore)));
 
     semaphore.wait();
 
     // Close the server socket.
 
     serverSocket->close(serverSocket->createCloseCallback(
-                                      NTCCFG_BIND(&processClose, &semaphore)));
+        NTCCFG_BIND(&processClose, &semaphore)));
 
     semaphore.wait();
 
     // Close the listener socket.
 
     listenerSocket->close(listenerSocket->createCloseCallback(
-                                      NTCCFG_BIND(&processClose, &semaphore)));
+        NTCCFG_BIND(&processClose, &semaphore)));
 
     semaphore.wait();
 
@@ -549,7 +552,7 @@ void execute(bslma::Allocator *allocator)
 
 namespace usage_local_cpp11 {
 
-void execute(bslma::Allocator *allocator)
+void execute(bslma::Allocator* allocator)
 {
 #if defined(BSLS_PLATFORM_OS_UNIX)
 #if NTCCFG_PLATFORM_COMPILER_SUPPORTS_LAMDAS
@@ -570,7 +573,7 @@ void execute(bslma::Allocator *allocator)
     interfaceConfig.setThreadName("example");
 
     bsl::shared_ptr<ntci::Interface> interface =
-                                ntcf::System::createInterface(interfaceConfig);
+        ntcf::System::createInterface(interfaceConfig);
 
     error = interface->start();
     BSLS_ASSERT_OPT(!error);
@@ -579,11 +582,15 @@ void execute(bslma::Allocator *allocator)
 
     ntca::ListenerSocketOptions listenerSocketOptions;
     listenerSocketOptions.setTransport(ntsa::Transport::e_LOCAL_STREAM);
-    listenerSocketOptions.setSourceEndpoint(
-                            ntsa::Endpoint(ntsa::LocalName::generateUnique()));
+
+    ntsa::LocalName localName;
+    error = ntsa::LocalName::generateUnique(&localName);
+    BSLS_ASSERT_OPT(!error);
+
+    listenerSocketOptions.setSourceEndpoint(ntsa::Endpoint(localName));
 
     bsl::shared_ptr<ntci::ListenerSocket> listenerSocket =
-                        interface->createListenerSocket(listenerSocketOptions);
+        interface->createListenerSocket(listenerSocketOptions);
 
     error = listenerSocket->open();
     BSLS_ASSERT_OPT(!error);
@@ -597,11 +604,11 @@ void execute(bslma::Allocator *allocator)
     streamSocketOptions.setTransport(ntsa::Transport::e_LOCAL_STREAM);
 
     bsl::shared_ptr<ntci::StreamSocket> clientSocket =
-                            interface->createStreamSocket(streamSocketOptions);
+        interface->createStreamSocket(streamSocketOptions);
 
     ntci::ConnectCallback connectCallback =
-          clientSocket->createConnectCallback([&](auto connector, auto event) {
-              NTCCFG_WARNING_UNUSED(connector);
+        clientSocket->createConnectCallback([&](auto connector, auto event) {
+            NTCCFG_WARNING_UNUSED(connector);
             BSLS_ASSERT_OPT(event.type() ==
                             ntca::ConnectEventType::e_COMPLETE);
             semaphore.post();
@@ -637,8 +644,8 @@ void execute(bslma::Allocator *allocator)
     bdlbb::BlobUtil::append(&clientData, "Hello, world!", 13);
 
     ntci::SendCallback sendCallback =
-                clientSocket->createSendCallback([&](auto sender, auto event) {
-                    NTCCFG_WARNING_UNUSED(sender);
+        clientSocket->createSendCallback([&](auto sender, auto event) {
+            NTCCFG_WARNING_UNUSED(sender);
             BSLS_ASSERT_OPT(event.type() == ntca::SendEventType::e_COMPLETE);
             semaphore.post();
         });
@@ -656,15 +663,14 @@ void execute(bslma::Allocator *allocator)
     bdlbb::Blob serverData;
 
     ntci::ReceiveCallback receiveCallback =
-                         serverSocket->createReceiveCallback([&](auto receiver,
-                                                                 auto data,
-                                                                 auto event) {
-                             NTCCFG_WARNING_UNUSED(receiver);
-            BSLS_ASSERT_OPT(event.type() ==
-                            ntca::ReceiveEventType::e_COMPLETE);
-            serverData = *data;
-            semaphore.post();
-        });
+        serverSocket->createReceiveCallback(
+            [&](auto receiver, auto data, auto event) {
+                NTCCFG_WARNING_UNUSED(receiver);
+                BSLS_ASSERT_OPT(event.type() ==
+                                ntca::ReceiveEventType::e_COMPLETE);
+                serverData = *data;
+                semaphore.post();
+            });
 
     error = serverSocket->receive(receiveOptions, receiveCallback);
     BSLS_ASSERT_OPT(!error || error == ntsa::Error::e_WOULD_BLOCK);
@@ -716,20 +722,22 @@ void help()
     bsl::cout << "usage: ntcu90.tsk [-v <level>]" << bsl::endl;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     int verbosity = 0;
     {
         int i = 1;
         while (i < argc) {
             if ((0 == std::strcmp(argv[i], "-?")) ||
-                (0 == std::strcmp(argv[i], "--help"))) {
+                (0 == std::strcmp(argv[i], "--help")))
+            {
                 help();
                 return 0;
             }
 
             if (0 == std::strcmp(argv[i], "-v") ||
-                0 == std::strcmp(argv[i], "--verbosity")) {
+                0 == std::strcmp(argv[i], "--verbosity"))
+            {
                 ++i;
                 if (i >= argc) {
                     help();
@@ -746,21 +754,21 @@ int main(int argc, char **argv)
     }
 
     switch (verbosity) {
-      case 0:
+    case 0:
         break;
-      case 1:
+    case 1:
         bsls::Log::setSeverityThreshold(bsls::LogSeverity::e_ERROR);
         break;
-      case 2:
+    case 2:
         bsls::Log::setSeverityThreshold(bsls::LogSeverity::e_WARN);
         break;
-      case 3:
+    case 3:
         bsls::Log::setSeverityThreshold(bsls::LogSeverity::e_INFO);
         break;
-      case 4:
+    case 4:
         bsls::Log::setSeverityThreshold(bsls::LogSeverity::e_DEBUG);
         break;
-      default:
+    default:
         bsls::Log::setSeverityThreshold(bsls::LogSeverity::e_TRACE);
         break;
     }

--- a/examples/m_ntcu12/ntcu12.m.cpp
+++ b/examples/m_ntcu12/ntcu12.m.cpp
@@ -85,10 +85,6 @@ namespace example {
 // fixed length message header.
 //
 
-                            
-                            
-                            
-
 // This struct describes the header of a message in the example wire
 // protocol.
 struct MessageHeader {
@@ -103,10 +99,6 @@ struct MessageHeader {
 // header followed by the variable length payload string.
 //
 
-                              
-                              
-                              
-
 // This struct describes a message in the example wire protocol. A
 // message consists of a fixed length header followed by a variable-length
 // string.
@@ -120,42 +112,32 @@ struct Message {
 // application protocol.
 //
 
-                             
-                             
-                             
-
 // Provide functions for encoding the message header and
 // payload of the example wire protocol.
 struct MessageUtil {
-    
-
     // Encode the specified 'header' to the specified 'result'.
-    static void encodeHeader(bdlbb::Blob                   *result,
-                             const example::MessageHeader&  header);
+    static void encodeHeader(bdlbb::Blob*                  result,
+                             const example::MessageHeader& header);
 
     // Encode the specified 'payload' to the specified 'result'.
-    static void encodePayload(bdlbb::Blob *result, const bsl::string& payload);
+    static void encodePayload(bdlbb::Blob* result, const bsl::string& payload);
 
     // Decode the specified specified 'result' from the specified 'blob'.
-    static void decodeHeader(example::MessageHeader *result,
+    static void decodeHeader(example::MessageHeader* result,
                              const bdlbb::Blob&      blob);
 
     // Decode the specified specified 'result' from the specified 'blob'.
-    static void decodePayload(bsl::string        *result,
-                              const bdlbb::Blob&  blob,
-                              int                 length);
+    static void decodePayload(bsl::string*       result,
+                              const bdlbb::Blob& blob,
+                              int                length);
 };
 
 //
 // Now, let's implement the encoding and decoding functions in our utility.
 //
 
-                             
-                             
-                             
-
-void MessageUtil::encodeHeader(bdlbb::Blob                   *result,
-                               const example::MessageHeader&  header)
+void MessageUtil::encodeHeader(bdlbb::Blob*                  result,
+                               const example::MessageHeader& header)
 {
     bdlbb::OutBlobStreamBuf osb(result);
     {
@@ -167,15 +149,15 @@ void MessageUtil::encodeHeader(bdlbb::Blob                   *result,
     osb.pubsync();
 }
 
-void MessageUtil::encodePayload(bdlbb::Blob        *result,
-                                const bsl::string&  payload)
+void MessageUtil::encodePayload(bdlbb::Blob*       result,
+                                const bsl::string& payload)
 {
     bdlbb::OutBlobStreamBuf osb(result);
     osb.sputn(payload.c_str(), payload.size());
     osb.pubsync();
 }
 
-void MessageUtil::decodeHeader(example::MessageHeader *result,
+void MessageUtil::decodeHeader(example::MessageHeader* result,
                                const bdlbb::Blob&      blob)
 {
     bdlbb::InBlobStreamBuf isb(&blob);
@@ -186,9 +168,9 @@ void MessageUtil::decodeHeader(example::MessageHeader *result,
     }
 }
 
-void MessageUtil::decodePayload(bsl::string        *result,
-                                const bdlbb::Blob&  blob,
-                                int                 length)
+void MessageUtil::decodePayload(bsl::string*       result,
+                                const bdlbb::Blob& blob,
+                                int                length)
 {
     bdlbb::InBlobStreamBuf isb(&blob);
     result->resize(length);
@@ -203,42 +185,30 @@ void MessageUtil::decodePayload(bsl::string        *result,
 // from a connection, which will become relevant later.
 //
 
-                            
-                            
-                            
-
 // Provide a mechanism to parse messages in the wire protocol
 // used in this example from a stream of bytes.
-class MessageParser {
-    
+class MessageParser
+{
     enum State { e_STATE_WANT_HEADER, e_STATE_WANT_PAYLOAD };
 
-    
     State            d_state;
     example::Message d_message;
 
   private:
-    
     MessageParser(const MessageParser&) BSLS_KEYWORD_DELETED;
     MessageParser& operator=(const MessageParser&) BSLS_KEYWORD_DELETED;
 
   public:
-    
-
     // This typedef defines a callback function invoked when a message is
     // parsed.
     typedef bsl::function<void(const example::Message& message)>
         MessageCallback;
-
-    
 
     // Create a new message parser.
     MessageParser();
 
     // Destroy this object.
     ~MessageParser();
-
-    
 
     // Receive zero or more messages from the read queue of the specified
     // 'streamSocket'. If the read queue of the 'streamSocket' does not
@@ -258,11 +228,6 @@ class MessageParser {
 // callers how much more data is needed to transition to the next state.
 //
 
-                            
-                            
-                            
-
-
 MessageParser::MessageParser()
 : d_state(e_STATE_WANT_HEADER)
 , d_message()
@@ -273,10 +238,9 @@ MessageParser::~MessageParser()
 {
 }
 
-
 ntsa::Error MessageParser::parse(
-                       const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
-                       const MessageCallback&                     callback)
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const MessageCallback&                     callback)
 {
     ntsa::Error error;
 
@@ -292,7 +256,7 @@ ntsa::Error MessageParser::parse(
             if (error) {
                 if (error == ntsa::Error::e_WOULD_BLOCK) {
                     streamSocket->setReadQueueLowWatermark(
-                                             example::MessageHeader::e_LENGTH);
+                        example::MessageHeader::e_LENGTH);
                     return ntsa::Error();
                 }
                 else {
@@ -306,7 +270,7 @@ ntsa::Error MessageParser::parse(
                 d_state = e_STATE_WANT_PAYLOAD;
 
                 streamSocket->setReadQueueLowWatermark(
-                                           d_message.d_header.d_payloadLength);
+                    d_message.d_header.d_payloadLength);
             }
             else {
                 callback(d_message);
@@ -314,7 +278,7 @@ ntsa::Error MessageParser::parse(
                 d_state = e_STATE_WANT_HEADER;
 
                 streamSocket->setReadQueueLowWatermark(
-                                             example::MessageHeader::e_LENGTH);
+                    example::MessageHeader::e_LENGTH);
             }
         }
 
@@ -331,7 +295,7 @@ ntsa::Error MessageParser::parse(
             if (error) {
                 if (error == ntsa::Error::e_WOULD_BLOCK) {
                     streamSocket->setReadQueueLowWatermark(
-                                           d_message.d_header.d_payloadLength);
+                        d_message.d_header.d_payloadLength);
                     return ntsa::Error();
                 }
                 else {
@@ -340,9 +304,9 @@ ntsa::Error MessageParser::parse(
             }
 
             example::MessageUtil::decodePayload(
-                                           &d_message.d_payload,
-                                           data,
-                                           d_message.d_header.d_payloadLength);
+                &d_message.d_payload,
+                data,
+                d_message.d_header.d_payloadLength);
 
             callback(d_message);
 
@@ -353,7 +317,7 @@ ntsa::Error MessageParser::parse(
             d_state = e_STATE_WANT_HEADER;
 
             streamSocket->setReadQueueLowWatermark(
-                                             example::MessageHeader::e_LENGTH);
+                example::MessageHeader::e_LENGTH);
         }
     }
 }
@@ -373,18 +337,13 @@ ntsa::Error MessageParser::parse(
 // protocol over a stream socket.
 //
 
-                             
-                             
-                             
-
 // This class implements the 'ntci::StreamSocketSession' protocol to
 // provide client communication of the example wire protocol over an
 // asynchronous stream socket. This class is thread safe.
 class ClientSocket : public ntci::StreamSocketSession,
-                     public ntccfg::Shared<ClientSocket> {
+                     public ntccfg::Shared<ClientSocket>
+{
   public:
-    
-
     // Defines a type alias for a generic function callback.
     typedef bsl::function<void()> Callback;
 
@@ -394,69 +353,55 @@ class ClientSocket : public ntci::StreamSocketSession,
         ResponseCallback;
 
   private:
-    
-
     // Define a type alias for an associative data
     // structure mapping a transaction ID to the callback function
     // to be invoked when the response for that transaction ID is received.
     typedef bdlcc::ObjectCatalog<ResponseCallback> PendingCatalog;
 
-    
-    bslmt::Mutex                         d_mutex;
-    bsl::shared_ptr<ntci::StreamSocket>  d_streamSocket_sp;
-    PendingCatalog                       d_pendingRequests;
-    example::MessageParser               d_parser;
-    example::ClientSocket::Callback      d_upgradeCallback;
-    example::ClientSocket::Callback      d_downgradeCallback;
-    bslma::Allocator                    *d_allocator_p;
+    bslmt::Mutex                        d_mutex;
+    bsl::shared_ptr<ntci::StreamSocket> d_streamSocket_sp;
+    PendingCatalog                      d_pendingRequests;
+    example::MessageParser              d_parser;
+    example::ClientSocket::Callback     d_upgradeCallback;
+    example::ClientSocket::Callback     d_downgradeCallback;
+    bslma::Allocator*                   d_allocator_p;
 
   private:
-    
     ClientSocket(const ClientSocket&) BSLS_KEYWORD_DELETED;
     ClientSocket& operator=(const ClientSocket&) BSLS_KEYWORD_DELETED;
 
   private:
-    
-
     // Process the condition that the size of the read queue is greater
     // than or equal to the read queue low watermark.
     void processReadQueueLowWatermark(
-       const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
-       const ntca::ReadQueueEvent&                event) BSLS_KEYWORD_OVERRIDE;
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const ntca::ReadQueueEvent& event) BSLS_KEYWORD_OVERRIDE;
 
     // Process the condition that the peer has indicated that it will
     // not send any more encrypted data.
     void processDowngradeComplete(
-       const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
-       const ntca::DowngradeEvent&                event) BSLS_KEYWORD_OVERRIDE;
-
-    
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const ntca::DowngradeEvent& event) BSLS_KEYWORD_OVERRIDE;
 
     // Process the upgrade of the specified 'upgradable' that is the
     // specified 'streamSocket' according to the specified 'upgradeEvent'.
     void processUpgrade(const bsl::shared_ptr<ntci::Upgradable>& upgradable,
                         const ntca::UpgradeEvent&                upgradeEvent);
 
-    
-
     // Process the specified 'response' received from the server.
     void processResponse(const example::Message& response);
 
   public:
-    
-
     // Create a new application client socket over the specified
     // 'streamSocket'. Optionally specify a 'basicAllocator' used to
     // supply memory. If 'basicAllocator' is 0, the currently installed
     // default allocator is used.
     explicit ClientSocket(
-               const bsl::shared_ptr<ntci::StreamSocket>&  streamSocket,
-               bslma::Allocator                           *basicAllocator = 0);
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        bslma::Allocator*                          basicAllocator = 0);
 
     // Destroy this object.
     ~ClientSocket();
-
-    
 
     // Assume the TLS client role and begin upgrading the socket from
     // being unencrypted to being encrypted with TLS. Invoke the specified
@@ -464,17 +409,17 @@ class ClientSocket : public ntci::StreamSocketSession,
     // and invoke the specified 'downgradeCallback' when the socket has
     // completed downgrading from TLS back to clear text.
     void upgrade(
-             const bsl::shared_ptr<ntci::EncryptionClient>& encryptionClient,
-             const example::ClientSocket::Callback&         upgradeCallback,
-             const example::ClientSocket::Callback&         downgradeCallback);
+        const bsl::shared_ptr<ntci::EncryptionClient>& encryptionClient,
+        const example::ClientSocket::Callback&         upgradeCallback,
+        const example::ClientSocket::Callback&         downgradeCallback);
 
     // Send a message requesting the transformation of the specified
     // 'requestPayload' according to the wire protocol. On success, invoke
     // the specified 'responseCallback' when the response to the request is
     // received. Return the error.
     ntsa::Error send(
-              const bsl::string&                             requestPayload,
-              const example::ClientSocket::ResponseCallback& responseCallback);
+        const bsl::string&                             requestPayload,
+        const example::ClientSocket::ResponseCallback& responseCallback);
 
     // Start or stop receiving data according to the specified 'enabled'
     // flag. When receiving data is enabled, the
@@ -493,8 +438,6 @@ class ClientSocket : public ntci::StreamSocketSession,
 
     // Shutdown and close the socket.
     void shutdown();
-
-    
 
     // Return the certificate of the peer of the socket.
     bsl::shared_ptr<ntci::EncryptionCertificate> remoteCertificate() const;
@@ -522,14 +465,9 @@ class ClientSocket : public ntci::StreamSocketSession,
 //  the graceful shutdown sequence of the connection.
 //
 
-                             
-                             
-                             
-
-
 void ClientSocket::processReadQueueLowWatermark(
-                       const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
-                       const ntca::ReadQueueEvent&                event)
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const ntca::ReadQueueEvent&                event)
 {
     NTCCFG_WARNING_UNUSED(streamSocket);
     NTCCFG_WARNING_UNUSED(event);
@@ -540,8 +478,8 @@ void ClientSocket::processReadQueueLowWatermark(
 }
 
 void ClientSocket::processDowngradeComplete(
-                       const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
-                       const ntca::DowngradeEvent&                event)
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const ntca::DowngradeEvent&                event)
 {
     NTCCFG_WARNING_UNUSED(streamSocket);
     NTCCFG_WARNING_UNUSED(event);
@@ -560,10 +498,9 @@ void ClientSocket::processDowngradeComplete(
     }
 }
 
-
 void ClientSocket::processUpgrade(
-                         const bsl::shared_ptr<ntci::Upgradable>& upgradable,
-                         const ntca::UpgradeEvent&                upgradeEvent)
+    const bsl::shared_ptr<ntci::Upgradable>& upgradable,
+    const ntca::UpgradeEvent&                upgradeEvent)
 {
     NTCCFG_WARNING_UNUSED(upgradable);
 
@@ -581,22 +518,21 @@ void ClientSocket::processUpgrade(
     }
 }
 
-
 void ClientSocket::processResponse(const example::Message& response)
 {
     example::ClientSocket::ResponseCallback responseCallback;
     if (0 != d_pendingRequests.remove(response.d_header.d_transactionId,
-                                      &responseCallback)) {
+                                      &responseCallback))
+    {
         return;
     }
 
     responseCallback(response.d_payload);
 }
 
-
 ClientSocket::ClientSocket(
-                    const bsl::shared_ptr<ntci::StreamSocket>&  streamSocket,
-                    bslma::Allocator                           *basicAllocator)
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    bslma::Allocator*                          basicAllocator)
 : d_mutex()
 , d_streamSocket_sp(streamSocket)
 , d_pendingRequests(basicAllocator)
@@ -611,11 +547,10 @@ ClientSocket::~ClientSocket()
 {
 }
 
-
 void ClientSocket::upgrade(
-              const bsl::shared_ptr<ntci::EncryptionClient>& encryptionClient,
-              const example::ClientSocket::Callback&         upgradeCallback,
-              const example::ClientSocket::Callback&         downgradeCallback)
+    const bsl::shared_ptr<ntci::EncryptionClient>& encryptionClient,
+    const example::ClientSocket::Callback&         upgradeCallback,
+    const example::ClientSocket::Callback&         downgradeCallback)
 {
     {
         bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
@@ -624,16 +559,16 @@ void ClientSocket::upgrade(
     }
 
     d_streamSocket_sp->upgrade(
-               encryptionClient,
-               ntca::UpgradeOptions(),
-               d_streamSocket_sp->createUpgradeCallback(
-                   bdlf::MemFnUtil::memFn(&ClientSocket::processUpgrade, this),
-                   d_allocator_p));
+        encryptionClient,
+        ntca::UpgradeOptions(),
+        d_streamSocket_sp->createUpgradeCallback(
+            bdlf::MemFnUtil::memFn(&ClientSocket::processUpgrade, this),
+            d_allocator_p));
 }
 
 ntsa::Error ClientSocket::send(
-               const bsl::string&                             requestPayload,
-               const example::ClientSocket::ResponseCallback& responseCallback)
+    const bsl::string&                             requestPayload,
+    const example::ClientSocket::ResponseCallback& responseCallback)
 {
     int transactionId = d_pendingRequests.add(responseCallback);
 
@@ -644,7 +579,7 @@ ntsa::Error ClientSocket::send(
     request.d_payload                = requestPayload;
 
     bdlbb::Blob requestBlob(
-                         d_streamSocket_sp->outgoingBlobBufferFactory().get());
+        d_streamSocket_sp->outgoingBlobBufferFactory().get());
 
     example::MessageUtil::encodeHeader(&requestBlob, request.d_header);
     example::MessageUtil::encodePayload(&requestBlob, request.d_payload);
@@ -659,8 +594,8 @@ void ClientSocket::receive(bool enabled)
     }
     else {
         d_streamSocket_sp->applyFlowControl(
-                                           ntca::FlowControlType::e_RECEIVE,
-                                           ntca::FlowControlMode::e_IMMEDIATE);
+            ntca::FlowControlType::e_RECEIVE,
+            ntca::FlowControlMode::e_IMMEDIATE);
     }
 }
 
@@ -677,9 +612,8 @@ void ClientSocket::shutdown()
     d_streamSocket_sp->close();
 }
 
-
-bsl::shared_ptr<ntci::EncryptionCertificate>
-ClientSocket::remoteCertificate() const
+bsl::shared_ptr<ntci::EncryptionCertificate> ClientSocket::remoteCertificate()
+    const
 {
     return d_streamSocket_sp->remoteCertificate();
 }
@@ -693,77 +627,60 @@ ClientSocket::remoteCertificate() const
 // client socket pertain to the server socket.
 //
 
-                             
-                             
-                             
-
 // This class implements the 'ntci::StreamSocketSession' protocol to
 // provide client communication of the example wire protocol over an
 // asynchronous stream socket. This class is thread safe.
 class ServerSocket : public ntci::StreamSocketSession,
-                     public ntccfg::Shared<ServerSocket> {
+                     public ntccfg::Shared<ServerSocket>
+{
   public:
-    
-
     // Defines a type alias for a generic function callback.
     typedef bsl::function<void()> Callback;
 
   private:
-    
-    bslmt::Mutex                         d_mutex;
-    bsl::shared_ptr<ntci::StreamSocket>  d_streamSocket_sp;
-    example::MessageParser               d_parser;
-    example::ServerSocket::Callback      d_upgradeCallback;
-    example::ServerSocket::Callback      d_downgradeCallback;
-    bslma::Allocator                    *d_allocator_p;
+    bslmt::Mutex                        d_mutex;
+    bsl::shared_ptr<ntci::StreamSocket> d_streamSocket_sp;
+    example::MessageParser              d_parser;
+    example::ServerSocket::Callback     d_upgradeCallback;
+    example::ServerSocket::Callback     d_downgradeCallback;
+    bslma::Allocator*                   d_allocator_p;
 
   private:
-    
     ServerSocket(const ServerSocket&) BSLS_KEYWORD_DELETED;
     ServerSocket& operator=(const ServerSocket&) BSLS_KEYWORD_DELETED;
 
   private:
-    
-
     // Process the condition that the size of the read queue is greater
     // than or equal to the read queue low watermark.
     void processReadQueueLowWatermark(
-       const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
-       const ntca::ReadQueueEvent&                event) BSLS_KEYWORD_OVERRIDE;
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const ntca::ReadQueueEvent& event) BSLS_KEYWORD_OVERRIDE;
 
     // Process the condition that the peer has indicated that it will
     // not send any more encrypted data.
     void processDowngradeComplete(
-       const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
-       const ntca::DowngradeEvent&                event) BSLS_KEYWORD_OVERRIDE;
-
-    
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const ntca::DowngradeEvent& event) BSLS_KEYWORD_OVERRIDE;
 
     // Process the upgrade of the specified 'upgradable' that is the
     // specified 'streamSocket' according to the specified 'upgradeEvent'.
     void processUpgrade(const bsl::shared_ptr<ntci::Upgradable>& upgradable,
                         const ntca::UpgradeEvent&                upgradeEvent);
 
-    
-
     // Process the specified 'request' received from the client.
     void processRequest(const example::Message& request);
 
   public:
-    
-
     // Create a new application server socket over the specified
     // 'streamSocket'. Optionally specify a 'basicAllocator' used to
     // supply memory. If 'basicAllocator' is 0, the currently installed
     // default allocator is used.
     explicit ServerSocket(
-               const bsl::shared_ptr<ntci::StreamSocket>&  streamSocket,
-               bslma::Allocator                           *basicAllocator = 0);
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        bslma::Allocator*                          basicAllocator = 0);
 
     // Destroy this object.
     ~ServerSocket() BSLS_KEYWORD_OVERRIDE;
-
-    
 
     // Assume the TLS server role and begin upgrading the socket from
     // being unencrypted to being encrypted with TLS. Invoke the specified
@@ -771,9 +688,9 @@ class ServerSocket : public ntci::StreamSocketSession,
     // and invoke the specified 'downgradeCallback' when the socket has
     // completed downgrading from TLS back to clear text.
     void upgrade(
-             const bsl::shared_ptr<ntci::EncryptionServer>& encryptionServer,
-             const example::ServerSocket::Callback&         upgradeCallback,
-             const example::ServerSocket::Callback&         downgradeCallback);
+        const bsl::shared_ptr<ntci::EncryptionServer>& encryptionServer,
+        const example::ServerSocket::Callback&         upgradeCallback,
+        const example::ServerSocket::Callback&         downgradeCallback);
 
     // Start or stop receiving data according to the specified 'enabled'
     // flag. When receiving data is enabled, the
@@ -793,8 +710,6 @@ class ServerSocket : public ntci::StreamSocketSession,
     // Shutdown and close the socket.
     void shutdown();
 
-    
-
     // Return the certificate of the peer of the socket.
     bsl::shared_ptr<ntci::EncryptionCertificate> remoteCertificate() const;
 };
@@ -803,26 +718,21 @@ class ServerSocket : public ntci::StreamSocketSession,
 // Next, let's define the implementation of the server socket.
 //
 
-                             
-                             
-                             
-
-
 void ServerSocket::processReadQueueLowWatermark(
-                       const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
-                       const ntca::ReadQueueEvent&                event)
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const ntca::ReadQueueEvent&                event)
 {
     NTCCFG_WARNING_UNUSED(streamSocket);
     NTCCFG_WARNING_UNUSED(event);
 
     ntsa::Error error = d_parser.parse(
-         d_streamSocket_sp,
-         bdlf::MemFnUtil::memFn(&example::ServerSocket::processRequest, this));
+        d_streamSocket_sp,
+        bdlf::MemFnUtil::memFn(&example::ServerSocket::processRequest, this));
 }
 
 void ServerSocket::processDowngradeComplete(
-                       const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
-                       const ntca::DowngradeEvent&                event)
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const ntca::DowngradeEvent&                event)
 {
     NTCCFG_WARNING_UNUSED(streamSocket);
     NTCCFG_WARNING_UNUSED(event);
@@ -841,10 +751,9 @@ void ServerSocket::processDowngradeComplete(
     }
 }
 
-
 void ServerSocket::processUpgrade(
-                         const bsl::shared_ptr<ntci::Upgradable>& upgradable,
-                         const ntca::UpgradeEvent&                upgradeEvent)
+    const bsl::shared_ptr<ntci::Upgradable>& upgradable,
+    const ntca::UpgradeEvent&                upgradeEvent)
 {
     NTCCFG_WARNING_UNUSED(upgradable);
 
@@ -862,7 +771,6 @@ void ServerSocket::processUpgrade(
     }
 }
 
-
 void ServerSocket::processRequest(const example::Message& request)
 {
     example::Message response;
@@ -874,7 +782,7 @@ void ServerSocket::processRequest(const example::Message& request)
     bdlb::String::toUpper(&response.d_payload);
 
     bdlbb::Blob responseBlob(
-                         d_streamSocket_sp->outgoingBlobBufferFactory().get());
+        d_streamSocket_sp->outgoingBlobBufferFactory().get());
 
     example::MessageUtil::encodeHeader(&responseBlob, response.d_header);
     example::MessageUtil::encodePayload(&responseBlob, response.d_payload);
@@ -882,10 +790,9 @@ void ServerSocket::processRequest(const example::Message& request)
     d_streamSocket_sp->send(responseBlob, ntca::SendOptions());
 }
 
-
 ServerSocket::ServerSocket(
-                    const bsl::shared_ptr<ntci::StreamSocket>&  streamSocket,
-                    bslma::Allocator                           *basicAllocator)
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    bslma::Allocator*                          basicAllocator)
 : d_mutex()
 , d_streamSocket_sp(streamSocket)
 , d_parser()
@@ -899,11 +806,10 @@ ServerSocket::~ServerSocket()
 {
 }
 
-
 void ServerSocket::upgrade(
-              const bsl::shared_ptr<ntci::EncryptionServer>& encryptionServer,
-              const example::ServerSocket::Callback&         upgradeCallback,
-              const example::ServerSocket::Callback&         downgradeCallback)
+    const bsl::shared_ptr<ntci::EncryptionServer>& encryptionServer,
+    const example::ServerSocket::Callback&         upgradeCallback,
+    const example::ServerSocket::Callback&         downgradeCallback)
 {
     {
         bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
@@ -912,11 +818,11 @@ void ServerSocket::upgrade(
     }
 
     d_streamSocket_sp->upgrade(
-               encryptionServer,
-               ntca::UpgradeOptions(),
-               d_streamSocket_sp->createUpgradeCallback(
-                   bdlf::MemFnUtil::memFn(&ServerSocket::processUpgrade, this),
-                   d_allocator_p));
+        encryptionServer,
+        ntca::UpgradeOptions(),
+        d_streamSocket_sp->createUpgradeCallback(
+            bdlf::MemFnUtil::memFn(&ServerSocket::processUpgrade, this),
+            d_allocator_p));
 }
 
 void ServerSocket::receive(bool enabled)
@@ -926,8 +832,8 @@ void ServerSocket::receive(bool enabled)
     }
     else {
         d_streamSocket_sp->applyFlowControl(
-                                           ntca::FlowControlType::e_RECEIVE,
-                                           ntca::FlowControlMode::e_IMMEDIATE);
+            ntca::FlowControlType::e_RECEIVE,
+            ntca::FlowControlMode::e_IMMEDIATE);
     }
 }
 
@@ -943,9 +849,8 @@ void ServerSocket::shutdown()
     d_streamSocket_sp->close();
 }
 
-
-bsl::shared_ptr<ntci::EncryptionCertificate>
-ServerSocket::remoteCertificate() const
+bsl::shared_ptr<ntci::EncryptionCertificate> ServerSocket::remoteCertificate()
+    const
 {
     return d_streamSocket_sp->remoteCertificate();
 }
@@ -956,56 +861,43 @@ ServerSocket::remoteCertificate() const
 // once they have been connected.
 //
 
-                            
-                            
-                            
-
 // This class implements the 'ntci::ListenerSocketSession' protocol to
 // accept stream sockets from the backlog of a listening socket. This class
 // is thread safe.
 class ListenerSocket : public ntci::ListenerSocketSession,
-                       public ntccfg::Shared<ListenerSocket> {
+                       public ntccfg::Shared<ListenerSocket>
+{
   public:
-    
-
     // Defines a type alias for a generic function callback.
     typedef bsl::function<void()> Callback;
 
   private:
-    
-    bslmt::Mutex                           d_mutex;
-    bsl::shared_ptr<ntci::ListenerSocket>  d_listenerSocket_sp;
-    bslma::Allocator                      *d_allocator_p;
+    bslmt::Mutex                          d_mutex;
+    bsl::shared_ptr<ntci::ListenerSocket> d_listenerSocket_sp;
+    bslma::Allocator*                     d_allocator_p;
 
   private:
-    
     ListenerSocket(const ListenerSocket&) BSLS_KEYWORD_DELETED;
     ListenerSocket& operator=(const ListenerSocket&) BSLS_KEYWORD_DELETED;
 
   private:
-    
-
     // Process the condition that the size of the accept queue is greater
     // than or equal to the accept queue low watermark.
     void processAcceptQueueLowWatermark(
-     const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
-     const ntca::AcceptQueueEvent&                event) BSLS_KEYWORD_OVERRIDE;
+        const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
+        const ntca::AcceptQueueEvent& event) BSLS_KEYWORD_OVERRIDE;
 
   public:
-    
-
     // Create a new application listener socket over the specified
     // 'listenerSocket'. Optionally specify a 'basicAllocator' used to
     // supply memory. If 'basicAllocator' is 0, the currently installed
     // default allocator is used.
     explicit ListenerSocket(
-             const bsl::shared_ptr<ntci::ListenerSocket>&  listenerSocket,
-             bslma::Allocator                             *basicAllocator = 0);
+        const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
+        bslma::Allocator*                            basicAllocator = 0);
 
     // Destroy this object.
     ~ListenerSocket() BSLS_KEYWORD_OVERRIDE;
-
-    
 
     // Start or stop accepting connections according to the specified
     // 'enabled' flag. When accepting connections is enabled, the
@@ -1024,14 +916,9 @@ class ListenerSocket : public ntci::ListenerSocketSession,
 // Next, let's define the implementation of the listener socket.
 //
 
-                            
-                            
-                            
-
-
 void ListenerSocket::processAcceptQueueLowWatermark(
-                   const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
-                   const ntca::AcceptQueueEvent&                event)
+    const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
+    const ntca::AcceptQueueEvent&                event)
 {
     NTCCFG_WARNING_UNUSED(listenerSocket);
     NTCCFG_WARNING_UNUSED(event);
@@ -1052,10 +939,9 @@ void ListenerSocket::processAcceptQueueLowWatermark(
     }
 }
 
-
 ListenerSocket::ListenerSocket(
-                  const bsl::shared_ptr<ntci::ListenerSocket>&  listenerSocket,
-                  bslma::Allocator                             *basicAllocator)
+    const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
+    bslma::Allocator*                            basicAllocator)
 : d_mutex()
 , d_listenerSocket_sp(listenerSocket)
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
@@ -1066,17 +952,16 @@ ListenerSocket::~ListenerSocket()
 {
 }
 
-
 void ListenerSocket::accept(bool enabled)
 {
     if (enabled) {
         d_listenerSocket_sp->relaxFlowControl(
-                                             ntca::FlowControlType::e_RECEIVE);
+            ntca::FlowControlType::e_RECEIVE);
     }
     else {
         d_listenerSocket_sp->applyFlowControl(
-                                           ntca::FlowControlType::e_RECEIVE,
-                                           ntca::FlowControlMode::e_IMMEDIATE);
+            ntca::FlowControlType::e_RECEIVE,
+            ntca::FlowControlMode::e_IMMEDIATE);
     }
 }
 
@@ -1098,26 +983,18 @@ void ListenerSocket::shutdown()
 // are all completely closed.  Let's start by declaring the client.
 //
 
-                                
-                                
-                                
-
 // This class implements the 'ntci::StreamSocketManager' protocol to
 // provide client communication of the example wire protocol. This class is
 // thread safe.
-class Client : public ntci::StreamSocketManager,
-               public ntccfg::Shared<Client> {
+class Client : public ntci::StreamSocketManager, public ntccfg::Shared<Client>
+{
   public:
-    
-
     // Defines a type alias for a deferred function.
-    typedef bsl::function<
-        void(const bsl::shared_ptr<example::ClientSocket>& clientSocket)>
+    typedef bsl::function<void(
+        const bsl::shared_ptr<example::ClientSocket>& clientSocket)>
         ClientSocketCallback;
 
   private:
-    
-
     // This typedef defines a map of stream sockets pending the completion
     // of their connection to the callbacks to notify the user of the
     // completion of the connection.
@@ -1131,49 +1008,41 @@ class Client : public ntci::StreamSocketManager,
                                bsl::shared_ptr<example::ClientSocket> >
         StreamSocketMap;
 
-    
-    bslmt::Mutex                      d_mutex;
-    bsl::shared_ptr<ntci::Interface>  d_interface_sp;
-    PendingConnectionMap              d_pendingConnections;
-    StreamSocketMap                   d_streamSockets;
-    bslmt::Condition                  d_linger;
-    bslma::Allocator                 *d_allocator_p;
+    bslmt::Mutex                     d_mutex;
+    bsl::shared_ptr<ntci::Interface> d_interface_sp;
+    PendingConnectionMap             d_pendingConnections;
+    StreamSocketMap                  d_streamSockets;
+    bslmt::Condition                 d_linger;
+    bslma::Allocator*                d_allocator_p;
 
   private:
-    
     Client(const Client&) BSLS_KEYWORD_DELETED;
     Client& operator=(const Client&) BSLS_KEYWORD_DELETED;
 
   private:
-    
     void processStreamSocketEstablished(
-                       const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
         BSLS_KEYWORD_OVERRIDE;
-        // Process the establishment of the specified 'streamSocket'.
+    // Process the establishment of the specified 'streamSocket'.
 
     // Process the closure of the specified 'streamSocket'.
     void processStreamSocketClosed(const bsl::shared_ptr<ntci::StreamSocket>&
                                        streamSocket) BSLS_KEYWORD_OVERRIDE;
 
-    
-
     // Process the specified 'connectEvent' for the specified 'connector'
     // that is the specified 'streamSocket'.
     void processConnect(
-                      const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
-                      const bsl::shared_ptr<ntci::Connector>&    connector,
-                      const ntca::ConnectEvent&                  connectEvent);
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const bsl::shared_ptr<ntci::Connector>&    connector,
+        const ntca::ConnectEvent&                  connectEvent);
 
   public:
-    
-
     // Create a new client that creates stream sockets using the specified
     // 'interface'. Optionally specify a 'basicAllocator' used to supply
     // memory. If 'basicAllocator' is 0, the currently installed default
     // allocator is used.
-    explicit Client(
-                  const bsl::shared_ptr<ntci::Interface>&  interface,
-                  bslma::Allocator                        *basicAllocator = 0);
+    explicit Client(const bsl::shared_ptr<ntci::Interface>& interface,
+                    bslma::Allocator* basicAllocator = 0);
 
     // Destroy this object.
     ~Client() BSLS_KEYWORD_OVERRIDE;
@@ -1195,13 +1064,8 @@ class Client : public ntci::StreamSocketManager,
 // Next, let's define the implementation of the client.
 //
 
-                                
-                                
-                                
-
-
 void Client::processStreamSocketEstablished(
-                       const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
 {
     bsl::shared_ptr<example::ClientSocket> clientSocket;
     example::Client::ClientSocketCallback  callback;
@@ -1210,7 +1074,7 @@ void Client::processStreamSocketEstablished(
         bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
 
         PendingConnectionMap::iterator it =
-                                       d_pendingConnections.find(streamSocket);
+            d_pendingConnections.find(streamSocket);
         BSLS_ASSERT_OPT(it != d_pendingConnections.end());
 
         callback = it->second;
@@ -1227,7 +1091,7 @@ void Client::processStreamSocketEstablished(
 }
 
 void Client::processStreamSocketClosed(
-                       const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
 {
     bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
 
@@ -1239,9 +1103,9 @@ void Client::processStreamSocketClosed(
 }
 
 void Client::processConnect(
-                       const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
-                       const bsl::shared_ptr<ntci::Connector>&    connector,
-                       const ntca::ConnectEvent&                  connectEvent)
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const bsl::shared_ptr<ntci::Connector>&    connector,
+    const ntca::ConnectEvent&                  connectEvent)
 {
     NTCCFG_WARNING_UNUSED(streamSocket);
     NTCCFG_WARNING_UNUSED(connector);
@@ -1252,9 +1116,8 @@ void Client::processConnect(
     }
 }
 
-
-Client::Client(const bsl::shared_ptr<ntci::Interface>&  interface,
-               bslma::Allocator                        *basicAllocator)
+Client::Client(const bsl::shared_ptr<ntci::Interface>& interface,
+               bslma::Allocator*                       basicAllocator)
 : d_mutex()
 , d_interface_sp(interface)
 , d_pendingConnections(basicAllocator)
@@ -1268,9 +1131,8 @@ Client::~Client()
 {
 }
 
-void Client::connect(
-                   const ntsa::Endpoint&                        remoteEndpoint,
-                   const example::Client::ClientSocketCallback& callback)
+void Client::connect(const ntsa::Endpoint& remoteEndpoint,
+                     const example::Client::ClientSocketCallback& callback)
 {
     ntsa::Error error;
 
@@ -1287,12 +1149,12 @@ void Client::connect(
     }
 
     ntci::ConnectCallback connectCallback =
-                               streamSocket->createConnectCallback(NTCCFG_BIND(
-                                   &Client::processConnect,
-                                   this,
-                                   streamSocket,
-                                   NTCCFG_BIND_PLACEHOLDER_1,
-                                   NTCCFG_BIND_PLACEHOLDER_2));
+        streamSocket->createConnectCallback(
+            NTCCFG_BIND(&Client::processConnect,
+                        this,
+                        streamSocket,
+                        NTCCFG_BIND_PLACEHOLDER_1,
+                        NTCCFG_BIND_PLACEHOLDER_2));
 
     streamSocket->connect(remoteEndpoint,
                           ntca::ConnectOptions(),
@@ -1309,7 +1171,8 @@ void Client::shutdown()
 
     for (StreamSocketMap::iterator it = streamSockets.begin();
          it != streamSockets.end();
-         ++it) {
+         ++it)
+    {
         it->first->close();
     }
 }
@@ -1330,25 +1193,18 @@ void Client::linger()
 // client role.
 //
 
-                                
-                                
-                                
-
 // This class implements the 'ntci::ListenerSocketManager' and
 // protocol to 'ntci::ListenerSocketSession' protocols to provide server
 // communication of the example wire protocol. This class is thread safe.
 class Server : public ntci::ListenerSocketManager,
                public ntci::ListenerSocketSession,
-               public ntccfg::Shared<Server> {
+               public ntccfg::Shared<Server>
+{
   public:
-    
-
     // Defines a type alias for a deferred function.
-    typedef bsl::function<
-        void(const bsl::shared_ptr<example::ServerSocket>& serverSocket)>
+    typedef bsl::function<void(
+        const bsl::shared_ptr<example::ServerSocket>& serverSocket)>
         ServerSocketCallback;
-
-    
 
     // This typedef defines a map of listener sockets listening for
     // connections to the callbacks to notify the user of the
@@ -1369,58 +1225,49 @@ class Server : public ntci::ListenerSocketManager,
                                bsl::shared_ptr<example::ServerSocket> >
         StreamSocketMap;
 
-    
-    mutable bslmt::Mutex              d_mutex;
-    bsl::shared_ptr<ntci::Interface>  d_interface_sp;
-    PendingConnectionMap              d_pendingConnections;
-    ListenerSocketMap                 d_listenerSockets;
-    StreamSocketMap                   d_streamSockets;
-    bslmt::Condition                  d_linger;
-    bslma::Allocator                 *d_allocator_p;
+    mutable bslmt::Mutex             d_mutex;
+    bsl::shared_ptr<ntci::Interface> d_interface_sp;
+    PendingConnectionMap             d_pendingConnections;
+    ListenerSocketMap                d_listenerSockets;
+    StreamSocketMap                  d_streamSockets;
+    bslmt::Condition                 d_linger;
+    bslma::Allocator*                d_allocator_p;
 
   private:
-    
     Server(const Server&) BSLS_KEYWORD_DELETED;
     Server& operator=(const Server&) BSLS_KEYWORD_DELETED;
 
   private:
-    
     void processListenerSocketEstablished(
-                   const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket)
+        const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket)
         BSLS_KEYWORD_OVERRIDE;
-        // Process the establishment of the specified 'listenerSocket'.
+    // Process the establishment of the specified 'listenerSocket'.
 
     void processListenerSocketClosed(
-                   const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket)
+        const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket)
         BSLS_KEYWORD_OVERRIDE;
-        // Process the closure of the specified 'listenerSocket'.
+    // Process the closure of the specified 'listenerSocket'.
 
-    
     void processStreamSocketEstablished(
-                       const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
         BSLS_KEYWORD_OVERRIDE;
-        // Process the establishment of the specified 'streamSocket'. Return
-        // the application protocol of the 'streamSocket'.
+    // Process the establishment of the specified 'streamSocket'. Return
+    // the application protocol of the 'streamSocket'.
 
     // Process the closure of the specified 'streamSocket'.
     void processStreamSocketClosed(const bsl::shared_ptr<ntci::StreamSocket>&
                                        streamSocket) BSLS_KEYWORD_OVERRIDE;
 
   public:
-    
-
     // Create a new server that creates listener and stream sockets using
     // the specified 'interface'. Optionally specify a 'basicAllocator'
     // used to supply memory. If 'basicAllocator' is 0, the currently
     // installed default allocator is used.
-    explicit Server(
-                  const bsl::shared_ptr<ntci::Interface>&  interface,
-                  bslma::Allocator                        *basicAllocator = 0);
+    explicit Server(const bsl::shared_ptr<ntci::Interface>& interface,
+                    bslma::Allocator* basicAllocator = 0);
 
     // Destroy this object.
     ~Server() BSLS_KEYWORD_OVERRIDE;
-
-    
 
     // Begin listening for connections to the specified 'sourceEndpoint'
     // and invoke the specified 'callback' when the listener has
@@ -1440,13 +1287,8 @@ class Server : public ntci::ListenerSocketManager,
 // Now, let's define the implementation of the server.
 //
 
-                                
-                                
-                                
-
-
 void Server::processListenerSocketEstablished(
-                   const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket)
+    const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket)
 {
     bsl::shared_ptr<example::ListenerSocket> listenerSocketSession;
     {
@@ -1465,7 +1307,7 @@ void Server::processListenerSocketEstablished(
 }
 
 void Server::processListenerSocketClosed(
-                   const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket)
+    const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket)
 {
     bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
 
@@ -1480,14 +1322,14 @@ void Server::processListenerSocketClosed(
     }
 
     if (d_pendingConnections.empty() && d_listenerSockets.empty() &&
-        d_streamSockets.empty()) {
+        d_streamSockets.empty())
+    {
         d_linger.signal();
     }
 }
 
-
 void Server::processStreamSocketEstablished(
-                       const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
 {
     bsl::shared_ptr<example::ServerSocket> serverSocket;
     serverSocket.createInplace(d_allocator_p, streamSocket, d_allocator_p);
@@ -1506,7 +1348,7 @@ void Server::processStreamSocketEstablished(
 }
 
 void Server::processStreamSocketClosed(
-                       const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
 {
     bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
 
@@ -1514,14 +1356,14 @@ void Server::processStreamSocketClosed(
     BSLS_ASSERT_OPT(n == 1);
 
     if (d_pendingConnections.empty() && d_listenerSockets.empty() &&
-        d_streamSockets.empty()) {
+        d_streamSockets.empty())
+    {
         d_linger.signal();
     }
 }
 
-
-Server::Server(const bsl::shared_ptr<ntci::Interface>&  interface,
-               bslma::Allocator                        *basicAllocator)
+Server::Server(const bsl::shared_ptr<ntci::Interface>& interface,
+               bslma::Allocator*                       basicAllocator)
 : d_mutex()
 , d_interface_sp(interface)
 , d_pendingConnections(basicAllocator)
@@ -1536,7 +1378,6 @@ Server::~Server()
 {
 }
 
-
 ntsa::Endpoint Server::listen(const ntsa::Endpoint&       sourceEndpoint,
                               const ServerSocketCallback& callback)
 {
@@ -1546,8 +1387,8 @@ ntsa::Endpoint Server::listen(const ntsa::Endpoint&       sourceEndpoint,
     listenerSocketOptions.setSourceEndpoint(sourceEndpoint);
 
     bsl::shared_ptr<ntci::ListenerSocket> listenerSocket =
-                    d_interface_sp->createListenerSocket(listenerSocketOptions,
-                                                         d_allocator_p);
+        d_interface_sp->createListenerSocket(listenerSocketOptions,
+                                             d_allocator_p);
 
     listenerSocket->registerManager(this->getSelf(this));
     listenerSocket->registerSession(this->getSelf(this));
@@ -1578,13 +1419,15 @@ void Server::shutdown()
 
     for (ListenerSocketMap::iterator it = listenerSockets.begin();
          it != listenerSockets.end();
-         ++it) {
+         ++it)
+    {
         it->first->close();
     }
 
     for (StreamSocketMap::iterator it = streamSockets.begin();
          it != streamSockets.end();
-         ++it) {
+         ++it)
+    {
         it->first->close();
     }
 }
@@ -1593,7 +1436,8 @@ void Server::linger()
 {
     bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
     while (!d_pendingConnections.empty() || !d_listenerSockets.empty() ||
-           !d_streamSockets.empty()) {
+           !d_streamSockets.empty())
+    {
         d_linger.wait(&d_mutex);
     }
 }
@@ -1607,10 +1451,10 @@ void Server::linger()
 //
 
 void processServerSocketEstablished(
-                   const bsl::shared_ptr<example::Server>&        server,
-                   const bsl::shared_ptr<example::ServerSocket>&  serverSocket,
-                   bslmt::Semaphore                              *semaphore,
-                   bsl::shared_ptr<example::ServerSocket>        *result)
+    const bsl::shared_ptr<example::Server>&       server,
+    const bsl::shared_ptr<example::ServerSocket>& serverSocket,
+    bslmt::Semaphore*                             semaphore,
+    bsl::shared_ptr<example::ServerSocket>*       result)
 {
     NTCCFG_WARNING_UNUSED(server);
 
@@ -1619,9 +1463,9 @@ void processServerSocketEstablished(
 }
 
 void processServerSocketEvent(
-                   const bsl::shared_ptr<example::Server>&        server,
-                   const bsl::shared_ptr<example::ServerSocket>&  serverSocket,
-                   bslmt::Semaphore                              *semaphore)
+    const bsl::shared_ptr<example::Server>&       server,
+    const bsl::shared_ptr<example::ServerSocket>& serverSocket,
+    bslmt::Semaphore*                             semaphore)
 {
     NTCCFG_WARNING_UNUSED(server);
     NTCCFG_WARNING_UNUSED(serverSocket);
@@ -1630,10 +1474,10 @@ void processServerSocketEvent(
 }
 
 void processClientSocketEstablished(
-                   const bsl::shared_ptr<example::Client>&        client,
-                   const bsl::shared_ptr<example::ClientSocket>&  clientSocket,
-                   bslmt::Semaphore                              *semaphore,
-                   bsl::shared_ptr<example::ClientSocket>        *result)
+    const bsl::shared_ptr<example::Client>&       client,
+    const bsl::shared_ptr<example::ClientSocket>& clientSocket,
+    bslmt::Semaphore*                             semaphore,
+    bsl::shared_ptr<example::ClientSocket>*       result)
 {
     NTCCFG_WARNING_UNUSED(client);
 
@@ -1642,9 +1486,9 @@ void processClientSocketEstablished(
 }
 
 void processClientSocketEvent(
-                   const bsl::shared_ptr<example::Client>&        client,
-                   const bsl::shared_ptr<example::ClientSocket>&  clientSocket,
-                   bslmt::Semaphore                              *semaphore)
+    const bsl::shared_ptr<example::Client>&       client,
+    const bsl::shared_ptr<example::ClientSocket>& clientSocket,
+    bslmt::Semaphore*                             semaphore)
 {
     NTCCFG_WARNING_UNUSED(client);
     NTCCFG_WARNING_UNUSED(clientSocket);
@@ -1652,9 +1496,9 @@ void processClientSocketEvent(
     semaphore->post();
 }
 
-void processClientResponseReceived(bsl::string        *result,
-                                   bslmt::Latch       *resultLatch,
-                                   const bsl::string&  response)
+void processClientResponseReceived(bsl::string*       result,
+                                   bslmt::Latch*      resultLatch,
+                                   const bsl::string& response)
 {
     // Store the response received and indicate a response was received.
 
@@ -1683,7 +1527,7 @@ void execute()
 {
 #if defined(BSLS_PLATFORM_OS_UNIX)
 
-    bslma::Allocator *allocator = bslma::Default::defaultAllocator();
+    bslma::Allocator* allocator = bslma::Default::defaultAllocator();
 
     // Create an asynchronous socket interface running two I/O threads.
 
@@ -1693,7 +1537,7 @@ void execute()
     interfaceConfig.setMaxThreads(2);
 
     bsl::shared_ptr<ntci::Interface> interface =
-                     ntcf::System::createInterface(interfaceConfig, allocator);
+        ntcf::System::createInterface(interfaceConfig, allocator);
 
     interface->start();
 
@@ -1707,16 +1551,19 @@ void execute()
     bsl::shared_ptr<example::ServerSocket> serverSocket;
     bslmt::Semaphore                       serverEstablished;
 
-    ntsa::Endpoint listenerEndpoint =
-                             ntsa::Endpoint(ntsa::LocalName::generateUnique());
+    ntsa::LocalName localName;
+    const ntsa::Error error = ntsa::LocalName::generateUnique(&localName);
+    BSLS_ASSERT_OPT(!error);
 
-    listenerEndpoint = server->listen(
-                          listenerEndpoint,
-                          NTCCFG_BIND(&example::processServerSocketEstablished,
-                                      server,
-                                      NTCCFG_BIND_PLACEHOLDER_1,
-                                      &serverEstablished,
-                                      &serverSocket));
+    ntsa::Endpoint listenerEndpoint = ntsa::Endpoint(localName);
+
+    listenerEndpoint =
+        server->listen(listenerEndpoint,
+                       NTCCFG_BIND(&example::processServerSocketEstablished,
+                                   server,
+                                   NTCCFG_BIND_PLACEHOLDER_1,
+                                   &serverEstablished,
+                                   &serverSocket));
 
     // Create a client of the application wire protocol and begin connecting
     // to the server.
@@ -1824,7 +1671,7 @@ void execute()
 #if defined(BSLS_PLATFORM_OS_UNIX)
 #if NTCU12_BUILD_WITH_TLS
 
-    bslma::Allocator *allocator = bslma::Default::defaultAllocator();
+    bslma::Allocator* allocator = bslma::Default::defaultAllocator();
 
     ntsa::Error error;
 
@@ -1836,7 +1683,7 @@ void execute()
     interfaceConfig.setMaxThreads(2);
 
     bsl::shared_ptr<ntci::Interface> interface =
-                     ntcf::System::createInterface(interfaceConfig, allocator);
+        ntcf::System::createInterface(interfaceConfig, allocator);
 
     interface->start();
 
@@ -1897,7 +1744,7 @@ void execute()
     encryptionServerOptions.setMinMethod(ntca::EncryptionMethod::e_TLS_V1_X);
     encryptionServerOptions.setMaxMethod(ntca::EncryptionMethod::e_TLS_V1_X);
     encryptionServerOptions.setAuthentication(
-                                       ntca::EncryptionAuthentication::e_NONE);
+        ntca::EncryptionAuthentication::e_NONE);
 
     {
         bsl::vector<char> identityData;
@@ -1925,7 +1772,7 @@ void execute()
     encryptionClientOptions.setMinMethod(ntca::EncryptionMethod::e_TLS_V1_2);
     encryptionClientOptions.setMaxMethod(ntca::EncryptionMethod::e_TLS_V1_2);
     encryptionClientOptions.setAuthentication(
-                                     ntca::EncryptionAuthentication::e_VERIFY);
+        ntca::EncryptionAuthentication::e_VERIFY);
 
     {
         bsl::vector<char> authorityData;
@@ -1949,15 +1796,15 @@ void execute()
     bslmt::Semaphore                       serverEstablished;
 
     ntsa::Endpoint listenerEndpoint =
-                             ntsa::Endpoint(ntsa::LocalName::generateUnique());
+        ntsa::Endpoint(ntsa::LocalName::generateUnique());
 
-    listenerEndpoint = server->listen(
-                          listenerEndpoint,
-                          NTCCFG_BIND(&example::processServerSocketEstablished,
-                                      server,
-                                      NTCCFG_BIND_PLACEHOLDER_1,
-                                      &serverEstablished,
-                                      &serverSocket));
+    listenerEndpoint =
+        server->listen(listenerEndpoint,
+                       NTCCFG_BIND(&example::processServerSocketEstablished,
+                                   server,
+                                   NTCCFG_BIND_PLACEHOLDER_1,
+                                   &serverEstablished,
+                                   &serverSocket));
 
     // Create a client of the application wire protocol and begin connecting
     // to the server.
@@ -2052,7 +1899,7 @@ void execute()
 
     {
         bsl::shared_ptr<ntci::EncryptionCertificate> peerCertificate =
-                                             clientSocket->remoteCertificate();
+            clientSocket->remoteCertificate();
 
         bsl::stringstream ss;
         peerCertificate->print(ss);
@@ -2211,7 +2058,7 @@ void help()
     bsl::cout << "usage: <program>> [-v <level>]" << bsl::endl;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     ntcf::System::initialize();
     ntcf::System::ignore(ntscfg::Signal::e_PIPE);
@@ -2221,13 +2068,15 @@ int main(int argc, char **argv)
         int i = 1;
         while (i < argc) {
             if ((0 == std::strcmp(argv[i], "-?")) ||
-                (0 == std::strcmp(argv[i], "--help"))) {
+                (0 == std::strcmp(argv[i], "--help")))
+            {
                 help();
                 return 0;
             }
 
             if (0 == std::strcmp(argv[i], "-v") ||
-                0 == std::strcmp(argv[i], "--verbosity")) {
+                0 == std::strcmp(argv[i], "--verbosity"))
+            {
                 ++i;
                 if (i >= argc) {
                     help();
@@ -2244,21 +2093,21 @@ int main(int argc, char **argv)
     }
 
     switch (verbosity) {
-      case 0:
+    case 0:
         break;
-      case 1:
+    case 1:
         bsls::Log::setSeverityThreshold(bsls::LogSeverity::e_ERROR);
         break;
-      case 2:
+    case 2:
         bsls::Log::setSeverityThreshold(bsls::LogSeverity::e_WARN);
         break;
-      case 3:
+    case 3:
         bsls::Log::setSeverityThreshold(bsls::LogSeverity::e_INFO);
         break;
-      case 4:
+    case 4:
         bsls::Log::setSeverityThreshold(bsls::LogSeverity::e_DEBUG);
         break;
-      default:
+    default:
         bsls::Log::setSeverityThreshold(bsls::LogSeverity::e_TRACE);
         break;
     }

--- a/examples/m_ntsu03/ntsu03.m.cpp
+++ b/examples/m_ntsu03/ntsu03.m.cpp
@@ -42,13 +42,16 @@ int main()
     // address, then begin listening for connections.
 
     bsl::shared_ptr<ntsi::ListenerSocket> listener =
-                                          ntsf::System::createListenerSocket();
+        ntsf::System::createListenerSocket();
 
     error = listener->open(ntsa::Transport::e_LOCAL_STREAM);
     BSLS_ASSERT_OPT(!error);
 
-    error = listener->bind(ntsa::Endpoint(ntsa::LocalName::generateUnique()),
-                           false);
+    ntsa::LocalName localName;
+    error = ntsa::LocalName::generateUnique(&localName);
+    BSLS_ASSERT_OPT(!error);
+
+    error = listener->bind(ntsa::Endpoint(localName), false);
     BSLS_ASSERT_OPT(!error);
 
     error = listener->listen(1);
@@ -62,7 +65,7 @@ int main()
     // the listener socket's local endpoint.
 
     bsl::shared_ptr<ntsi::StreamSocket> client =
-                                            ntsf::System::createStreamSocket();
+        ntsf::System::createStreamSocket();
 
     error = client->open(ntsa::Transport::e_LOCAL_STREAM);
     BSLS_ASSERT_OPT(!error);

--- a/examples/m_ntsu06/ntsu06.m.cpp
+++ b/examples/m_ntsu06/ntsu06.m.cpp
@@ -39,14 +39,19 @@ int main()
     // loopback address.
 
     bsl::shared_ptr<ntsi::DatagramSocket> server =
-                                          ntsf::System::createDatagramSocket();
+        ntsf::System::createDatagramSocket();
 
     error = server->open(ntsa::Transport::e_LOCAL_DATAGRAM);
     BSLS_ASSERT_OPT(!error);
 
-    error = server->bind(ntsa::Endpoint(ntsa::LocalName::generateUnique()),
-                         false);
-    BSLS_ASSERT_OPT(!error);
+    {
+        ntsa::LocalName localName;
+        error = ntsa::LocalName::generateUnique(&localName);
+        BSLS_ASSERT_OPT(!error);
+
+        error = server->bind(ntsa::Endpoint(localName), false);
+        BSLS_ASSERT_OPT(!error);
+    }
 
     ntsa::Endpoint serverEndpoint;
     error = server->sourceEndpoint(&serverEndpoint);
@@ -56,14 +61,19 @@ int main()
     // loopback address.
 
     bsl::shared_ptr<ntsi::DatagramSocket> client =
-                                          ntsf::System::createDatagramSocket();
+        ntsf::System::createDatagramSocket();
 
     error = client->open(ntsa::Transport::e_LOCAL_DATAGRAM);
     BSLS_ASSERT_OPT(!error);
 
-    error = client->bind(ntsa::Endpoint(ntsa::LocalName::generateUnique()),
-                         false);
-    BSLS_ASSERT_OPT(!error);
+    {
+        ntsa::LocalName localName;
+        error = ntsa::LocalName::generateUnique(&localName);
+        BSLS_ASSERT_OPT(!error);
+
+        error = client->bind(ntsa::Endpoint(localName), false);
+        BSLS_ASSERT_OPT(!error);
+    }
 
     ntsa::Endpoint clientEndpoint;
     error = client->sourceEndpoint(&clientEndpoint);

--- a/groups/ntc/ntcd/ntcd_machine.cpp
+++ b/groups/ntc/ntcd/ntcd_machine.cpp
@@ -400,7 +400,7 @@ void generateTransmitTimestampScheduled(
     bsl::uint32_t                                   idIncrement)
 {
     *tsKey                       += idIncrement;
-    const bsl::uint32_t packetId = *tsKey - 1;
+    const bsl::uint32_t packetId  = *tsKey - 1;
     packet->setId(packetId);
     ntsa::Notification n;
     ntsa::Timestamp&   t = n.makeTimestamp();
@@ -1198,7 +1198,7 @@ void PacketQueue::retry(const PacketVector& packetVector)
          it != packetVector.end();
          ++it)
     {
-        const bsl::shared_ptr<ntcd::Packet>& packet = *it;
+        const bsl::shared_ptr<ntcd::Packet>& packet  = *it;
         totalPacketCost                             += packet->cost();
     }
 
@@ -1438,7 +1438,10 @@ ntsa::Endpoint Binding::makeAny(ntsa::Transport::Value transport)
     else if (transport == ntsa::Transport::e_LOCAL_DATAGRAM ||
              transport == ntsa::Transport::e_LOCAL_STREAM)
     {
-        result = ntsa::Endpoint(ntsa::LocalName::generateUnique());
+        ntsa::LocalName   localName;
+        const ntsa::Error error = ntsa::LocalName::generateUnique(&localName);
+        BSLS_ASSERT_OPT(!error);
+        result = ntsa::Endpoint(localName);
     }
 
     return result;
@@ -2290,7 +2293,12 @@ ntsa::Error Session::bindAny(ntsa::Transport::Value transport,
             ntsa::Endpoint(ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0));
     }
     else if (transportDomain == ntsa::TransportDomain::e_LOCAL) {
-        endpoint = ntsa::Endpoint(ntsa::LocalName::generateUnique());
+        ntsa::LocalName   localName;
+        const ntsa::Error error = ntsa::LocalName::generateUnique(&localName);
+        if (error) {
+            return error;
+        }
+        endpoint = ntsa::Endpoint(localName);
     }
     else {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -2473,8 +2481,13 @@ ntsa::Error Session::connect(const ntsa::Endpoint& endpoint)
                 ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0));
         }
         else if (transportDomain == ntsa::TransportDomain::e_LOCAL) {
-            sourceEndpointRequested =
-                ntsa::Endpoint(ntsa::LocalName::generateUnique());
+            ntsa::LocalName   localName;
+            const ntsa::Error error =
+                ntsa::LocalName::generateUnique(&localName);
+            if (error) {
+                return error;
+            }
+            sourceEndpointRequested = ntsa::Endpoint(localName);
         }
         else {
             return ntsa::Error(ntsa::Error::e_INVALID);
@@ -2663,8 +2676,13 @@ ntsa::Error Session::send(ntsa::SendContext*       context,
                     ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0));
             }
             else if (transportDomain == ntsa::TransportDomain::e_LOCAL) {
-                sourceEndpointRequested =
-                    ntsa::Endpoint(ntsa::LocalName::generateUnique());
+                ntsa::LocalName   localName;
+                const ntsa::Error error =
+                    ntsa::LocalName::generateUnique(&localName);
+                if (error) {
+                    return error;
+                }
+                sourceEndpointRequested = ntsa::Endpoint(localName);
             }
             else {
                 return ntsa::Error(ntsa::Error::e_INVALID);
@@ -2891,8 +2909,13 @@ ntsa::Error Session::send(ntsa::SendContext*       context,
                     ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0));
             }
             else if (transportDomain == ntsa::TransportDomain::e_LOCAL) {
-                sourceEndpointRequested =
-                    ntsa::Endpoint(ntsa::LocalName::generateUnique());
+                ntsa::LocalName   localName;
+                const ntsa::Error error =
+                    ntsa::LocalName::generateUnique(&localName);
+                if (error) {
+                    return error;
+                }
+                sourceEndpointRequested = ntsa::Endpoint(localName);
             }
             else {
                 return ntsa::Error(ntsa::Error::e_INVALID);
@@ -5104,7 +5127,7 @@ void Monitor::interruptAll()
     bsl::uint64_t waiters   = d_waiters.load();
 
     if (interrupt < waiters) {
-        bsl::uint64_t difference = waiters - interrupt;
+        bsl::uint64_t difference  = waiters - interrupt;
         d_interrupt              += difference;
         d_condition.broadcast();
     }
@@ -5120,7 +5143,7 @@ void Monitor::stop()
     bsl::uint64_t waiters   = d_waiters.load();
 
     if (interrupt < waiters) {
-        bsl::uint64_t difference = waiters - interrupt;
+        bsl::uint64_t difference  = waiters - interrupt;
         d_interrupt              += difference;
         d_condition.broadcast();
     }

--- a/groups/ntc/ntcdns/ntcdns_client.cpp
+++ b/groups/ntc/ntcdns/ntcdns_client.cpp
@@ -1244,8 +1244,12 @@ ntsa::Error ClientNameServer::createDatagramSocket()
         }
     }
     else if (d_endpoint.isLocal()) {
-        datagramSocketOptions.setSourceEndpoint(
-            ntsa::Endpoint(ntsa::LocalName::generateUnique()));
+        ntsa::LocalName   localName;
+        const ntsa::Error error = ntsa::LocalName::generateUnique(&localName);
+        if (error) {
+            return error;
+        }
+        datagramSocketOptions.setSourceEndpoint(ntsa::Endpoint(localName));
     }
     else {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -1315,8 +1319,12 @@ ntsa::Error ClientNameServer::createStreamSocket()
         }
     }
     else if (d_endpoint.isLocal()) {
-        streamSocketOptions.setSourceEndpoint(
-            ntsa::Endpoint(ntsa::LocalName::generateUnique()));
+        ntsa::LocalName   localName;
+        const ntsa::Error error = ntsa::LocalName::generateUnique(&localName);
+        if (error) {
+            return error;
+        }
+        streamSocketOptions.setSourceEndpoint(ntsa::Endpoint(localName));
     }
     else {
         return ntsa::Error(ntsa::Error::e_INVALID);

--- a/groups/ntc/ntcf/ntcf_test.cpp
+++ b/groups/ntc/ntcf/ntcf_test.cpp
@@ -83,7 +83,11 @@ ntsa::Error Test::createStreamSocketPair(
             ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0)));
     }
     else if (transport == ntsa::Transport::e_LOCAL_STREAM) {
-        ntsa::LocalName localName = ntsa::LocalName::generateUnique();
+        ntsa::LocalName   localName;
+        const ntsa::Error error = ntsa::LocalName::generateUnique(&localName);
+        if (error) {
+            return error;
+        }
         listenerSocketOptions.setSourceEndpoint(ntsa::Endpoint(localName));
     }
     else {

--- a/groups/ntc/ntcp/ntcp_datagramsocket.t.cpp
+++ b/groups/ntc/ntcp/ntcp_datagramsocket.t.cpp
@@ -243,9 +243,14 @@ ntsa::Endpoint EndpointUtil::any(ntsa::Transport::Value transport)
         endpoint.makeIp(ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0));
         break;
     case ntsa::Transport::e_LOCAL_STREAM:
-    case ntsa::Transport::e_LOCAL_DATAGRAM:
-        endpoint.makeLocal(ntsa::LocalName::generateUnique());
+    case ntsa::Transport::e_LOCAL_DATAGRAM: {
+        ntsa::LocalName   localName;
+        const ntsa::Error error = ntsa::LocalName::generateUnique(&localName);
+        BSLS_ASSERT_OPT(!error);
+
+        endpoint.makeLocal(localName);
         break;
+    }
     default:
         NTCCFG_UNREACHABLE();
     }

--- a/groups/ntc/ntcp/ntcp_listenersocket.t.cpp
+++ b/groups/ntc/ntcp/ntcp_listenersocket.t.cpp
@@ -244,9 +244,14 @@ ntsa::Endpoint EndpointUtil::any(ntsa::Transport::Value transport)
         endpoint.makeIp(ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0));
         break;
     case ntsa::Transport::e_LOCAL_STREAM:
-    case ntsa::Transport::e_LOCAL_DATAGRAM:
-        endpoint.makeLocal(ntsa::LocalName::generateUnique());
+    case ntsa::Transport::e_LOCAL_DATAGRAM: {
+        ntsa::LocalName   localName;
+        const ntsa::Error error = ntsa::LocalName::generateUnique(&localName);
+        BSLS_ASSERT_OPT(!error);
+
+        endpoint.makeLocal(localName);
         break;
+    }
     default:
         NTCCFG_UNREACHABLE();
     }

--- a/groups/ntc/ntcp/ntcp_streamsocket.t.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.t.cpp
@@ -248,9 +248,14 @@ ntsa::Endpoint EndpointUtil::any(ntsa::Transport::Value transport)
         endpoint.makeIp(ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0));
         break;
     case ntsa::Transport::e_LOCAL_STREAM:
-    case ntsa::Transport::e_LOCAL_DATAGRAM:
-        endpoint.makeLocal(ntsa::LocalName::generateUnique());
+    case ntsa::Transport::e_LOCAL_DATAGRAM: {
+        ntsa::LocalName   localName;
+        const ntsa::Error error = ntsa::LocalName::generateUnique(&localName);
+        BSLS_ASSERT_OPT(!error);
+
+        endpoint.makeLocal(localName);
         break;
+    }
     default:
         NTCCFG_UNREACHABLE();
     }

--- a/groups/ntc/ntcr/ntcr_datagramsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.t.cpp
@@ -277,9 +277,14 @@ ntsa::Endpoint EndpointUtil::any(ntsa::Transport::Value transport)
         endpoint.makeIp(ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0));
         break;
     case ntsa::Transport::e_LOCAL_STREAM:
-    case ntsa::Transport::e_LOCAL_DATAGRAM:
-        endpoint.makeLocal(ntsa::LocalName::generateUnique());
+    case ntsa::Transport::e_LOCAL_DATAGRAM: {
+        ntsa::LocalName   localName;
+        const ntsa::Error error = ntsa::LocalName::generateUnique(&localName);
+        BSLS_ASSERT_OPT(!error);
+
+        endpoint.makeLocal(localName);
         break;
+    }
     default:
         NTCCFG_UNREACHABLE();
     }
@@ -1186,8 +1191,6 @@ void DatagramSocketManager::run()
              it != monitorables.end();
              ++it)
         {
-
-
             bdld::ManagedDatum stats;
             (*it)->getStats(&stats);
             const bdld::Datum& d = stats.datum();

--- a/groups/ntc/ntcr/ntcr_listenersocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_listenersocket.t.cpp
@@ -247,9 +247,14 @@ ntsa::Endpoint EndpointUtil::any(ntsa::Transport::Value transport)
         endpoint.makeIp(ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0));
         break;
     case ntsa::Transport::e_LOCAL_STREAM:
-    case ntsa::Transport::e_LOCAL_DATAGRAM:
-        endpoint.makeLocal(ntsa::LocalName::generateUnique());
+    case ntsa::Transport::e_LOCAL_DATAGRAM: {
+        ntsa::LocalName   localName;
+        const ntsa::Error error = ntsa::LocalName::generateUnique(&localName);
+        BSLS_ASSERT_OPT(!error);
+
+        endpoint.makeLocal(localName);
         break;
+    }
     default:
         NTCCFG_UNREACHABLE();
     }

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -283,9 +283,14 @@ ntsa::Endpoint EndpointUtil::any(ntsa::Transport::Value transport)
         endpoint.makeIp(ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0));
         break;
     case ntsa::Transport::e_LOCAL_STREAM:
-    case ntsa::Transport::e_LOCAL_DATAGRAM:
-        endpoint.makeLocal(ntsa::LocalName::generateUnique());
+    case ntsa::Transport::e_LOCAL_DATAGRAM: {
+        ntsa::LocalName localName;
+        const ntsa::Error error = ntsa::LocalName::generateUnique(&localName);
+        BSLS_ASSERT_OPT(!error);
+
+        endpoint.makeLocal(localName);
         break;
+    }
     default:
         NTCCFG_UNREACHABLE();
     }

--- a/groups/nts/ntsa/ntsa_localname.cpp
+++ b/groups/nts/ntsa/ntsa_localname.cpp
@@ -50,7 +50,11 @@ LocalName::LocalName()
 , d_abstract(false)
 {
     bsl::memset(d_path, 0, k_MAX_PATH_LENGTH);
+#if defined(BSLS_PLATFORM_OS_AIX)
+    BSLMF_ASSERT(k_MAX_PATH_LENGTH <= (sizeof(sockaddr_un::sun_path) - 1));
+#else
     BSLMF_ASSERT(k_MAX_PATH_LENGTH == (sizeof(sockaddr_un::sun_path) - 1));
+#endif
 }
 
 LocalName::LocalName(const LocalName& other)

--- a/groups/nts/ntsa/ntsa_localname.cpp
+++ b/groups/nts/ntsa/ntsa_localname.cpp
@@ -20,6 +20,8 @@ BSLS_IDENT_RCSID(ntsa_localname_cpp, "$Id$ $CSID$")
 
 #include <bdlb_guid.h>
 #include <bdlb_guidutil.h>
+#include <bdls_filesystemutil.h>
+#include <bdls_pathutil.h>
 
 #include <bslim_printer.h>
 #include <bslmf_assert.h>
@@ -29,22 +31,29 @@ BSLS_IDENT_RCSID(ntsa_localname_cpp, "$Id$ $CSID$")
 
 #if defined(BSLS_PLATFORM_OS_UNIX)
 #include <errno.h>
+#include <sys/un.h>
 #endif
 
 #if defined(BSLS_PLATFORM_OS_WINDOWS)
 #include <windows.h>
+#include <ws2def.h>
+#endif
+#if defined(BSLS_PLATFORM_OS_WINDOWS)
+#include <afunix.h>
 #endif
 
 namespace BloombergLP {
 namespace ntsa {
 
+const bsl::size_t LocalName::k_MAX_PATH_LENGTH =
+    sizeof(sockaddr_un::sun_path) - 1;
+
 LocalName::LocalName()
 : d_size(0)
-, d_abstract(0)
-, d_unused(0)
+, d_abstract(false)
 {
-    BSLMF_ASSERT(sizeof(LocalName) == sizeof d_path + 1 + 1 + 1);
-    BSLMF_ASSERT(sizeof(LocalName) == 96);
+    bsl::memset(d_path, 0, k_CAPACITY);
+    BSLMF_ASSERT(k_MAX_PATH_LENGTH <= k_CAPACITY);
 }
 
 LocalName::LocalName(const LocalName& other)
@@ -67,25 +76,25 @@ LocalName& LocalName::operator=(const LocalName& other)
 
 void LocalName::reset()
 {
+    bsl::memset(d_path, 0, k_CAPACITY);
     d_size     = 0;
-    d_abstract = 0;
-    d_unused   = 0;
+    d_abstract = false;
 }
 
 ntsa::Error LocalName::setAbstract()
 {
 #if defined(BSLS_PLATFORM_OS_LINUX)
-    d_abstract = 1;
+    d_abstract = true;
     return ntsa::Error();
 #else
-    d_abstract = 0;
+    d_abstract = false;
     return ntsa::Error(ENOTSUP);
 #endif
 }
 
 ntsa::Error LocalName::setPersistent()
 {
-    d_abstract = 0;
+    d_abstract = false;
     return ntsa::Error();
 }
 
@@ -97,16 +106,15 @@ ntsa::Error LocalName::setUnnamed()
 
 ntsa::Error LocalName::setValue(const bslstl::StringRef& value)
 {
-    bsl::size_t size = value.size();
+    const bsl::size_t size = value.size();
 
     if (size > ntsa::LocalName::k_MAX_PATH_LENGTH) {
-        size = ntsa::LocalName::k_MAX_PATH_LENGTH;
+        return ntsa::Error(ntsa::Error::e_LIMIT);
     }
 
     bsl::memcpy(d_path, value.data(), size);
 
-    d_path[size] = 0;
-    d_size       = static_cast<bsl::uint8_t>(size);
+    d_size = static_cast<bsl::uint8_t>(size);
 
     return ntsa::Error();
 }
@@ -118,59 +126,17 @@ bslstl::StringRef LocalName::value() const
 
 bool LocalName::isAbstract() const
 {
-    return static_cast<bool>(d_abstract);
+    return d_abstract;
 }
 
 bool LocalName::isPersistent() const
 {
-    return !static_cast<bool>(d_abstract);
+    return !d_abstract;
 }
 
 bool LocalName::isAbsolute() const
 {
-#if defined(BSLS_PLATFORM_OS_UNIX)
-
-    if (d_size > 0) {
-        return d_path[0] == '/';
-    }
-    else {
-        return false;
-    }
-
-#elif defined(BSLS_PLATFORM_OS_WINDOWS)
-
-    // clang-format off
-    if (d_size > 0) {
-        if (d_path[0] == '/' || d_path[0] == '\\') {
-            return true;
-        }
-        else {
-            if (d_size > 3) {
-                if (((d_path[0] >= 'A' && d_path[0] <= 'Z') ||
-                     (d_path[0] >= 'a' && d_path[0] <= 'z')) 
-                     &&
-                     (d_path[1] == ':')
-                     &&
-                     (d_path[2] == '/' || d_path[2] == '\\')) {
-                    return true;
-                }
-                else {
-                    return false;
-                }
-            }
-            else {
-                return false;
-            }
-        }
-    }
-    else {
-        return false;
-    }
-    // clang-format on
-
-#else
-#error Not implemented
-#endif
+    return bdls::PathUtil::isAbsolute(d_path);
 }
 
 bool LocalName::isRelative() const
@@ -185,7 +151,15 @@ bool LocalName::isUnnamed() const
 
 bool LocalName::equals(const LocalName& other) const
 {
+    if (this == &other) {
+        return true;
+    }
+
     if (d_size != other.d_size) {
+        return false;
+    }
+
+    if (d_abstract != other.d_abstract) {
         return false;
     }
 
@@ -241,6 +215,9 @@ bsl::ostream& LocalName::print(bsl::ostream& stream,
     if (isUnnamed()) {
         stream << "(unnamed)";
     }
+    else if (isAbstract()) {
+        stream << "(abstract): " << bslstl::StringRef(d_path, d_size);
+    }
     else {
         stream << bslstl::StringRef(d_path, d_size);
     }
@@ -252,68 +229,44 @@ bsl::ostream& LocalName::print(bsl::ostream& stream,
 
 ntsa::LocalName LocalName::generateUnique()
 {
-#if defined(BSLS_PLATFORM_OS_UNIX)
+    ntsa::LocalName name;
+    ntsa::Error     error = generateUnique(&name);
+    if (error) {
+        abort();  //TODO;
+    }
+    return name;
+}
 
-    ntsa::LocalName localName;
+ntsa::Error LocalName::generateUnique(ntsa::LocalName* name)
+{
+    bsl::string path;
+    int         rc = bdls::FilesystemUtil::getSystemTemporaryDirectory(&path);
+    if (rc != 0) {
+#if defined(BSLS_PLATFORM_OS_UNIX)
+        path = "/tmp";
+#else
+        return ntsa::Error(ntsa::Error::e_INVALID);
+#endif
+    }
+
+    bdlb::Guid        guid = bdlb::GuidUtil::generate();
+    bsl::stringstream ss;
+    ss << "ntf-" << guid;
+
+    rc = bdls::PathUtil::appendIfValid(&path, ss.str());
+    if (rc != 0) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    name->reset();
 
 #if defined(BSLS_PLATFORM_OS_LINUX)
-    localName.setAbstract();
+    name->setAbstract();
 #endif
 
-    {
-        bdlb::Guid guid = bdlb::GuidUtil::generate();
+    ntsa::Error error = name->setValue(path);
 
-        const char* tmp = bsl::getenv("TMPDIR");
-        if (tmp == 0) {
-            tmp = "/tmp";
-        }
-
-        bsl::stringstream ss;
-        ss << tmp << "/ntf-" << guid;
-
-        localName.setValue(ss.str());
-    }
-
-    return localName;
-
-#elif defined(BSLS_PLATFORM_OS_WINDOWS)
-
-    ntsa::LocalName localName;
-
-    {
-        bdlb::Guid guid = bdlb::GuidUtil::generate();
-
-        bsl::stringstream ss;
-
-        const char* tmp = std::getenv("TMPDIR");
-        if (tmp != 0) {
-            ss << tmp << "/ntf-" << guid;
-        }
-        else {
-            char  buffer[MAX_PATH + 1];
-            DWORD rc = GetTempPathA(static_cast<DWORD>(sizeof buffer), buffer);
-            if (rc <= 0 || rc >= static_cast<DWORD>(sizeof buffer)) {
-                ss << "C:\\Windows\\Temp\\ntf-" << guid;
-            }
-            else {
-                ss << buffer;
-
-                if (buffer[rc - 1] != '/' && buffer[rc - 1] != '\\') {
-                    ss << '\\';
-                }
-
-                ss << "ntf-" << guid;
-            }
-        }
-
-        localName.setValue(ss.str());
-    }
-
-    return localName;
-
-#else
-#error Not implemented
-#endif
+    return error;
 }
 
 }  // close package namespace

--- a/groups/nts/ntsa/ntsa_localname.h
+++ b/groups/nts/ntsa/ntsa_localname.h
@@ -51,7 +51,11 @@ class LocalName
     /// enormously large size of sockaddr_un::sun_path == 1022 bytes, but
     /// it is considered unnecessary to store such large path inside the class.
 
+#if defined(BSLS_PLATFORM_OS_DARWIN)
+    enum { k_MAX_PATH_LENGTH = 103 };
+#else
     enum { k_MAX_PATH_LENGTH = 107 };
+#endif
 
   private:
     char         d_path[k_MAX_PATH_LENGTH];

--- a/groups/nts/ntsa/ntsa_localname.h
+++ b/groups/nts/ntsa/ntsa_localname.h
@@ -46,15 +46,14 @@ class LocalName
     /// include leading null, in case of real namespace it does not include the
     /// null terminator
 
-    static const bsl::size_t k_MAX_PATH_LENGTH;
+#if defined(BSLS_PLATFORM_OS_AIX)
+    enum { k_MAX_PATH_LENGTH = 1022 };
+#else
+    enum { k_MAX_PATH_LENGTH = 107 };
+#endif
 
   private:
-#if defined(BSLS_PLATFORM_OS_AIX)
-    enum { k_CAPACITY = 1022 };
-#else
-    enum { k_CAPACITY = 108 };
-#endif
-    char         d_path[k_CAPACITY];
+    char         d_path[k_MAX_PATH_LENGTH];
     bsl::uint8_t d_size;
     bool         d_abstract;
 

--- a/groups/nts/ntsa/ntsa_localname.h
+++ b/groups/nts/ntsa/ntsa_localname.h
@@ -43,14 +43,15 @@ class LocalName
 {
   public:
     /// The maximum path length, in case of abstract namespace it does not
-    /// include leading null, in case of real namespace it does not include the
-    /// null terminator
+    /// include leading null, in case of all namespaces it does not include
+    /// the null terminator
 
-#if defined(BSLS_PLATFORM_OS_AIX)
-    enum { k_MAX_PATH_LENGTH = 1022 };
-#else
+    /// On Linux, Windows and SunOS this value is assigned in a way to ensure
+    /// that capacity of sockaddr_un::sun_path is fully utilized. AIX has
+    /// enormously large size of sockaddr_un::sun_path == 1022 bytes, but
+    /// it is considered unnecessary to store such large path inside the class.
+
     enum { k_MAX_PATH_LENGTH = 107 };
-#endif
 
   private:
     char         d_path[k_MAX_PATH_LENGTH];
@@ -78,6 +79,10 @@ class LocalName
     /// Set the local name to be abstract. A socket bound to an abstract
     /// name does not have a representation in the file system. Return the
     /// error. Note that abstract local names are only supported on Linux.
+    /// Name in the abstract namespace requires a leading null character.
+    /// It is not stored inside the class instance, but if some name is
+    /// already stored then it is ensure that there is free space to place
+    /// a leading nul character
     ntsa::Error setAbstract();
 
     /// Set the local name to be persistent. A socket bound to a persistent
@@ -88,8 +93,9 @@ class LocalName
     ntsa::Error setUnnamed();
 
     /// Set the path of the local name to the specified 'value'. If length of
-    /// the 'value' is greater than k_MAX_PATH_LENGTH then operation is not
-    /// performed and error is returned.
+    /// the 'value' is greater than k_MAX_PATH_LENGTH , in case of abstract
+    /// name, (k_MAX_PATH_LEN - 1) then operation is not performed and error
+    /// is returned.
     ntsa::Error setValue(const bslstl::StringRef& value);
 
     /// Return the value of the local name.

--- a/groups/nts/ntsa/ntsa_localname.t.cpp
+++ b/groups/nts/ntsa/ntsa_localname.t.cpp
@@ -249,20 +249,33 @@ NTSCFG_TEST_CASE(4)
     {
         ntsa::LocalName localName;
         NTSCFG_TEST_OK(localName.setAbstract());
+        NTSCFG_TEST_ERROR(localName.setValue(ss.str()),
+                          ntsa::Error(ntsa::Error::Code::e_LIMIT));
+    }
+    {
+        ntsa::LocalName localName;
+        NTSCFG_TEST_OK(localName.setAbstract());
+        NTSCFG_TEST_OK(localName.setValue(
+            ss.str().substr(0, ntsa::LocalName::k_MAX_PATH_LENGTH - 1)));
+    }
+    {
+        ntsa::LocalName localName;
         NTSCFG_TEST_OK(localName.setValue(ss.str()));
+        NTSCFG_TEST_ERROR(localName.setAbstract(),
+                          ntsa::Error(ntsa::Error::Code::e_LIMIT));
     }
 #endif
 
     ss << 'x';  // now string length is k_MAX_PATH_LENGTH
     {
-        ntsa::LocalName localName;
+        ntsa::LocalName   localName;
         ntsa::Error::Code code = ntsa::Error::e_LIMIT;
         NTSCFG_TEST_ERROR(localName.setValue(ss.str()), ntsa::Error(code));
     }
 
     ss << 'x';  // now string length > k_MAX_PATH_LENGTH
     {
-        ntsa::LocalName localName;
+        ntsa::LocalName   localName;
         ntsa::Error::Code code = ntsa::Error::e_LIMIT;
         NTSCFG_TEST_ERROR(localName.setValue(ss.str()), ntsa::Error(code));
     }

--- a/groups/nts/ntsu/ntsu_socketutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.t.cpp
@@ -38,10 +38,10 @@
 #if defined(BSLS_PLATFORM_OS_LINUX)
 #include <linux/version.h>
 
-#include <sys/ioctl.h>
-#include <net/if.h>
 #include <linux/ethtool.h>
 #include <linux/sockios.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
 #endif
 
 using namespace BloombergLP;
@@ -84,7 +84,7 @@ class Storage
 bsl::uint32_t timestampingSupport(ntsa::Handle socket)
 {
     ntsa::Error error;
-    int rc;
+    int         rc;
 
     struct ::ethtool_ts_info info;
     bsl::memset(&info, 0, sizeof info);
@@ -100,7 +100,7 @@ bsl::uint32_t timestampingSupport(ntsa::Handle socket)
     rc = ::ioctl(socket, SIOCETHTOOL, &ifr);
     if (rc != 0) {
         error = ntsa::Error(errno);
-        BSLS_LOG_DEBUG("I/O control SIOCETHTOOL failed: %s", 
+        BSLS_LOG_DEBUG("I/O control SIOCETHTOOL failed: %s",
                        error.text().c_str());
         return 0;
     }
@@ -213,10 +213,13 @@ void executeStreamSocketTest(const StreamSocketTestCallback& test,
             NTSCFG_TEST_ASSERT(!error);
         }
         else if (transport == ntsa::Transport::e_LOCAL_STREAM) {
-            error = ntsu::SocketUtil::bind(
-                ntsa::Endpoint(ntsa::LocalName::generateUnique()),
-                false,
-                listener);
+            ntsa::LocalName localName;
+            error = ntsa::LocalName::generateUnique(&localName);
+            NTSCFG_TEST_ASSERT(!error);
+
+            error = ntsu::SocketUtil::bind(ntsa::Endpoint(localName),
+                                           false,
+                                           listener);
             NTSCFG_TEST_ASSERT(!error);
         }
         else {
@@ -366,10 +369,13 @@ void executeDatagramSocketTest(const DatagramSocketTestCallback& test,
             NTSCFG_TEST_ASSERT(!error);
         }
         else if (transport == ntsa::Transport::e_LOCAL_DATAGRAM) {
-            error = ntsu::SocketUtil::bind(
-                ntsa::Endpoint(ntsa::LocalName::generateUnique()),
-                false,
-                server);
+            ntsa::LocalName localName;
+            error = ntsa::LocalName::generateUnique(&localName);
+            NTSCFG_TEST_ASSERT(!error);
+
+            error = ntsu::SocketUtil::bind(ntsa::Endpoint(localName),
+                                           false,
+                                           server);
             NTSCFG_TEST_ASSERT(!error);
         }
         else {
@@ -402,10 +408,13 @@ void executeDatagramSocketTest(const DatagramSocketTestCallback& test,
             NTSCFG_TEST_ASSERT(!error);
         }
         else if (transport == ntsa::Transport::e_LOCAL_DATAGRAM) {
-            error = ntsu::SocketUtil::bind(
-                ntsa::Endpoint(ntsa::LocalName::generateUnique()),
-                false,
-                client);
+            ntsa::LocalName localName;
+            error = ntsa::LocalName::generateUnique(&localName);
+            NTSCFG_TEST_ASSERT(!error);
+
+            error = ntsu::SocketUtil::bind(ntsa::Endpoint(localName),
+                                           false,
+                                           client);
             NTSCFG_TEST_ASSERT(!error);
         }
         else {
@@ -1288,10 +1297,13 @@ NTSCFG_TEST_CASE(1)
             NTSCFG_TEST_ASSERT(!error);
         }
         else if (transport == ntsa::Transport::e_LOCAL_STREAM) {
-            error = ntsu::SocketUtil::bind(
-                ntsa::Endpoint(ntsa::LocalName::generateUnique()),
-                false,
-                listener);
+            ntsa::LocalName localName;
+            error = ntsa::LocalName::generateUnique(&localName);
+            NTSCFG_TEST_ASSERT(!error);
+
+            error = ntsu::SocketUtil::bind(ntsa::Endpoint(localName),
+                                           false,
+                                           listener);
             NTSCFG_TEST_ASSERT(!error);
         }
         else {
@@ -1539,10 +1551,13 @@ NTSCFG_TEST_CASE(2)
             NTSCFG_TEST_ASSERT(!error);
         }
         else if (transport == ntsa::Transport::e_LOCAL_DATAGRAM) {
-            error = ntsu::SocketUtil::bind(
-                ntsa::Endpoint(ntsa::LocalName::generateUnique()),
-                false,
-                server);
+            ntsa::LocalName localName;
+            error = ntsa::LocalName::generateUnique(&localName);
+            NTSCFG_TEST_ASSERT(!error);
+
+            error = ntsu::SocketUtil::bind(ntsa::Endpoint(localName),
+                                           false,
+                                           server);
             NTSCFG_TEST_ASSERT(!error);
         }
         else {
@@ -1575,10 +1590,13 @@ NTSCFG_TEST_CASE(2)
             NTSCFG_TEST_ASSERT(!error);
         }
         else if (transport == ntsa::Transport::e_LOCAL_DATAGRAM) {
-            error = ntsu::SocketUtil::bind(
-                ntsa::Endpoint(ntsa::LocalName::generateUnique()),
-                false,
-                client);
+            ntsa::LocalName localName;
+            error = ntsa::LocalName::generateUnique(&localName);
+            NTSCFG_TEST_ASSERT(!error);
+
+            error = ntsu::SocketUtil::bind(ntsa::Endpoint(localName),
+                                           false,
+                                           client);
             NTSCFG_TEST_ASSERT(!error);
         }
         else {
@@ -1866,10 +1884,13 @@ NTSCFG_TEST_CASE(12)
                     NTSCFG_TEST_ASSERT(!error);
                 }
                 else if (transport == ntsa::Transport::e_LOCAL_STREAM) {
-                    error = ntsu::SocketUtil::bind(
-                        ntsa::Endpoint(ntsa::LocalName::generateUnique()),
-                        false,
-                        listener);
+                    ntsa::LocalName localName;
+                    error = ntsa::LocalName::generateUnique(&localName);
+                    NTSCFG_TEST_ASSERT(!error);
+
+                    error = ntsu::SocketUtil::bind(ntsa::Endpoint(localName),
+                                                   false,
+                                                   listener);
                     NTSCFG_TEST_ASSERT(!error);
                 }
                 else {
@@ -3926,8 +3947,12 @@ NTSCFG_TEST_CASE(14)
                 NTSCFG_TEST_ASSERT(!error);
 
                 {
+                    ntsa::LocalName localName;
+                    error = ntsa::LocalName::generateUnique(&localName);
+                    NTSCFG_TEST_ASSERT(!error);
+
                     ntsa::Endpoint explicitSourceEndpoint =
-                        ntsa::Endpoint(ntsa::LocalName::generateUnique());
+                        ntsa::Endpoint(localName);
 
                     error = ntsu::SocketUtil::bind(explicitSourceEndpoint,
                                                    k_REUSE_ADDRESS,
@@ -3964,8 +3989,12 @@ NTSCFG_TEST_CASE(14)
                 ntsa::Endpoint serverEndpoint;
 
                 {
+                    ntsa::LocalName localName;
+                    error = ntsa::LocalName::generateUnique(&localName);
+                    NTSCFG_TEST_ASSERT(!error);
+
                     ntsa::Endpoint explicitServerEndpoint =
-                        ntsa::Endpoint(ntsa::LocalName::generateUnique());
+                        ntsa::Endpoint(localName);
 
                     error = ntsu::SocketUtil::bind(explicitServerEndpoint,
                                                    k_REUSE_ADDRESS,
@@ -4063,8 +4092,12 @@ NTSCFG_TEST_CASE(14)
                 ntsa::Endpoint serverEndpoint;
 
                 {
+                    ntsa::LocalName localName;
+                    error = ntsa::LocalName::generateUnique(&localName);
+                    NTSCFG_TEST_ASSERT(!error);
+
                     ntsa::Endpoint explicitServerEndpoint =
-                        ntsa::Endpoint(ntsa::LocalName::generateUnique());
+                        ntsa::Endpoint(localName);
 
                     error = ntsu::SocketUtil::bind(explicitServerEndpoint,
                                                    k_REUSE_ADDRESS,
@@ -5254,8 +5287,12 @@ NTSCFG_TEST_CASE(15)
                 NTSCFG_TEST_ASSERT(!error);
 
                 {
+                    ntsa::LocalName localName;
+                    error = ntsa::LocalName::generateUnique(&localName);
+                    NTSCFG_TEST_ASSERT(!error);
+
                     ntsa::Endpoint explicitSourceEndpoint =
-                        ntsa::Endpoint(ntsa::LocalName::generateUnique());
+                        ntsa::Endpoint(localName);
 
                     error = ntsu::SocketUtil::bind(explicitSourceEndpoint,
                                                    k_REUSE_ADDRESS,
@@ -5292,8 +5329,12 @@ NTSCFG_TEST_CASE(15)
                 ntsa::Endpoint serverEndpoint;
 
                 {
+                    ntsa::LocalName localName;
+                    error = ntsa::LocalName::generateUnique(&localName);
+                    NTSCFG_TEST_ASSERT(!error);
+
                     ntsa::Endpoint explicitServerEndpoint =
-                        ntsa::Endpoint(ntsa::LocalName::generateUnique());
+                        ntsa::Endpoint(localName);
 
                     error = ntsu::SocketUtil::bind(explicitServerEndpoint,
                                                    k_REUSE_ADDRESS,
@@ -5700,7 +5741,7 @@ NTSCFG_TEST_CASE(17)
                         NTSCFG_TEST_TRUE(context.hardwareTimestamp().isNull());
                     }
                     else {
-                        BSLS_LOG_DEBUG("Detected RX timestamp"); 
+                        BSLS_LOG_DEBUG("Detected RX timestamp");
                         NTSCFG_TEST_TRUE(
                             context.softwareTimestamp().has_value());
                         NTSCFG_TEST_LE(sysTimeBeforeSending,
@@ -5841,7 +5882,7 @@ NTSCFG_TEST_CASE(17)
                             notifications.notifications().at(i).timestamp());
                     }
 
-                    BSLS_LOG_DEBUG("Detected TX timestamp"); 
+                    BSLS_LOG_DEBUG("Detected TX timestamp");
 
                     NTSCFG_TEST_EQ(timestamps.size(), 3);
                     bsl::set<ntsa::Timestamp,
@@ -6287,7 +6328,7 @@ NTSCFG_TEST_CASE(18)
                         NTSCFG_TEST_TRUE(context.softwareTimestamp().isNull());
                     }
                     else {
-                        BSLS_LOG_DEBUG("Detected RX timestamp"); 
+                        BSLS_LOG_DEBUG("Detected RX timestamp");
                         NTSCFG_TEST_FALSE(
                             context.softwareTimestamp().isNull());
                         NTSCFG_TEST_LE(sysTimeBeforeSending,
@@ -6442,7 +6483,7 @@ NTSCFG_TEST_CASE(18)
                         timestamps.insert(
                             notifications.notifications().at(i).timestamp());
 
-                        BSLS_LOG_DEBUG("Detected TX timestamp"); 
+                        BSLS_LOG_DEBUG("Detected TX timestamp");
                     }
                     NTSCFG_TEST_EQ(timestamps.size(), numTimestamps);
                     bsl::set<ntsa::Timestamp,


### PR DESCRIPTION
**Describe your changes**
`struct sockaddr_un` is used to store UDS address on each platfrom. Generally, on each platform `sockaddr_un` consists of `sun_family` field and `sun_path` char array where its length differs between platforms. Also, the way how `sun_path` is filled differes depending on where unix domain name is unnamed/real/abstract.

`ntsa::LocalName` class provides a way to store UDS address and ensures that the address stored can be correctly fitted into the `sun_path` field on each platform. Previously there was no such guarantee. 

Existing method `ntsa::Error setValue(const bslstl::StringRef& value);` contract is changed so that if `value` cannot be stored then error is returned (previously the `value` would have been trancated).

New method is added: `static ntsa::Error generateUnique(ntsa::LocalName* name);`. It is supposed to replace the existing one `static ntsa::LocalName generateUnique();` because the existing method had no way of indicating that local name cannot be generated (possible reason of generation failure could be that path to TMP directory where UDS files would be created in case of real name usage is longer than capacity of `sun_path`).

**Testing performed**
`ntsa_localname.t` is update accordingly

**Additional context**
Need to decide still if we keep existing `static ntsa::LocalName generateUnique();` or it can be removed. Additional idea: replace it with `static ntsa::LocalName generateUnique(ntsa::Error* error = NULL);`
