### PR TITLE
Timer management

### DIFF
--- a/groups/ntc/ntca/ntca_acceptqueueeventtype.cpp
+++ b/groups/ntc/ntca/ntca_acceptqueueeventtype.cpp
@@ -34,6 +34,8 @@ int AcceptQueueEventType::fromInt(AcceptQueueEventType::Value* result,
     case AcceptQueueEventType::e_LOW_WATERMARK:
     case AcceptQueueEventType::e_HIGH_WATERMARK:
     case AcceptQueueEventType::e_DISCARDED:
+    case AcceptQueueEventType::e_RATE_LIMIT_APPLIED:
+    case AcceptQueueEventType::e_RATE_LIMIT_RELAXED:
         *result = static_cast<AcceptQueueEventType::Value>(number);
         return 0;
     default:
@@ -64,6 +66,14 @@ int AcceptQueueEventType::fromString(AcceptQueueEventType::Value* result,
         *result = e_DISCARDED;
         return 0;
     }
+    if (bdlb::String::areEqualCaseless(string, "RATE_LIMIT_APPLIED")) {
+        *result = e_RATE_LIMIT_APPLIED;
+        return 0;
+    }
+    if (bdlb::String::areEqualCaseless(string, "RATE_LIMIT_RELAXED")) {
+        *result = e_RATE_LIMIT_RELAXED;
+        return 0;
+    }
 
     return -1;
 }
@@ -73,19 +83,25 @@ const char* AcceptQueueEventType::toString(AcceptQueueEventType::Value value)
     switch (value) {
     case e_FLOW_CONTROL_RELAXED: {
         return "FLOW_CONTROL_RELAXED";
-    } break;
+    }
     case e_FLOW_CONTROL_APPLIED: {
         return "FLOW_CONTROL_APPLIED";
-    } break;
+    }
     case e_LOW_WATERMARK: {
         return "LOW_WATERMARK";
-    } break;
+    }
     case e_HIGH_WATERMARK: {
         return "HIGH_WATERMARK";
-    } break;
+    }
     case e_DISCARDED: {
         return "DISCARDED";
-    } break;
+    }
+    case e_RATE_LIMIT_APPLIED: {
+        return "RATE_LIMIT_APPLIED";
+    }
+    case e_RATE_LIMIT_RELAXED: {
+        return "RATE_LIMIT_RELAXED";
+    }
     }
 
     BSLS_ASSERT(!"invalid enumerator");

--- a/groups/ntc/ntca/ntca_acceptqueueeventtype.h
+++ b/groups/ntc/ntca/ntca_acceptqueueeventtype.h
@@ -55,7 +55,15 @@ struct AcceptQueueEventType {
 
         // The contents of the accept queue have been discarded without being
         // processed.
-        e_DISCARDED = 4
+        e_DISCARDED = 4,
+
+        /// Accept rate limit has been reached and accept rate limit timer
+        /// has been set
+        e_RATE_LIMIT_APPLIED = 5,
+
+        /// Accept rate limit timer has fired and accept rate limit has been
+        /// relaxed
+        e_RATE_LIMIT_RELAXED = 6
     };
 
     /// Return the string representation exactly matching the enumerator

--- a/groups/ntc/ntca/ntca_acceptqueueeventtype.h
+++ b/groups/ntc/ntca/ntca_acceptqueueeventtype.h
@@ -57,12 +57,12 @@ struct AcceptQueueEventType {
         // processed.
         e_DISCARDED = 4,
 
-        /// Accept rate limit has been reached and accept rate limit timer
-        /// has been set
+        /// The accept rate limit has been reached and the accept rate limit
+        /// timer has been set.
         e_RATE_LIMIT_APPLIED = 5,
 
-        /// Accept rate limit timer has fired and accept rate limit has been
-        /// relaxed
+        /// The accept rate limit timer has fired and the accept rate limit has
+        /// been relaxed.
         e_RATE_LIMIT_RELAXED = 6
     };
 

--- a/groups/ntc/ntca/ntca_readqueueeventtype.cpp
+++ b/groups/ntc/ntca/ntca_readqueueeventtype.cpp
@@ -33,6 +33,8 @@ int ReadQueueEventType::fromInt(ReadQueueEventType::Value* result, int number)
     case ReadQueueEventType::e_LOW_WATERMARK:
     case ReadQueueEventType::e_HIGH_WATERMARK:
     case ReadQueueEventType::e_DISCARDED:
+    case ReadQueueEventType::e_RATE_LIMIT_APPLIED:
+    case ReadQueueEventType::e_RATE_LIMIT_RELAXED:
         *result = static_cast<ReadQueueEventType::Value>(number);
         return 0;
     default:
@@ -63,7 +65,14 @@ int ReadQueueEventType::fromString(ReadQueueEventType::Value* result,
         *result = e_DISCARDED;
         return 0;
     }
-
+    if (bdlb::String::areEqualCaseless(string, "RATE_LIMIT_APPLIED")) {
+        *result = e_RATE_LIMIT_APPLIED;
+        return 0;
+    }
+    if (bdlb::String::areEqualCaseless(string, "RATE_LIMIT_RELAXED")) {
+        *result = e_RATE_LIMIT_RELAXED;
+        return 0;
+    }
     return -1;
 }
 
@@ -72,19 +81,25 @@ const char* ReadQueueEventType::toString(ReadQueueEventType::Value value)
     switch (value) {
     case e_FLOW_CONTROL_RELAXED: {
         return "FLOW_CONTROL_RELAXED";
-    } break;
+    }
     case e_FLOW_CONTROL_APPLIED: {
         return "FLOW_CONTROL_APPLIED";
-    } break;
+    }
     case e_LOW_WATERMARK: {
         return "LOW_WATERMARK";
-    } break;
+    }
     case e_HIGH_WATERMARK: {
         return "HIGH_WATERMARK";
-    } break;
+    }
     case e_DISCARDED: {
         return "DISCARDED";
-    } break;
+    }
+    case e_RATE_LIMIT_APPLIED: {
+        return "RATE_LIMIT_APPLIED";
+    }
+    case e_RATE_LIMIT_RELAXED: {
+        return "RATE_LIMIT_RELAXED";
+    }
     }
 
     BSLS_ASSERT(!"invalid enumerator");

--- a/groups/ntc/ntca/ntca_readqueueeventtype.h
+++ b/groups/ntc/ntca/ntca_readqueueeventtype.h
@@ -53,7 +53,15 @@ struct ReadQueueEventType {
 
         /// The contents of the read queue have been discarded without being
         /// processed.
-        e_DISCARDED = 4
+        e_DISCARDED = 4,
+
+        /// Receive rate limit has been reached and receive rate limit timer
+        /// has been set
+        e_RATE_LIMIT_APPLIED = 5,
+
+        /// Receive rate limit timer has fired and receive rate limit has been
+        /// relaxed
+        e_RATE_LIMIT_RELAXED = 6
     };
 
     /// Return the string representation exactly matching the enumerator

--- a/groups/ntc/ntca/ntca_readqueueeventtype.h
+++ b/groups/ntc/ntca/ntca_readqueueeventtype.h
@@ -55,12 +55,12 @@ struct ReadQueueEventType {
         /// processed.
         e_DISCARDED = 4,
 
-        /// Receive rate limit has been reached and receive rate limit timer
-        /// has been set
+        /// The receive rate limit has been reached and the receive rate limit
+        /// timer has been set.
         e_RATE_LIMIT_APPLIED = 5,
 
-        /// Receive rate limit timer has fired and receive rate limit has been
-        /// relaxed
+        /// The receive rate limit timer has fired and the receive rate limit
+        /// has been relaxed.
         e_RATE_LIMIT_RELAXED = 6
     };
 

--- a/groups/ntc/ntca/ntca_writequeueeventtype.cpp
+++ b/groups/ntc/ntca/ntca_writequeueeventtype.cpp
@@ -34,6 +34,8 @@ int WriteQueueEventType::fromInt(WriteQueueEventType::Value* result,
     case WriteQueueEventType::e_LOW_WATERMARK:
     case WriteQueueEventType::e_HIGH_WATERMARK:
     case WriteQueueEventType::e_DISCARDED:
+    case WriteQueueEventType::e_RATE_LIMIT_APPLIED:
+    case WriteQueueEventType::e_RATE_LIMIT_RELAXED:
         *result = static_cast<WriteQueueEventType::Value>(number);
         return 0;
     default:
@@ -64,6 +66,14 @@ int WriteQueueEventType::fromString(WriteQueueEventType::Value* result,
         *result = e_DISCARDED;
         return 0;
     }
+    if (bdlb::String::areEqualCaseless(string, "RATE_LIMIT_APPLIED")) {
+        *result = e_RATE_LIMIT_APPLIED;
+        return 0;
+    }
+    if (bdlb::String::areEqualCaseless(string, "RATE_LIMIT_RELAXED")) {
+        *result = e_RATE_LIMIT_RELAXED;
+        return 0;
+    }
 
     return -1;
 }
@@ -73,19 +83,25 @@ const char* WriteQueueEventType::toString(WriteQueueEventType::Value value)
     switch (value) {
     case e_FLOW_CONTROL_RELAXED: {
         return "FLOW_CONTROL_RELAXED";
-    } break;
+    }
     case e_FLOW_CONTROL_APPLIED: {
         return "FLOW_CONTROL_APPLIED";
-    } break;
+    }
     case e_LOW_WATERMARK: {
         return "LOW_WATERMARK";
-    } break;
+    }
     case e_HIGH_WATERMARK: {
         return "HIGH_WATERMARK";
-    } break;
+    }
     case e_DISCARDED: {
         return "DISCARDED";
-    } break;
+    }
+    case e_RATE_LIMIT_APPLIED: {
+        return "RATE_LIMIT_APPLIED";
+    }
+    case e_RATE_LIMIT_RELAXED: {
+        return "RATE_LIMIT_RELAXED";
+    }
     }
 
     BSLS_ASSERT(!"invalid enumerator");

--- a/groups/ntc/ntca/ntca_writequeueeventtype.h
+++ b/groups/ntc/ntca/ntca_writequeueeventtype.h
@@ -55,12 +55,12 @@ struct WriteQueueEventType {
         /// processed.
         e_DISCARDED = 4,
 
-        /// Send rate limit has been reached and send rate limit timer has been
-        /// set
+        /// The send rate limit has been reached and the send rate limit timer
+        /// has been set.
         e_RATE_LIMIT_APPLIED = 5,
 
-        /// Send rate limit timer has fired and send rate limit has been
-        /// relaxed
+        /// The send rate limit timer has fired and the send rate limit has
+        /// been relaxed.
         e_RATE_LIMIT_RELAXED = 6
     };
 

--- a/groups/ntc/ntca/ntca_writequeueeventtype.h
+++ b/groups/ntc/ntca/ntca_writequeueeventtype.h
@@ -53,7 +53,15 @@ struct WriteQueueEventType {
 
         /// The contents of the write queue have been discarded without being
         /// processed.
-        e_DISCARDED = 4
+        e_DISCARDED = 4,
+
+        /// Send rate limit has been reached and send rate limit timer has been
+        /// set
+        e_RATE_LIMIT_APPLIED = 5,
+
+        /// Send rate limit timer has fired and send rate limit has been
+        /// relaxed
+        e_RATE_LIMIT_RELAXED = 6
     };
 
     /// Return the string representation exactly matching the enumerator

--- a/groups/ntc/ntcf/ntcf_system.t.cpp
+++ b/groups/ntc/ntcf/ntcf_system.t.cpp
@@ -13998,18 +13998,21 @@ NTCCFG_TEST_CASE(70)
 {
     ntccfg::TestAllocator ta;
     {
-        test::concern(&test::concernDatagramSocketReceiveRateLimitTimerClose,
-                      &ta);
+        test::concern(
+            &test::
+                concernDatagramSocketReceiveRateLimitTimerEventNotifications,
+            &ta);
+        NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
     }
-    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
 
 NTCCFG_TEST_CASE(71)
 {
     ntccfg::TestAllocator ta;
     {
-        test::concern(&test::concernStreamSocketReceiveRateLimitTimerClose,
-                      &ta);
+        test::concern(
+            &test::concernStreamSocketReceiveRateLimitTimerEventNotifications,
+            &ta);
     }
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
@@ -14018,8 +14021,9 @@ NTCCFG_TEST_CASE(72)
 {
     ntccfg::TestAllocator ta;
     {
-        test::concern(&test::concernDatagramSocketSendRateLimitTimerClose,
-                      &ta);
+        test::concern(
+            &test::concernDatagramSocketSendRateLimitTimerEventNotifications,
+            &ta);
     }
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
@@ -14028,7 +14032,9 @@ NTCCFG_TEST_CASE(73)
 {
     ntccfg::TestAllocator ta;
     {
-        test::concern(&test::concernStreamSocketSendRateLimitTimerClose, &ta);
+        test::concern(
+            &test::concernStreamSocketSendRateLimitTimerEventNotifications,
+            &ta);
     }
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
@@ -14037,8 +14043,9 @@ NTCCFG_TEST_CASE(74)
 {
     ntccfg::TestAllocator ta;
     {
-        test::concern(&test::concernListenerSocketAcceptRateLimitTimerClose,
-                      &ta);
+        test::concern(
+            &test::concernListenerSocketAcceptRateLimitTimerEventNotifications,
+            &ta);
     }
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
@@ -14066,21 +14073,18 @@ NTCCFG_TEST_CASE(77)
 {
     ntccfg::TestAllocator ta;
     {
-        test::concern(
-            &test::
-                concernDatagramSocketReceiveRateLimitTimerEventNotifications,
-            &ta);
-        NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+        test::concern(&test::concernDatagramSocketReceiveRateLimitTimerClose,
+                      &ta);
     }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
 
 NTCCFG_TEST_CASE(78)
 {
     ntccfg::TestAllocator ta;
     {
-        test::concern(
-            &test::concernDatagramSocketSendRateLimitTimerEventNotifications,
-            &ta);
+        test::concern(&test::concernDatagramSocketSendRateLimitTimerClose,
+                      &ta);
     }
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
@@ -14089,9 +14093,8 @@ NTCCFG_TEST_CASE(79)
 {
     ntccfg::TestAllocator ta;
     {
-        test::concern(
-            &test::concernStreamSocketReceiveRateLimitTimerEventNotifications,
-            &ta);
+        test::concern(&test::concernStreamSocketReceiveRateLimitTimerClose,
+                      &ta);
     }
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
@@ -14100,9 +14103,7 @@ NTCCFG_TEST_CASE(80)
 {
     ntccfg::TestAllocator ta;
     {
-        test::concern(
-            &test::concernStreamSocketSendRateLimitTimerEventNotifications,
-            &ta);
+        test::concern(&test::concernStreamSocketSendRateLimitTimerClose, &ta);
     }
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
@@ -14111,9 +14112,8 @@ NTCCFG_TEST_CASE(81)
 {
     ntccfg::TestAllocator ta;
     {
-        test::concern(
-            &test::concernListenerSocketAcceptRateLimitTimerEventNotifications,
-            &ta);
+        test::concern(&test::concernListenerSocketAcceptRateLimitTimerClose,
+                      &ta);
     }
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }

--- a/groups/ntc/ntcf/ntcf_system.t.cpp
+++ b/groups/ntc/ntcf/ntcf_system.t.cpp
@@ -110,7 +110,7 @@ using namespace BloombergLP;
 // "KQUEUE"      Implementation using kqueue/kevent
 // "IOCP"        Implementation using I/O completion ports
 // "IOCP"        Implementation using I/O rings
-// #define NTCF_SYSTEM_TEST_DRIVER_TYPE "IORING"
+// #define NTCF_SYSTEM_TEST_DRIVER_TYPE "IOCP"
 
 // Uncomment to test a specific address family, instead of all address
 // families.
@@ -5043,10 +5043,17 @@ void CloseUtil::processConnect(
 
 /// Provide callbacks for datagram socket tests.
 struct DatagramSocketUtil {
+    static void processReceiveFailed(
+        const bsl::shared_ptr<ntci::Receiver>& receiver,
+        const bsl::shared_ptr<bdlbb::Blob>&    data,
+        const ntca::ReceiveEvent&              event,
+        bslmt::Semaphore*                      semaphore);
+
     static void processReceiveTimeout(
         const bsl::shared_ptr<ntci::Receiver>& receiver,
         const bsl::shared_ptr<bdlbb::Blob>&    data,
         const ntca::ReceiveEvent&              event,
+        ntsa::Error::Code                      error,
         bslmt::Semaphore*                      semaphore);
 
     static void processReceiveCancelled(
@@ -5060,7 +5067,7 @@ struct DatagramSocketUtil {
         const ntca::ReceiveToken                     token);
 };
 
-void DatagramSocketUtil::processReceiveTimeout(
+void DatagramSocketUtil::processReceiveFailed(
     const bsl::shared_ptr<ntci::Receiver>& receiver,
     const bsl::shared_ptr<bdlbb::Blob>&    data,
     const ntca::ReceiveEvent&              event,
@@ -5072,7 +5079,25 @@ void DatagramSocketUtil::processReceiveTimeout(
                    event.context().error().text().c_str());
 
     NTCCFG_TEST_EQ(event.type(), ntca::ReceiveEventType::e_ERROR);
-    NTCCFG_TEST_EQ(event.context().error(), ntsa::Error::e_WOULD_BLOCK);
+    NTCCFG_TEST_EQ(event.context().error(), ntsa::Error::e_EOF);
+
+    semaphore->post();
+}
+
+void DatagramSocketUtil::processReceiveTimeout(
+    const bsl::shared_ptr<ntci::Receiver>& receiver,
+    const bsl::shared_ptr<bdlbb::Blob>&    data,
+    const ntca::ReceiveEvent&              event,
+    ntsa::Error::Code                      error,
+    bslmt::Semaphore*                      semaphore)
+{
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_DEBUG("Processing receive from event type %s: %s",
+                   ntca::ReceiveEventType::toString(event.type()),
+                   event.context().error().text().c_str());
+
+    NTCCFG_TEST_EQ(event.type(), ntca::ReceiveEventType::e_ERROR);
+    NTCCFG_TEST_EQ(event.context().error(), error);
 
     semaphore->post();
 }
@@ -5116,6 +5141,7 @@ struct ListenerSocketUtil {
         const bsl::shared_ptr<ntci::Acceptor>&       acceptor,
         const bsl::shared_ptr<ntci::StreamSocket>&   streamSocket,
         const ntca::AcceptEvent&                     event,
+        const ntsa::Error::Code                      error,
         bslmt::Semaphore*                            semaphore);
 
     static void cancelAccept(
@@ -5146,6 +5172,7 @@ void ListenerSocketUtil::processAcceptCancelled(
     const bsl::shared_ptr<ntci::Acceptor>&       acceptor,
     const bsl::shared_ptr<ntci::StreamSocket>&   streamSocket,
     const ntca::AcceptEvent&                     event,
+    const ntsa::Error::Code                      error,
     bslmt::Semaphore*                            semaphore)
 {
     NTCI_LOG_CONTEXT();
@@ -5154,7 +5181,7 @@ void ListenerSocketUtil::processAcceptCancelled(
                    event.context().error().text().c_str());
 
     NTCCFG_TEST_EQ(event.type(), ntca::AcceptEventType::e_ERROR);
-    NTCCFG_TEST_EQ(event.context().error(), ntsa::Error::e_CANCELLED);
+    NTCCFG_TEST_EQ(event.context().error(), error);
 
     semaphore->post();
 }
@@ -5174,6 +5201,7 @@ struct StreamSocketUtil {
         const bsl::shared_ptr<ntci::Receiver>&     receiver,
         const bsl::shared_ptr<bdlbb::Blob>&        data,
         const ntca::ReceiveEvent&                  event,
+        ntsa::Error::Code                          error,
         bslmt::Semaphore*                          semaphore);
 
     static void processReceiveCancelled(
@@ -5181,6 +5209,13 @@ struct StreamSocketUtil {
         const bsl::shared_ptr<ntci::Receiver>&     receiver,
         const bsl::shared_ptr<bdlbb::Blob>&        data,
         const ntca::ReceiveEvent&                  event,
+        bslmt::Semaphore*                          semaphore);
+
+    static void processSendAborted(
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const bsl::shared_ptr<ntci::Sender>&       sender,
+        const ntca::SendEvent&                     event,
+        const bsl::string&                         name,
         bslmt::Semaphore*                          semaphore);
 
     static void processSendSuccessOrTimeout(
@@ -5231,6 +5266,7 @@ void StreamSocketUtil::processReceiveTimeout(
     const bsl::shared_ptr<ntci::Receiver>&     receiver,
     const bsl::shared_ptr<bdlbb::Blob>&        data,
     const ntca::ReceiveEvent&                  event,
+    ntsa::Error::Code                          error,
     bslmt::Semaphore*                          semaphore)
 {
     NTCI_LOG_CONTEXT();
@@ -5239,7 +5275,7 @@ void StreamSocketUtil::processReceiveTimeout(
                    event.context().error().text().c_str());
 
     NTCCFG_TEST_EQ(event.type(), ntca::ReceiveEventType::e_ERROR);
-    NTCCFG_TEST_EQ(event.context().error(), ntsa::Error::e_WOULD_BLOCK);
+    NTCCFG_TEST_EQ(event.context().error(), error);
 
     semaphore->post();
 }
@@ -5258,6 +5294,28 @@ void StreamSocketUtil::processReceiveCancelled(
 
     NTCCFG_TEST_EQ(event.type(), ntca::ReceiveEventType::e_ERROR);
     NTCCFG_TEST_EQ(event.context().error(), ntsa::Error::e_CANCELLED);
+
+    semaphore->post();
+}
+
+void StreamSocketUtil::processSendAborted(
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const bsl::shared_ptr<ntci::Sender>&       sender,
+    const ntca::SendEvent&                     event,
+    const bsl::string&                         name,
+    bslmt::Semaphore*                          semaphore)
+{
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_DEBUG("Processing send event type %s: %s",
+                   ntca::SendEventType::toString(event.type()),
+                   event.context().error().text().c_str());
+
+    NTCI_LOG_INFO("Message %s send was aborted", name.c_str());
+    NTCCFG_TEST_EQ(event.type(), ntca::SendEventType::e_ERROR);
+    NTCCFG_TEST_TRUE(
+        (event.context().error() ==
+         ntsa::Error::e_CONNECTION_DEAD) ||                      // Reactors
+        (event.context().error() == ntsa::Error::e_CANCELLED));  // Proactors
 
     semaphore->post();
 }
@@ -9717,6 +9775,7 @@ void concernDatagramSocketReceiveDeadline(
                         NTCCFG_BIND_PLACEHOLDER_1,
                         NTCCFG_BIND_PLACEHOLDER_2,
                         NTCCFG_BIND_PLACEHOLDER_3,
+                        ntsa::Error::e_WOULD_BLOCK,
                         &semaphore),
             allocator);
 
@@ -9733,11 +9792,75 @@ void concernDatagramSocketReceiveDeadline(
     NTCI_LOG_DEBUG("Datagram socket receive deadline test complete");
 }
 
+void concernDatagramSocketReceiveDeadlineClose(
+    const bsl::shared_ptr<ntci::Interface>& interface,
+    bslma::Allocator*                       allocator)
+{
+    // Concern: validate that receive deadline timer is automatically closed
+    // when the socket is closed and then destroyed
+
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_DEBUG("Datagram socket receive deadline test starting");
+
+    const int k_RECEIVE_TIMEOUT_IN_HOURS = 1;
+
+    const ntsa::Transport::Value transport =
+        ntsa::Transport::e_UDP_IPV4_DATAGRAM;
+
+    ntsa::Error      error;
+    bslmt::Semaphore semaphore;
+
+    ntca::DatagramSocketOptions options;
+    options.setTransport(transport);
+    options.setSourceEndpoint(test::EndpointUtil::any(transport));
+
+    bsl::shared_ptr<ntci::Resolver> resolver;
+
+    bsl::shared_ptr<ntci::DatagramSocket> datagramSocket =
+        interface->createDatagramSocket(options, allocator);
+
+    error = datagramSocket->open();
+    NTCCFG_TEST_FALSE(error);
+
+    bsls::TimeInterval receiveTimeout;
+    receiveTimeout.setTotalHours(k_RECEIVE_TIMEOUT_IN_HOURS);
+
+    bsls::TimeInterval receiveDeadline =
+        datagramSocket->currentTime() + receiveTimeout;
+
+    ntca::ReceiveOptions receiveOptions;
+    receiveOptions.setDeadline(receiveDeadline);
+
+    ntci::ReceiveCallback receiveCallback =
+        datagramSocket->createReceiveCallback(
+            NTCCFG_BIND(&test::DatagramSocketUtil::processReceiveTimeout,
+                        NTCCFG_BIND_PLACEHOLDER_1,
+                        NTCCFG_BIND_PLACEHOLDER_2,
+                        NTCCFG_BIND_PLACEHOLDER_3,
+                        ntsa::Error::e_EOF,
+                        &semaphore),
+            allocator);
+
+    error = datagramSocket->receive(receiveOptions, receiveCallback);
+    NTCCFG_TEST_OK(error);
+
+    {
+        ntci::DatagramSocketCloseGuard datagramSocketCloseGuard(
+            datagramSocket);
+    }
+
+    semaphore.wait();
+
+    NTCI_LOG_DEBUG("Datagram socket receive deadline test complete");
+}
+
 void concernDatagramSocketReceiveCancellation(
     const bsl::shared_ptr<ntci::Interface>& interface,
     bslma::Allocator*                       allocator)
 {
-    // Concern: Receive cancellation.
+    // Concern: validate that receive deadline timer is automatically closed
+    // when the socket is closed and then destroyed
 
     NTCI_LOG_CONTEXT();
 
@@ -9928,6 +10051,7 @@ void concernListenerSocketAcceptCancellation(
                     NTCCFG_BIND_PLACEHOLDER_1,
                     NTCCFG_BIND_PLACEHOLDER_2,
                     NTCCFG_BIND_PLACEHOLDER_3,
+                    ntsa::Error::e_CANCELLED,
                     &semaphore),
         allocator);
 
@@ -10317,6 +10441,7 @@ void concernStreamSocketReceiveDeadline(
                         NTCCFG_BIND_PLACEHOLDER_1,
                         NTCCFG_BIND_PLACEHOLDER_2,
                         NTCCFG_BIND_PLACEHOLDER_3,
+                        ntsa::Error::e_WOULD_BLOCK,
                         &semaphore),
             allocator);
 
@@ -10436,6 +10561,86 @@ void concernStreamSocketReceiveCancellation(
     }
 
     NTCI_LOG_DEBUG("Stream socket receive cancellation test complete");
+}
+
+void concernStreamSocketReceiveDeadlineClose(
+    const bsl::shared_ptr<ntci::Interface>& interface,
+    bslma::Allocator*                       allocator)
+{
+    // Concern: validate that receive deadline timer is automatically closed
+    // when the socket is closed and then destroyed
+
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_DEBUG("Stream socket receive deadline test starting");
+
+    const int k_RECEIVE_TIMEOUT_IN_HOURS = 1;
+
+    const ntsa::Transport::Value transport =
+        ntsa::Transport::e_TCP_IPV4_STREAM;
+
+    ntsa::Error      error;
+    bslmt::Semaphore semaphore;
+
+    bsl::shared_ptr<ntci::StreamSocket> clientStreamSocket;
+    bsl::shared_ptr<ntci::StreamSocket> serverStreamSocket;
+    {
+        ntca::StreamSocketOptions options;
+        options.setTransport(transport);
+
+        bsl::shared_ptr<ntsi::StreamSocket> basicClientSocket;
+        bsl::shared_ptr<ntsi::StreamSocket> basicServerSocket;
+
+        error = ntsf::System::createStreamSocketPair(&basicClientSocket,
+                                                     &basicServerSocket,
+                                                     transport);
+        NTCCFG_TEST_FALSE(error);
+
+        clientStreamSocket = interface->createStreamSocket(options, allocator);
+
+        error = clientStreamSocket->open(transport, basicClientSocket);
+        NTCCFG_TEST_FALSE(error);
+
+        serverStreamSocket = interface->createStreamSocket(options, allocator);
+
+        error = serverStreamSocket->open(transport, basicServerSocket);
+        NTCCFG_TEST_FALSE(error);
+    }
+
+    bsls::TimeInterval receiveTimeout;
+    receiveTimeout.setTotalHours(k_RECEIVE_TIMEOUT_IN_HOURS);
+
+    bsls::TimeInterval receiveDeadline =
+        serverStreamSocket->currentTime() + receiveTimeout;
+
+    ntca::ReceiveOptions receiveOptions;
+    receiveOptions.setDeadline(receiveDeadline);
+
+    ntci::ReceiveCallback receiveCallback =
+        serverStreamSocket->createReceiveCallback(
+            NTCCFG_BIND(&test::StreamSocketUtil::processReceiveTimeout,
+                        serverStreamSocket,
+                        NTCCFG_BIND_PLACEHOLDER_1,
+                        NTCCFG_BIND_PLACEHOLDER_2,
+                        NTCCFG_BIND_PLACEHOLDER_3,
+                        ntsa::Error::e_EOF,
+                        &semaphore),
+            allocator);
+
+    error = serverStreamSocket->receive(receiveOptions, receiveCallback);
+    NTCCFG_TEST_OK(error);
+
+    {
+        ntci::StreamSocketCloseGuard clientStreamSocketCloseGuard(
+            clientStreamSocket);
+
+        ntci::StreamSocketCloseGuard serverStreamSocketCloseGuard(
+            serverStreamSocket);
+    }
+
+    semaphore.wait();
+
+    NTCI_LOG_DEBUG("Stream socket receive deadline test complete");
 }
 
 void concernStreamSocketSendDeadline(
@@ -10828,6 +11033,1834 @@ void concernStreamSocketSendCancellation(
     }
 
     NTCI_LOG_DEBUG("Stream socket send cancellation test complete");
+}
+
+void concernStreamSocketSendDeadlineClose(
+    const bsl::shared_ptr<ntci::Interface>& interface,
+    bslma::Allocator*                       allocator)
+{
+    // Concern: validate that send deadline timer is automatically closed
+    // when the socket is closed and then destroyed
+
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_DEBUG("Stream socket send deadline test starting");
+
+    const int k_SEND_TIMEOUT_IN_HOURS = 1;
+    const int k_MESSAGE_A_SIZE        = 1024 * 1024 * 16;
+    const int k_MESSAGE_B_SIZE        = 1024;
+
+    const ntsa::Transport::Value transport =
+        ntsa::Transport::e_TCP_IPV4_STREAM;
+
+    ntsa::Error      error;
+    bslmt::Semaphore sendSemaphore;
+    bslmt::Semaphore receiveSemaphore;
+
+    bsl::shared_ptr<ntci::StreamSocket> clientStreamSocket;
+    bsl::shared_ptr<ntci::StreamSocket> serverStreamSocket;
+    {
+        ntca::StreamSocketOptions options;
+        options.setTransport(transport);
+        options.setWriteQueueHighWatermark(k_MESSAGE_A_SIZE +
+                                           k_MESSAGE_B_SIZE);
+        options.setReadQueueHighWatermark(k_MESSAGE_B_SIZE * 2);
+        options.setReadQueueLowWatermark(k_MESSAGE_B_SIZE);
+
+        options.setSendBufferSize(1024 * 32);
+        options.setReceiveBufferSize(1024 * 32);
+
+        bsl::shared_ptr<ntsi::StreamSocket> basicClientSocket;
+        bsl::shared_ptr<ntsi::StreamSocket> basicServerSocket;
+
+        error = ntsf::System::createStreamSocketPair(&basicClientSocket,
+                                                     &basicServerSocket,
+                                                     transport);
+        NTCCFG_TEST_FALSE(error);
+
+        clientStreamSocket = interface->createStreamSocket(options, allocator);
+
+        error = clientStreamSocket->open(transport, basicClientSocket);
+        NTCCFG_TEST_FALSE(error);
+
+        serverStreamSocket = interface->createStreamSocket(options, allocator);
+
+        error = serverStreamSocket->open(transport, basicServerSocket);
+        NTCCFG_TEST_FALSE(error);
+    }
+
+    NTCI_LOG_DEBUG("Generating message A");
+
+    bsl::shared_ptr<bdlbb::Blob> dataA =
+        clientStreamSocket->createOutgoingBlob();
+    ntcd::DataUtil::generateData(dataA.get(), k_MESSAGE_A_SIZE, 0, 0);
+
+    NTCI_LOG_DEBUG("Generating message A: OK");
+
+    NTCI_LOG_DEBUG("Generating message B");
+
+    bsl::shared_ptr<bdlbb::Blob> dataB =
+        clientStreamSocket->createOutgoingBlob();
+    ntcd::DataUtil::generateData(dataB.get(), k_MESSAGE_B_SIZE, 0, 1);
+
+    NTCI_LOG_DEBUG("Generating message B: OK");
+
+    NTCI_LOG_DEBUG("Sending message A");
+    {
+        ntca::SendOptions sendOptions;
+
+        error = clientStreamSocket->send(*dataA, sendOptions);
+        NTCCFG_TEST_TRUE(!error);
+    }
+
+    NTCI_LOG_DEBUG("Sending message B");
+    {
+        bsls::TimeInterval sendTimeout;
+        sendTimeout.setTotalHours(k_SEND_TIMEOUT_IN_HOURS);
+
+        bsls::TimeInterval sendDeadline =
+            clientStreamSocket->currentTime() + sendTimeout;
+
+        ntca::SendOptions sendOptions;
+        sendOptions.setDeadline(sendDeadline);
+
+        ntci::SendCallback sendCallback =
+            clientStreamSocket->createSendCallback(
+                NTCCFG_BIND(&test::StreamSocketUtil::processSendAborted,
+                            clientStreamSocket,
+                            NTCCFG_BIND_PLACEHOLDER_1,
+                            NTCCFG_BIND_PLACEHOLDER_2,
+                            bsl::string("B"),
+                            &sendSemaphore),
+                allocator);
+
+        error = clientStreamSocket->send(*dataB, sendOptions, sendCallback);
+        NTCCFG_TEST_TRUE(!error);
+    }
+
+    {
+        ntci::StreamSocketCloseGuard clientStreamSocketCloseGuard(
+            clientStreamSocket);
+
+        ntci::StreamSocketCloseGuard serverStreamSocketCloseGuard(
+            serverStreamSocket);
+    }
+
+    sendSemaphore.wait();
+
+    NTCI_LOG_DEBUG("Stream socket send deadline test complete");
+}
+
+void concernListenerSocketAcceptClose(
+    const bsl::shared_ptr<ntci::Interface>& interface,
+    bslma::Allocator*                       allocator)
+{
+    // Concern: validate that accept deadline timer is automatically closed
+    // when the socket is closed and then destroyed
+
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_DEBUG("Listener socket accept cancellation test starting");
+
+    const int k_ACCEPT_TIMEOUT_IN_HOURS = 1;
+
+    const ntsa::Transport::Value transport =
+        ntsa::Transport::e_TCP_IPV4_STREAM;
+
+    ntsa::Error      error;
+    bslmt::Semaphore semaphore;
+
+    ntca::ListenerSocketOptions options;
+    options.setTransport(transport);
+    options.setSourceEndpoint(test::EndpointUtil::any(transport));
+
+    bsl::shared_ptr<ntci::Resolver> resolver;
+
+    bsl::shared_ptr<ntci::ListenerSocket> listenerSocket =
+        interface->createListenerSocket(options, allocator);
+
+    error = listenerSocket->open();
+    NTCCFG_TEST_FALSE(error);
+
+    error = listenerSocket->listen();
+    NTCCFG_TEST_FALSE(error);
+
+    bsls::TimeInterval acceptTimeout;
+    acceptTimeout.setTotalHours(k_ACCEPT_TIMEOUT_IN_HOURS);
+
+    const bsls::TimeInterval acceptDeadline =
+        listenerSocket->currentTime() + acceptTimeout;
+
+    ntca::AcceptOptions acceptOptions;
+    acceptOptions.setDeadline(acceptDeadline);
+
+    ntci::AcceptCallback acceptCallback = listenerSocket->createAcceptCallback(
+        NTCCFG_BIND(&test::ListenerSocketUtil::processAcceptCancelled,
+                    listenerSocket,
+                    NTCCFG_BIND_PLACEHOLDER_1,
+                    NTCCFG_BIND_PLACEHOLDER_2,
+                    NTCCFG_BIND_PLACEHOLDER_3,
+                    ntsa::Error::e_EOF,
+                    &semaphore),
+        allocator);
+
+    error = listenerSocket->accept(acceptOptions, acceptCallback);
+    NTCCFG_TEST_OK(error);
+
+    {
+        ntci::ListenerSocketCloseGuard listenerSocketCloseGuard(
+            listenerSocket);
+    }
+
+    semaphore.wait();
+
+    NTCI_LOG_DEBUG("Listener socket accept cancellation test complete");
+}
+
+namespace rateLimit {
+class DatagramSocketSession : public ntci::DatagramSocketSession
+{
+  private:
+    DatagramSocketSession(const DatagramSocketSession&) BSLS_KEYWORD_DELETED;
+    DatagramSocketSession& operator=(const DatagramSocketSession&)
+        BSLS_KEYWORD_DELETED;
+
+    bslmt::Semaphore& d_semaphore;
+    bsls::AtomicInt   d_readQueueRateLimitApplied;
+    bsls::AtomicInt   d_readQueueRateLimitRelaxed;
+    bsls::AtomicInt   d_writeQueueRateLimitApplied;
+    bsls::AtomicInt   d_writeQueueRateLimitRelaxed;
+
+  public:
+    explicit DatagramSocketSession(bslmt::Semaphore& semaphore);
+
+    ~DatagramSocketSession() BSLS_KEYWORD_OVERRIDE;
+
+    void processReadQueueRateLimitApplied(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::ReadQueueEvent& event) BSLS_KEYWORD_OVERRIDE;
+
+    void processReadQueueRateLimitRelaxed(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::ReadQueueEvent& event) BSLS_KEYWORD_OVERRIDE;
+
+    void processWriteQueueRateLimitApplied(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::WriteQueueEvent& event) BSLS_KEYWORD_OVERRIDE;
+
+    void processWriteQueueRateLimitRelaxed(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::WriteQueueEvent& event) BSLS_KEYWORD_OVERRIDE;
+
+    BSLS_ANNOTATION_NODISCARD int readQueueRateLimitApplied() const;
+    BSLS_ANNOTATION_NODISCARD int readQueueRateLimitRelaxed() const;
+
+    BSLS_ANNOTATION_NODISCARD int writeQueueRateLimitApplied() const;
+    BSLS_ANNOTATION_NODISCARD int writeQueueRateLimitRelaxed() const;
+};
+
+DatagramSocketSession::DatagramSocketSession(bslmt::Semaphore& semaphore)
+: d_semaphore(semaphore)
+, d_readQueueRateLimitApplied(0)
+, d_readQueueRateLimitRelaxed(0)
+, d_writeQueueRateLimitApplied(0)
+, d_writeQueueRateLimitRelaxed(0)
+{
+}
+
+DatagramSocketSession::~DatagramSocketSession()
+{
+}
+
+void DatagramSocketSession::processReadQueueRateLimitApplied(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::ReadQueueEvent&                  event)
+{
+    NTCI_LOG_CONTEXT();
+    NTCCFG_TEST_EQ(event.type(),
+                   ntca::ReadQueueEventType::e_RATE_LIMIT_APPLIED);
+    d_readQueueRateLimitApplied.addAcqRel(1);
+    d_semaphore.post();
+}
+
+void DatagramSocketSession::processReadQueueRateLimitRelaxed(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::ReadQueueEvent&                  event)
+{
+    NTCI_LOG_CONTEXT();
+    NTCCFG_TEST_EQ(event.type(),
+                   ntca::ReadQueueEventType::e_RATE_LIMIT_RELAXED);
+    d_readQueueRateLimitRelaxed.addAcqRel(1);
+    d_semaphore.post();
+}
+
+void DatagramSocketSession::processWriteQueueRateLimitApplied(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::WriteQueueEvent&                 event)
+{
+    NTCI_LOG_CONTEXT();
+    NTCCFG_TEST_EQ(event.type(),
+                   ntca::WriteQueueEventType::e_RATE_LIMIT_APPLIED);
+    d_writeQueueRateLimitApplied.addAcqRel(1);
+    d_semaphore.post();
+}
+
+void DatagramSocketSession::processWriteQueueRateLimitRelaxed(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::WriteQueueEvent&                 event)
+{
+    NTCI_LOG_CONTEXT();
+    NTCCFG_TEST_EQ(event.type(),
+                   ntca::WriteQueueEventType::e_RATE_LIMIT_RELAXED);
+    d_writeQueueRateLimitRelaxed.addAcqRel(1);
+    d_semaphore.post();
+}
+
+int DatagramSocketSession::readQueueRateLimitApplied() const
+{
+    return d_readQueueRateLimitApplied.loadAcquire();
+}
+
+int DatagramSocketSession::readQueueRateLimitRelaxed() const
+{
+    return d_readQueueRateLimitRelaxed.loadAcquire();
+}
+
+int DatagramSocketSession::writeQueueRateLimitApplied() const
+{
+    return d_writeQueueRateLimitApplied.loadAcquire();
+}
+
+int DatagramSocketSession::writeQueueRateLimitRelaxed() const
+{
+    return d_writeQueueRateLimitRelaxed.loadAcquire();
+}
+
+class StreamSocketSession : public ntci::StreamSocketSession
+{
+  private:
+    StreamSocketSession(const StreamSocketSession&) BSLS_KEYWORD_DELETED;
+    StreamSocketSession& operator=(const StreamSocketSession&)
+        BSLS_KEYWORD_DELETED;
+
+    bslmt::Semaphore& d_semaphore;
+    bsls::AtomicInt   d_readQueueRateLimitApplied;
+    bsls::AtomicInt   d_readQueueRateLimitRelaxed;
+    bsls::AtomicInt   d_writeQueueRateLimitApplied;
+    bsls::AtomicInt   d_writeQueueRateLimitRelaxed;
+
+  public:
+    explicit StreamSocketSession(bslmt::Semaphore& semaphore);
+
+    ~StreamSocketSession() BSLS_KEYWORD_OVERRIDE;
+
+    void processReadQueueRateLimitApplied(
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const ntca::ReadQueueEvent& event) BSLS_KEYWORD_OVERRIDE;
+
+    void processReadQueueRateLimitRelaxed(
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const ntca::ReadQueueEvent& event) BSLS_KEYWORD_OVERRIDE;
+
+    void processWriteQueueRateLimitApplied(
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const ntca::WriteQueueEvent& event) BSLS_KEYWORD_OVERRIDE;
+
+    void processWriteQueueRateLimitRelaxed(
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const ntca::WriteQueueEvent& event) BSLS_KEYWORD_OVERRIDE;
+
+    BSLS_ANNOTATION_NODISCARD int readQueueRateLimitApplied() const;
+    BSLS_ANNOTATION_NODISCARD int readQueueRateLimitRelaxed() const;
+    BSLS_ANNOTATION_NODISCARD int writeQueueRateLimitApplied() const;
+    BSLS_ANNOTATION_NODISCARD int writeQueueRateLimitRelaxed() const;
+};
+
+StreamSocketSession::StreamSocketSession(bslmt::Semaphore& semaphore)
+: d_semaphore(semaphore)
+, d_readQueueRateLimitApplied(0)
+, d_readQueueRateLimitRelaxed(0)
+, d_writeQueueRateLimitApplied(0)
+, d_writeQueueRateLimitRelaxed(0)
+{
+}
+
+StreamSocketSession::~StreamSocketSession()
+{
+}
+
+void StreamSocketSession::processReadQueueRateLimitApplied(
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const ntca::ReadQueueEvent&                event)
+{
+    NTCI_LOG_CONTEXT();
+    NTCCFG_TEST_EQ(event.type(),
+                   ntca::ReadQueueEventType::e_RATE_LIMIT_APPLIED);
+    d_readQueueRateLimitApplied.addAcqRel(1);
+
+    d_semaphore.post();
+}
+
+void StreamSocketSession::processWriteQueueRateLimitApplied(
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const ntca::WriteQueueEvent&               event)
+{
+    NTCI_LOG_CONTEXT();
+    NTCCFG_TEST_EQ(event.type(),
+                   ntca::WriteQueueEventType::e_RATE_LIMIT_APPLIED);
+    d_writeQueueRateLimitApplied.addAcqRel(1);
+    d_semaphore.post();
+}
+
+void StreamSocketSession::processReadQueueRateLimitRelaxed(
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const ntca::ReadQueueEvent&                event)
+{
+    NTCI_LOG_CONTEXT();
+    NTCCFG_TEST_EQ(event.type(),
+                   ntca::ReadQueueEventType::e_RATE_LIMIT_RELAXED);
+    d_readQueueRateLimitRelaxed.addAcqRel(1);
+
+    d_semaphore.post();
+}
+
+void StreamSocketSession::processWriteQueueRateLimitRelaxed(
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const ntca::WriteQueueEvent&               event)
+{
+    NTCI_LOG_CONTEXT();
+    NTCCFG_TEST_EQ(event.type(),
+                   ntca::WriteQueueEventType::e_RATE_LIMIT_RELAXED);
+    d_writeQueueRateLimitRelaxed.addAcqRel(1);
+    d_semaphore.post();
+}
+
+int StreamSocketSession::readQueueRateLimitApplied() const
+{
+    return d_readQueueRateLimitApplied.loadAcquire();
+}
+
+int StreamSocketSession::writeQueueRateLimitApplied() const
+{
+    return d_writeQueueRateLimitApplied.loadAcquire();
+}
+
+int StreamSocketSession::readQueueRateLimitRelaxed() const
+{
+    return d_readQueueRateLimitRelaxed.loadAcquire();
+}
+
+int StreamSocketSession::writeQueueRateLimitRelaxed() const
+{
+    return d_writeQueueRateLimitRelaxed.loadAcquire();
+}
+
+class ListenerSocketSession : public ntci::ListenerSocketSession
+{
+  private:
+    ListenerSocketSession(const ListenerSocketSession&) BSLS_KEYWORD_DELETED;
+    ListenerSocketSession& operator=(const ListenerSocketSession&)
+        BSLS_KEYWORD_DELETED;
+
+    bslmt::Semaphore& d_semaphore;
+    bsls::AtomicInt   d_rateLimitApplied;
+    bsls::AtomicInt   d_rateLimitRelaxed;
+
+  public:
+    explicit ListenerSocketSession(bslmt::Semaphore& semaphore);
+
+    ~ListenerSocketSession() BSLS_KEYWORD_OVERRIDE;
+
+    void processAcceptQueueRateLimitApplied(
+        const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
+        const ntca::AcceptQueueEvent& event) BSLS_KEYWORD_OVERRIDE;
+
+    void processAcceptQueueRateLimitRelaxed(
+        const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
+        const ntca::AcceptQueueEvent& event) BSLS_KEYWORD_OVERRIDE;
+
+    BSLS_ANNOTATION_NODISCARD int rateLimitApplied() const;
+    BSLS_ANNOTATION_NODISCARD int rateLimitRelaxed() const;
+};
+
+ListenerSocketSession::ListenerSocketSession(bslmt::Semaphore& semaphore)
+: d_semaphore(semaphore)
+{
+}
+
+ListenerSocketSession::~ListenerSocketSession()
+{
+}
+
+void ListenerSocketSession::processAcceptQueueRateLimitApplied(
+    const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
+    const ntca::AcceptQueueEvent&                event)
+{
+    NTCI_LOG_CONTEXT();
+    NTCCFG_TEST_EQ(event.type(),
+                   ntca::AcceptQueueEventType::e_RATE_LIMIT_APPLIED);
+    d_rateLimitApplied.addAcqRel(1);
+    d_semaphore.post();
+}
+
+void ListenerSocketSession::processAcceptQueueRateLimitRelaxed(
+    const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
+    const ntca::AcceptQueueEvent&                event)
+{
+    NTCI_LOG_CONTEXT();
+    NTCCFG_TEST_EQ(event.type(),
+                   ntca::AcceptQueueEventType::e_RATE_LIMIT_RELAXED);
+    d_rateLimitRelaxed.addAcqRel(1);
+    d_semaphore.post();
+}
+
+int ListenerSocketSession::rateLimitApplied() const
+{
+    return d_rateLimitApplied.loadAcquire();
+}
+
+int ListenerSocketSession::rateLimitRelaxed() const
+{
+    return d_rateLimitApplied.loadAcquire();
+}
+
+}  // rateLimit
+
+void concernDatagramSocketReceiveRateLimitTimerClose(
+    const bsl::shared_ptr<ntci::Interface>& interface,
+    bslma::Allocator*                       allocator)
+{
+    // Concern: validate that receive rate limit timer is automatically closed
+    // when the socket is closed and then destroyed
+
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_DEBUG("Test started");
+
+    const ntsa::Transport::Value transport =
+        ntsa::Transport::e_UDP_IPV4_DATAGRAM;
+
+    ntsa::Error      error;
+    bslmt::Semaphore receiveSemaphore;
+    bslmt::Semaphore rateLimitSemaphore;
+
+    bsl::shared_ptr<ntci::DatagramSocket> clientDatagramSocket;
+    bsl::shared_ptr<ntci::DatagramSocket> serverDatagramSocket;
+    {
+        ntca::DatagramSocketOptions options;
+        options.setTransport(transport);
+
+        bsl::shared_ptr<ntsi::DatagramSocket> basicClientSocket;
+        bsl::shared_ptr<ntsi::DatagramSocket> basicServerSocket;
+
+        error = ntsf::System::createDatagramSocketPair(&basicClientSocket,
+                                                       &basicServerSocket,
+                                                       transport);
+        NTCCFG_TEST_FALSE(error);
+
+        clientDatagramSocket =
+            interface->createDatagramSocket(options, allocator);
+
+        error = clientDatagramSocket->open(transport, basicClientSocket);
+        NTCCFG_TEST_FALSE(error);
+
+        serverDatagramSocket =
+            interface->createDatagramSocket(options, allocator);
+
+        error = serverDatagramSocket->open(transport, basicServerSocket);
+        NTCCFG_TEST_FALSE(error);
+    }
+
+    bsl::shared_ptr<rateLimit::DatagramSocketSession> session;
+    {
+        session.createInplace(allocator, rateLimitSemaphore);
+        serverDatagramSocket->registerSession(session);
+    }
+
+    const int k_MESSAGE_SIZE = 65507;  //maximum
+    const int k_NUM_MESSAGES = 1024;
+
+    NTCI_LOG_DEBUG("Generating message");
+    bsl::shared_ptr<bdlbb::Blob> message =
+        clientDatagramSocket->createOutgoingBlob();
+    ntcd::DataUtil::generateData(message.get(), k_MESSAGE_SIZE, 0, 0);
+
+    NTCI_LOG_DEBUG("Generating message: OK");
+
+    {
+        bsl::shared_ptr<ntcs::RateLimiter> limiter;
+
+        //configure sustained rate limit in a way that it will be reached
+        // immediately. e.g. 2 bytes per second
+        const bsl::uint64_t sustainedRateLimit = 2;
+        bsls::TimeInterval  sustainedRateWindow;
+        sustainedRateWindow.setTotalHours(1);
+
+        // do not care about peak limit
+        const bsl::uint64_t peakRateLimit =
+            bsl::numeric_limits<bsl::uint32_t>::max();
+        bsls::TimeInterval peakRateWindow;
+        peakRateWindow.setTotalSeconds(1);
+
+        limiter.createInplace(allocator,
+                              sustainedRateLimit,
+                              sustainedRateWindow,
+                              peakRateLimit,
+                              peakRateWindow,
+                              serverDatagramSocket->currentTime());
+        serverDatagramSocket->setReadRateLimiter(limiter);
+    }
+
+    NTCI_LOG_DEBUG("Sending messages");
+    {
+        for (int i = 0; i < k_NUM_MESSAGES; ++i) {
+            ntca::SendOptions sendOptions;
+
+            error = clientDatagramSocket->send(*message, sendOptions);
+            NTCCFG_TEST_TRUE(!error);
+        }
+    }
+
+    NTCI_LOG_DEBUG("Receiving messages");
+    {
+        ntca::ReceiveOptions receiveOptions;
+        receiveOptions.setSize(k_MESSAGE_SIZE * k_NUM_MESSAGES);
+
+        ntci::ReceiveCallback receiveCallback =
+            serverDatagramSocket->createReceiveCallback(
+                NTCCFG_BIND(&test::DatagramSocketUtil::processReceiveFailed,
+                            NTCCFG_BIND_PLACEHOLDER_1,
+                            NTCCFG_BIND_PLACEHOLDER_2,
+                            NTCCFG_BIND_PLACEHOLDER_3,
+                            &receiveSemaphore),
+                allocator);
+
+        error = serverDatagramSocket->receive(receiveOptions, receiveCallback);
+        NTCCFG_TEST_OK(error);
+    }
+
+    rateLimitSemaphore.wait();
+
+    {
+        ntci::DatagramSocketCloseGuard closeGuardClient(clientDatagramSocket);
+        ntci::DatagramSocketCloseGuard closeGuardServer(serverDatagramSocket);
+    }
+
+    receiveSemaphore.wait();
+
+    NTCCFG_TEST_GE(session->readQueueRateLimitApplied(), 1);
+}
+
+void concernStreamSocketReceiveRateLimitTimerClose(
+    const bsl::shared_ptr<ntci::Interface>& interface,
+    bslma::Allocator*                       allocator)
+{
+    // Concern: validate that receive rate limit timer is automatically closed
+    // when the socket is closed and then destroyed
+
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_DEBUG("Test started");
+
+    const ntsa::Transport::Value transport =
+        ntsa::Transport::e_TCP_IPV4_STREAM;
+
+    ntsa::Error      error;
+    bslmt::Semaphore receiveSemaphore;
+    bslmt::Semaphore rateLimitSemaphore;
+
+    bsl::shared_ptr<ntci::StreamSocket> clientStreamSocket;
+    bsl::shared_ptr<ntci::StreamSocket> serverStreamSocket;
+    {
+        ntca::StreamSocketOptions options;
+        options.setTransport(transport);
+
+        bsl::shared_ptr<ntsi::StreamSocket> basicClientSocket;
+        bsl::shared_ptr<ntsi::StreamSocket> basicServerSocket;
+
+        error = ntsf::System::createStreamSocketPair(&basicClientSocket,
+                                                     &basicServerSocket,
+                                                     transport);
+        NTCCFG_TEST_FALSE(error);
+
+        clientStreamSocket = interface->createStreamSocket(options, allocator);
+
+        error = clientStreamSocket->open(transport, basicClientSocket);
+        NTCCFG_TEST_FALSE(error);
+
+        serverStreamSocket = interface->createStreamSocket(options, allocator);
+
+        error = serverStreamSocket->open(transport, basicServerSocket);
+        NTCCFG_TEST_FALSE(error);
+    }
+
+    bsl::shared_ptr<rateLimit::StreamSocketSession> session;
+    {
+        session.createInplace(allocator, rateLimitSemaphore);
+        serverStreamSocket->registerSession(session);
+    }
+
+    const int k_MESSAGE_SIZE = 65000;
+    const int k_NUM_MESSAGES = 1024;
+
+    NTCI_LOG_DEBUG("Generating message");
+    bsl::shared_ptr<bdlbb::Blob> message =
+        clientStreamSocket->createOutgoingBlob();
+    ntcd::DataUtil::generateData(message.get(), k_MESSAGE_SIZE, 0, 0);
+
+    NTCI_LOG_DEBUG("Generating message: OK");
+
+    {
+        bsl::shared_ptr<ntcs::RateLimiter> limiter;
+
+        //configure sustained rate limit in a way that it will be reached
+        // immediately. e.g. 2 bytes per hour
+        const bsl::uint64_t sustainedRateLimit = 2;
+        bsls::TimeInterval  sustainedRateWindow;
+        sustainedRateWindow.setTotalHours(1);
+
+        // do not care about peak limit
+        const bsl::uint64_t peakRateLimit =
+            bsl::numeric_limits<bsl::uint32_t>::max();
+        bsls::TimeInterval peakRateWindow;
+        peakRateWindow.setTotalSeconds(1);
+
+        limiter.createInplace(allocator,
+                              sustainedRateLimit,
+                              sustainedRateWindow,
+                              peakRateLimit,
+                              peakRateWindow,
+                              serverStreamSocket->currentTime());
+        serverStreamSocket->setReadRateLimiter(limiter);
+    }
+
+    NTCI_LOG_DEBUG("Sending messages");
+    {
+        for (int i = 0; i < k_NUM_MESSAGES; ++i) {
+            ntca::SendOptions sendOptions;
+
+            error = clientStreamSocket->send(*message, sendOptions);
+            NTCCFG_TEST_TRUE(!error);
+        }
+    }
+
+    NTCI_LOG_DEBUG("Receiving messages");
+    {
+        ntca::ReceiveOptions receiveOptions;
+        receiveOptions.setSize(k_MESSAGE_SIZE * k_NUM_MESSAGES);
+
+        ntci::ReceiveCallback receiveCallback =
+            serverStreamSocket->createReceiveCallback(
+                NTCCFG_BIND(&test::DatagramSocketUtil::processReceiveFailed,
+                            NTCCFG_BIND_PLACEHOLDER_1,
+                            NTCCFG_BIND_PLACEHOLDER_2,
+                            NTCCFG_BIND_PLACEHOLDER_3,
+                            &receiveSemaphore),
+                allocator);
+
+        error = serverStreamSocket->receive(receiveOptions, receiveCallback);
+        NTCCFG_TEST_OK(error);
+    }
+
+    rateLimitSemaphore.wait();
+
+    {
+        ntci::StreamSocketCloseGuard closeGuardClient(clientStreamSocket);
+        ntci::StreamSocketCloseGuard closeGuardServer(serverStreamSocket);
+    }
+
+    receiveSemaphore.wait();
+
+    NTCCFG_TEST_GE(session->readQueueRateLimitApplied(), 1);
+}
+
+void concernDatagramSocketSendRateLimitTimerClose(
+    const bsl::shared_ptr<ntci::Interface>& interface,
+    bslma::Allocator*                       allocator)
+{
+    // Concern: validate that send rate limit timer is automatically closed
+    // when the socket is closed and then destroyed
+
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_DEBUG("Test started");
+
+    const ntsa::Transport::Value transport =
+        ntsa::Transport::e_UDP_IPV4_DATAGRAM;
+
+    ntsa::Error      error;
+    bslmt::Semaphore rateLimitSemaphore;
+
+    bsl::shared_ptr<ntci::DatagramSocket> clientDatagramSocket;
+    bsl::shared_ptr<ntci::DatagramSocket> serverDatagramSocket;
+    {
+        ntca::DatagramSocketOptions options;
+        options.setTransport(transport);
+
+        bsl::shared_ptr<ntsi::DatagramSocket> basicClientSocket;
+        bsl::shared_ptr<ntsi::DatagramSocket> basicServerSocket;
+
+        error = ntsf::System::createDatagramSocketPair(&basicClientSocket,
+                                                       &basicServerSocket,
+                                                       transport);
+        NTCCFG_TEST_FALSE(error);
+
+        clientDatagramSocket =
+            interface->createDatagramSocket(options, allocator);
+
+        error = clientDatagramSocket->open(transport, basicClientSocket);
+        NTCCFG_TEST_FALSE(error);
+
+        serverDatagramSocket =
+            interface->createDatagramSocket(options, allocator);
+
+        error = serverDatagramSocket->open(transport, basicServerSocket);
+        NTCCFG_TEST_FALSE(error);
+    }
+
+    bsl::shared_ptr<rateLimit::DatagramSocketSession> session;
+    {
+        session.createInplace(allocator, rateLimitSemaphore);
+        clientDatagramSocket->registerSession(session);
+    }
+
+    const int k_MESSAGE_SIZE = 65507;  //maximum
+    const int k_NUM_MESSAGES = 1024;
+
+    NTCI_LOG_DEBUG("Generating message");
+    bsl::shared_ptr<bdlbb::Blob> message =
+        clientDatagramSocket->createOutgoingBlob();
+    ntcd::DataUtil::generateData(message.get(), k_MESSAGE_SIZE, 0, 0);
+
+    NTCI_LOG_DEBUG("Generating message: OK");
+
+    {
+        bsl::shared_ptr<ntcs::RateLimiter> limiter;
+
+        //configure sustained rate limit in a way that it will be reached
+        // immediately. e.g. 2 bytes per hour
+        const bsl::uint64_t sustainedRateLimit = 2;
+        bsls::TimeInterval  sustainedRateWindow;
+        sustainedRateWindow.setTotalHours(1);
+
+        // do not care about peak limit
+        const bsl::uint64_t peakRateLimit =
+            bsl::numeric_limits<bsl::uint32_t>::max();
+        bsls::TimeInterval peakRateWindow;
+        peakRateWindow.setTotalSeconds(1);
+
+        limiter.createInplace(allocator,
+                              sustainedRateLimit,
+                              sustainedRateWindow,
+                              peakRateLimit,
+                              peakRateWindow,
+                              serverDatagramSocket->currentTime());
+        clientDatagramSocket->setWriteRateLimiter(limiter);
+    }
+
+    NTCI_LOG_DEBUG("Sending messages");
+    {
+        for (int i = 0; i < k_NUM_MESSAGES; ++i) {
+            ntca::SendOptions sendOptions;
+
+            error = clientDatagramSocket->send(*message, sendOptions);
+            NTCCFG_TEST_TRUE(!error);
+        }
+    }
+    NTCI_LOG_DEBUG("Sending done");
+
+    rateLimitSemaphore.wait();
+
+    NTCCFG_TEST_GE(session->writeQueueRateLimitApplied(), 1);
+
+    {
+        ntci::DatagramSocketCloseGuard closeGuardClient(clientDatagramSocket);
+        ntci::DatagramSocketCloseGuard closeGuardServer(serverDatagramSocket);
+    }
+}
+
+void concernStreamSocketSendRateLimitTimerClose(
+    const bsl::shared_ptr<ntci::Interface>& interface,
+    bslma::Allocator*                       allocator)
+{
+    // Concern: validate that send rate limit timer is automatically closed
+    // when the socket is closed and then destroyed
+
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_DEBUG("Test started");
+
+    const ntsa::Transport::Value transport =
+        ntsa::Transport::e_TCP_IPV4_STREAM;
+
+    ntsa::Error      error;
+    bslmt::Semaphore receiveSemaphore;
+    bslmt::Semaphore rateLimitSemaphore;
+
+    bsl::shared_ptr<ntci::StreamSocket> clientStreamSocket;
+    bsl::shared_ptr<ntci::StreamSocket> serverStreamSocket;
+    {
+        ntca::StreamSocketOptions options;
+        options.setTransport(transport);
+
+        bsl::shared_ptr<ntsi::StreamSocket> basicClientSocket;
+        bsl::shared_ptr<ntsi::StreamSocket> basicServerSocket;
+
+        error = ntsf::System::createStreamSocketPair(&basicClientSocket,
+                                                     &basicServerSocket,
+                                                     transport);
+        NTCCFG_TEST_FALSE(error);
+
+        clientStreamSocket = interface->createStreamSocket(options, allocator);
+
+        error = clientStreamSocket->open(transport, basicClientSocket);
+        NTCCFG_TEST_FALSE(error);
+
+        serverStreamSocket = interface->createStreamSocket(options, allocator);
+
+        error = serverStreamSocket->open(transport, basicServerSocket);
+        NTCCFG_TEST_FALSE(error);
+    }
+
+    bsl::shared_ptr<rateLimit::StreamSocketSession> session;
+    {
+        session.createInplace(allocator, rateLimitSemaphore);
+        clientStreamSocket->registerSession(session);
+    }
+
+    const int k_MESSAGE_SIZE = 65000;
+    const int k_NUM_MESSAGES = 1024;
+
+    NTCI_LOG_DEBUG("Generating message");
+    bsl::shared_ptr<bdlbb::Blob> message =
+        clientStreamSocket->createOutgoingBlob();
+    ntcd::DataUtil::generateData(message.get(), k_MESSAGE_SIZE, 0, 0);
+
+    NTCI_LOG_DEBUG("Generating message: OK");
+
+    {
+        bsl::shared_ptr<ntcs::RateLimiter> limiter;
+
+        //configure sustained rate limit in a way that it will be reached
+        // immediately. e.g. 2 bytes per hour
+        const bsl::uint64_t sustainedRateLimit = 2;
+        bsls::TimeInterval  sustainedRateWindow;
+        sustainedRateWindow.setTotalHours(1);
+
+        // do not care about peak limit
+        const bsl::uint64_t peakRateLimit =
+            bsl::numeric_limits<bsl::uint32_t>::max();
+        bsls::TimeInterval peakRateWindow;
+        peakRateWindow.setTotalSeconds(1);
+
+        limiter.createInplace(allocator,
+                              sustainedRateLimit,
+                              sustainedRateWindow,
+                              peakRateLimit,
+                              peakRateWindow,
+                              serverStreamSocket->currentTime());
+        clientStreamSocket->setWriteRateLimiter(limiter);
+    }
+
+    NTCI_LOG_DEBUG("Sending messages");
+    {
+        for (int i = 0; i < k_NUM_MESSAGES; ++i) {
+            ntca::SendOptions sendOptions;
+
+            error = clientStreamSocket->send(*message, sendOptions);
+            NTCCFG_TEST_TRUE(!error);
+        }
+    }
+
+    rateLimitSemaphore.wait();
+
+    {
+        ntci::StreamSocketCloseGuard closeGuardClient(clientStreamSocket);
+        ntci::StreamSocketCloseGuard closeGuardServer(serverStreamSocket);
+    }
+
+    NTCCFG_TEST_GE(session->writeQueueRateLimitApplied(), 1);
+}
+
+void concernListenerSocketAcceptRateLimitTimerClose(
+    const bsl::shared_ptr<ntci::Interface>& interface,
+    bslma::Allocator*                       allocator)
+{
+    // Concern: validate that accept rate limit timer is automatically closed
+    // when the socket is closed and then destroyed
+
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_DEBUG("Test started");
+
+    const ntsa::Transport::Value transport =
+        ntsa::Transport::e_TCP_IPV4_STREAM;
+
+    ntsa::Error      error;
+    bslmt::Semaphore acceptLimitSemaphore;
+
+    bsl::shared_ptr<ntci::ListenerSocket> listenerSocket;
+    {
+        ntca::ListenerSocketOptions options;
+        options.setTransport(transport);
+        options.setSourceEndpoint(test::EndpointUtil::any(transport));
+
+        listenerSocket = interface->createListenerSocket(options, allocator);
+    }
+
+    bsl::shared_ptr<rateLimit::ListenerSocketSession> session;
+    {
+        session.createInplace(allocator, acceptLimitSemaphore);
+        listenerSocket->registerSession(session);
+    }
+
+    {
+        bsl::shared_ptr<ntcs::RateLimiter> limiter;
+
+        // configure sustained rate limit in a way that it will be reached
+        // immediately. e.g. 1 acceptance per second
+        const bsl::uint64_t sustainedRateLimit = 1;
+        bsls::TimeInterval  sustainedRateWindow;
+        sustainedRateWindow.setTotalHours(1);
+
+        // do not care about peak limit
+        const bsl::uint64_t peakRateLimit = 1;
+        bsls::TimeInterval  peakRateWindow;
+        peakRateWindow.setTotalSeconds(1);
+
+        limiter.createInplace(allocator,
+                              sustainedRateLimit,
+                              sustainedRateWindow,
+                              peakRateLimit,
+                              peakRateWindow,
+                              listenerSocket->currentTime());
+        listenerSocket->setAcceptRateLimiter(limiter);
+    }
+
+    error = listenerSocket->open();
+    NTCCFG_TEST_FALSE(error);
+
+    error = listenerSocket->listen();
+    NTCCFG_TEST_FALSE(error);
+
+    NTCI_LOG_DEBUG("Listener socket starts listening");
+
+    const int numSockets = 10;
+
+    bsl::vector<bsl::shared_ptr<ntci::StreamSocket> > clientSockets(allocator);
+    bsl::vector<bsl::shared_ptr<ntci::ConnectFuture> > connectFutures(
+        allocator);
+    bsl::vector<bsl::shared_ptr<ntci::AcceptFuture> > acceptFutures(allocator);
+
+    NTCI_LOG_DEBUG("Creating client sockets");
+
+    for (int i = 0; i < numSockets; ++i) {
+        ntca::StreamSocketOptions options;
+        options.setTransport(transport);
+
+        bsl::shared_ptr<ntci::StreamSocket> clientStreamSocket =
+            interface->createStreamSocket(options, allocator);
+
+        error = clientStreamSocket->open();
+        NTCCFG_TEST_OK(error);
+        clientSockets.push_back(clientStreamSocket);
+    }
+
+    NTCI_LOG_DEBUG("Preparing futures");
+    for (int i = 0; i < numSockets; ++i) {
+        bsl::shared_ptr<ntci::ConnectFuture> connectFuture;
+        connectFuture.createInplace(allocator);
+        connectFutures.push_back(connectFuture);
+
+        bsl::shared_ptr<ntci::AcceptFuture> acceptFuture;
+        acceptFuture.createInplace(allocator);
+        acceptFutures.push_back(acceptFuture);
+    }
+
+    NTCI_LOG_DEBUG("Accepting connections");
+    for (int i = 0; i < numSockets; ++i) {
+        error =
+            listenerSocket->accept(ntca::AcceptOptions(), *(acceptFutures[i]));
+        NTCCFG_TEST_OK(error);
+    }
+
+    NTCI_LOG_DEBUG("Initiating connections");
+    for (int i = 0; i < numSockets; ++i) {
+        error = clientSockets[i]->connect(listenerSocket->sourceEndpoint(),
+                                          ntca::ConnectOptions(),
+                                          *(connectFutures[i]));
+        NTCCFG_TEST_OK(error);
+    }
+
+    acceptLimitSemaphore.wait();
+    acceptLimitSemaphore.wait();
+
+    NTCCFG_TEST_GE(session->rateLimitApplied(), 1);
+    NTCCFG_TEST_GE(session->rateLimitRelaxed(), 1);
+
+    {
+        {
+            ntci::ListenerSocketCloseGuard listenerSocketCloseGuard(
+                listenerSocket);
+        }
+        listenerSocket.reset();
+    }
+
+    NTCI_LOG_DEBUG("Cleaning accepted connections");
+    for (size_t i = 0; i < acceptFutures.size(); ++i) {
+        const bsls::TimeInterval zero;
+        ntci::AcceptResult       acceptResult;
+        error = acceptFutures[i]->wait(&acceptResult, zero);
+        if (!error) {
+            ntci::StreamSocketCloseGuard closeGuard(
+                acceptResult.streamSocket());
+        }
+    }
+
+    for (size_t i = 0; i < clientSockets.size(); ++i) {
+        ntci::StreamSocketCloseGuard closeGuard(clientSockets[i]);
+    }
+}
+
+void concernStreamSocketConnectRetryTimerClose(
+    const bsl::shared_ptr<ntci::Interface>& interface,
+    bslma::Allocator*                       allocator)
+{
+    // Concern: validate that connect retry timer is automatically closed
+    // when the socket is closed and then destroyed
+
+    const bsl::size_t k_MAX_CONNECTION_ATTEMPTS = 2;
+    const double      k_RETRY_INTERVAL_HOURS    = 1;
+
+    NTCI_LOG_CONTEXT();
+
+    ntsa::Error                  error;
+    const ntsa::Transport::Value transport =
+        ntsa::Transport::e_TCP_IPV4_STREAM;
+
+    NTCI_LOG_DEBUG("Creating stream socket");
+    bsl::shared_ptr<ntci::StreamSocket> streamSocket;
+    {
+        ntca::StreamSocketOptions streamSocketOptions;
+        streamSocketOptions.setTransport(transport);
+
+        streamSocket =
+            interface->createStreamSocket(streamSocketOptions, allocator);
+    }
+
+    NTCI_LOG_DEBUG("Creating and binding listener socket");
+    bsl::shared_ptr<ntci::ListenerSocket> listenerSocket;
+    {
+        ntca::ListenerSocketOptions options;
+        options.setTransport(transport);
+        options.setSourceEndpoint(test::EndpointUtil::any(transport));
+
+        listenerSocket = interface->createListenerSocket(options, allocator);
+        listenerSocket->open();
+    }
+    ntci::ListenerSocketCloseGuard listenerCloseGuard(listenerSocket);
+
+    NTCI_LOG_DEBUG("Trying to connect");
+    ntci::ConnectFuture connectFuture(allocator);
+    {
+        bsls::TimeInterval retryInterval;
+        retryInterval.setTotalHours(k_RETRY_INTERVAL_HOURS);
+        ntca::ConnectOptions connectOptions;
+        connectOptions.setRetryCount(k_MAX_CONNECTION_ATTEMPTS - 1);
+        connectOptions.setRetryInterval(retryInterval);
+
+        const ntsa::Endpoint endpoint = listenerSocket->sourceEndpoint();
+
+        error = streamSocket->connect(endpoint, connectOptions, connectFuture);
+        NTCCFG_TEST_OK(error);
+    }
+
+    NTCI_LOG_DEBUG("Processing connect result");
+    {
+        ntci::ConnectResult connectResult;
+        error = connectFuture.wait(&connectResult);
+        NTCCFG_TEST_OK(error);
+
+        NTCCFG_TEST_LOG_INFO << "Processing connect event "
+                             << connectResult.event() << NTCCFG_TEST_LOG_END;
+
+        NTCCFG_TEST_EQ(connectResult.event().type(),
+                       ntca::ConnectEventType::e_ERROR);
+    }
+
+    NTCI_LOG_DEBUG("closing the socket");
+    {
+        {
+            ntci::StreamSocketCloseGuard closeGuard(streamSocket);
+        }
+        streamSocket.reset();
+    }
+}
+
+void concernStreamSocketConnectDeadlineTimerClose(
+    const bsl::shared_ptr<ntci::Interface>& interface,
+    bslma::Allocator*                       allocator)
+{
+    // Concern: validate that connect deadline timer is automatically closed
+    // when the socket is closed and then destroyed
+
+    const bsl::size_t k_MAX_CONNECTION_ATTEMPTS = 60;
+    const int         k_DEADLINE_INTERVAL_HOURS = 1;
+    const int         k_RETRY_INTERVAL_MINUTES  = 1;
+
+    NTCI_LOG_CONTEXT();
+
+    ntsa::Error                  error;
+    const ntsa::Transport::Value transport =
+        ntsa::Transport::e_TCP_IPV4_STREAM;
+
+    NTCI_LOG_DEBUG("Creating stream socket");
+    bsl::shared_ptr<ntci::StreamSocket> streamSocket;
+    {
+        ntca::StreamSocketOptions streamSocketOptions;
+        streamSocketOptions.setTransport(transport);
+
+        streamSocket =
+            interface->createStreamSocket(streamSocketOptions, allocator);
+    }
+
+    NTCI_LOG_DEBUG("Creating and binding listener socket");
+    bsl::shared_ptr<ntci::ListenerSocket> listenerSocket;
+    {
+        ntca::ListenerSocketOptions options;
+        options.setTransport(transport);
+        options.setSourceEndpoint(test::EndpointUtil::any(transport));
+
+        listenerSocket = interface->createListenerSocket(options, allocator);
+        listenerSocket->open();
+    }
+    ntci::ListenerSocketCloseGuard listenerCloseGuard(listenerSocket);
+
+    NTCI_LOG_DEBUG("Trying to connect");
+    ntci::ConnectFuture connectFuture(allocator);
+    {
+        bsls::TimeInterval deadlineInterval;
+        deadlineInterval.setTotalHours(k_DEADLINE_INTERVAL_HOURS);
+
+        bsls::TimeInterval retryInterval;
+        retryInterval.setTotalMinutes(k_RETRY_INTERVAL_MINUTES);
+
+        ntca::ConnectOptions connectOptions;
+        connectOptions.setRetryCount(k_MAX_CONNECTION_ATTEMPTS);
+        connectOptions.setRetryInterval(retryInterval);
+        connectOptions.setDeadline(streamSocket->currentTime() +
+                                   deadlineInterval);
+
+        const ntsa::Endpoint endpoint = listenerSocket->sourceEndpoint();
+
+        error = streamSocket->connect(endpoint, connectOptions, connectFuture);
+        NTCCFG_TEST_OK(error);
+    }
+
+    NTCI_LOG_DEBUG("Processing connect result");
+    {
+        ntci::ConnectResult connectResult;
+        error = connectFuture.wait(&connectResult);
+        NTCCFG_TEST_OK(error);
+
+        NTCCFG_TEST_LOG_INFO << "Processing connect event "
+                             << connectResult.event() << NTCCFG_TEST_LOG_END;
+
+        NTCCFG_TEST_EQ(connectResult.event().type(),
+                       ntca::ConnectEventType::e_ERROR);
+    }
+
+    NTCI_LOG_DEBUG("closing the socket");
+    {
+        {
+            ntci::StreamSocketCloseGuard closeGuard(streamSocket);
+        }
+        streamSocket.reset();
+    }
+}
+
+void concernDatagramSocketReceiveRateLimitTimerEventNotifications(
+    const bsl::shared_ptr<ntci::Interface>& interface,
+    bslma::Allocator*                       allocator)
+{
+    // Concern: validate that e_RATE_LIMIT_APPLIED and e_RATE_LIMIT_RELAXED
+    // events are fired
+
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_DEBUG("Test started");
+
+    const ntsa::Transport::Value transport =
+        ntsa::Transport::e_UDP_IPV4_DATAGRAM;
+
+    ntsa::Error      error;
+    bslmt::Semaphore receiveSemaphore;
+    bslmt::Semaphore rateLimitSemaphore;
+
+    bsl::shared_ptr<ntci::DatagramSocket> clientDatagramSocket;
+    bsl::shared_ptr<ntci::DatagramSocket> serverDatagramSocket;
+    {
+        ntca::DatagramSocketOptions options;
+        options.setTransport(transport);
+
+        bsl::shared_ptr<ntsi::DatagramSocket> basicClientSocket;
+        bsl::shared_ptr<ntsi::DatagramSocket> basicServerSocket;
+
+        error = ntsf::System::createDatagramSocketPair(&basicClientSocket,
+                                                       &basicServerSocket,
+                                                       transport);
+        NTCCFG_TEST_FALSE(error);
+
+        clientDatagramSocket =
+            interface->createDatagramSocket(options, allocator);
+
+        error = clientDatagramSocket->open(transport, basicClientSocket);
+        NTCCFG_TEST_FALSE(error);
+
+        serverDatagramSocket =
+            interface->createDatagramSocket(options, allocator);
+
+        error = serverDatagramSocket->open(transport, basicServerSocket);
+        NTCCFG_TEST_FALSE(error);
+    }
+
+    bsl::shared_ptr<rateLimit::DatagramSocketSession> session;
+    {
+        session.createInplace(allocator, rateLimitSemaphore);
+        serverDatagramSocket->registerSession(session);
+    }
+
+    const int k_MESSAGE_SIZE = 65507;  //maximum
+    const int k_NUM_MESSAGES = 100;
+
+    NTCI_LOG_DEBUG("Generating message");
+    bsl::shared_ptr<bdlbb::Blob> message =
+        clientDatagramSocket->createOutgoingBlob();
+    ntcd::DataUtil::generateData(message.get(), k_MESSAGE_SIZE, 0, 0);
+
+    NTCI_LOG_DEBUG("Generating message: OK");
+
+    {
+        bsl::shared_ptr<ntcs::RateLimiter> limiter;
+
+        // configure sustained rate limit in a way that it will be reached
+        // immediately
+
+        const bsl::uint64_t      sustainedRateLimit = k_MESSAGE_SIZE;
+        const bsls::TimeInterval sustainedRateWindow(0.01);
+
+        // do not care about peak limit
+        const bsl::uint64_t peakRateLimit =
+            bsl::numeric_limits<bsl::uint32_t>::max();
+        bsls::TimeInterval peakRateWindow;
+        peakRateWindow.setTotalSeconds(10);
+
+        limiter.createInplace(allocator,
+                              sustainedRateLimit,
+                              sustainedRateWindow,
+                              peakRateLimit,
+                              peakRateWindow,
+                              serverDatagramSocket->currentTime());
+        serverDatagramSocket->setReadRateLimiter(limiter);
+    }
+
+    NTCI_LOG_DEBUG("Sending messages");
+    {
+        for (int i = 0; i < k_NUM_MESSAGES; ++i) {
+            ntca::SendOptions sendOptions;
+
+            error = clientDatagramSocket->send(*message, sendOptions);
+            NTCCFG_TEST_TRUE(!error);
+        }
+    }
+
+    NTCI_LOG_DEBUG("Receiving messages");
+    {
+        ntca::ReceiveOptions receiveOptions;
+        receiveOptions.setSize(k_MESSAGE_SIZE * k_NUM_MESSAGES);
+
+        ntci::ReceiveCallback receiveCallback =
+            serverDatagramSocket->createReceiveCallback(
+                NTCCFG_BIND(&test::DatagramSocketUtil::processReceiveFailed,
+                            NTCCFG_BIND_PLACEHOLDER_1,
+                            NTCCFG_BIND_PLACEHOLDER_2,
+                            NTCCFG_BIND_PLACEHOLDER_3,
+                            &receiveSemaphore),
+                allocator);
+
+        error = serverDatagramSocket->receive(receiveOptions, receiveCallback);
+        NTCCFG_TEST_OK(error);
+    }
+
+    rateLimitSemaphore.wait();
+    rateLimitSemaphore.wait();
+
+    NTCCFG_TEST_GE(session->readQueueRateLimitApplied(), 1);
+    NTCCFG_TEST_GE(session->readQueueRateLimitRelaxed(), 1);
+
+    {
+        ntci::DatagramSocketCloseGuard closeGuardClient(clientDatagramSocket);
+        ntci::DatagramSocketCloseGuard closeGuardServer(serverDatagramSocket);
+    }
+
+    receiveSemaphore.wait();
+}
+
+void concernDatagramSocketSendRateLimitTimerEventNotifications(
+    const bsl::shared_ptr<ntci::Interface>& interface,
+    bslma::Allocator*                       allocator)
+{
+    // Concern: validate that e_RATE_LIMIT_APPLIED and e_RATE_LIMIT_RELAXED
+    // events are fired
+
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_DEBUG("Test started");
+
+    const ntsa::Transport::Value transport =
+        ntsa::Transport::e_UDP_IPV4_DATAGRAM;
+
+    ntsa::Error      error;
+    bslmt::Semaphore receiveSemaphore;
+    bslmt::Semaphore rateLimitSemaphore;
+
+    bsl::shared_ptr<ntci::DatagramSocket> clientDatagramSocket;
+    bsl::shared_ptr<ntci::DatagramSocket> serverDatagramSocket;
+    {
+        ntca::DatagramSocketOptions options;
+        options.setTransport(transport);
+
+        bsl::shared_ptr<ntsi::DatagramSocket> basicClientSocket;
+        bsl::shared_ptr<ntsi::DatagramSocket> basicServerSocket;
+
+        error = ntsf::System::createDatagramSocketPair(&basicClientSocket,
+                                                       &basicServerSocket,
+                                                       transport);
+        NTCCFG_TEST_FALSE(error);
+
+        clientDatagramSocket =
+            interface->createDatagramSocket(options, allocator);
+
+        error = clientDatagramSocket->open(transport, basicClientSocket);
+        NTCCFG_TEST_FALSE(error);
+
+        serverDatagramSocket =
+            interface->createDatagramSocket(options, allocator);
+
+        error = serverDatagramSocket->open(transport, basicServerSocket);
+        NTCCFG_TEST_FALSE(error);
+    }
+
+    bsl::shared_ptr<rateLimit::DatagramSocketSession> session;
+    {
+        session.createInplace(allocator, rateLimitSemaphore);
+        clientDatagramSocket->registerSession(session);
+    }
+
+    const int k_MESSAGE_SIZE = 65507;  //maximum
+    const int k_NUM_MESSAGES = 100;
+
+    NTCI_LOG_DEBUG("Generating message");
+    bsl::shared_ptr<bdlbb::Blob> message =
+        clientDatagramSocket->createOutgoingBlob();
+    ntcd::DataUtil::generateData(message.get(), k_MESSAGE_SIZE, 0, 0);
+
+    NTCI_LOG_DEBUG("Generating message: OK");
+
+    {
+        bsl::shared_ptr<ntcs::RateLimiter> limiter;
+
+        // configure sustained rate limit in a way that it will be reached
+        // immediately
+
+        const bsl::uint64_t      sustainedRateLimit = k_MESSAGE_SIZE / 2;
+        const bsls::TimeInterval sustainedRateWindow(1.0);
+
+        // do not care about peak limit
+        const bsl::uint64_t peakRateLimit =
+            bsl::numeric_limits<bsl::uint32_t>::max();
+        bsls::TimeInterval peakRateWindow;
+        peakRateWindow.setTotalSeconds(10);
+
+        limiter.createInplace(allocator,
+                              sustainedRateLimit,
+                              sustainedRateWindow,
+                              peakRateLimit,
+                              peakRateWindow,
+                              serverDatagramSocket->currentTime());
+        clientDatagramSocket->setWriteRateLimiter(limiter);
+    }
+
+    NTCI_LOG_DEBUG("Sending messages");
+    {
+        for (int i = 0; i < k_NUM_MESSAGES; ++i) {
+            ntca::SendOptions sendOptions;
+
+            error = clientDatagramSocket->send(*message, sendOptions);
+            NTCCFG_TEST_TRUE(!error);
+        }
+    }
+
+    rateLimitSemaphore.wait();
+    rateLimitSemaphore.wait();
+
+    NTCCFG_TEST_GE(session->writeQueueRateLimitApplied(), 1);
+    NTCCFG_TEST_GE(session->writeQueueRateLimitRelaxed(), 1);
+
+    ntci::DatagramSocketCloseGuard closeGuardClient(clientDatagramSocket);
+    ntci::DatagramSocketCloseGuard closeGuardServer(serverDatagramSocket);
+}
+
+void concernStreamSocketReceiveRateLimitTimerEventNotifications(
+    const bsl::shared_ptr<ntci::Interface>& interface,
+    bslma::Allocator*                       allocator)
+{
+    // Concern: validate that e_RATE_LIMIT_APPLIED and e_RATE_LIMIT_RELAXED
+    // events are fired
+
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_DEBUG("Test started");
+
+    const ntsa::Transport::Value transport =
+        ntsa::Transport::e_TCP_IPV4_STREAM;
+
+    ntsa::Error      error;
+    bslmt::Semaphore receiveSemaphore;
+    bslmt::Semaphore rateLimitSemaphore;
+
+    bsl::shared_ptr<ntci::StreamSocket> clientStreamSocket;
+    bsl::shared_ptr<ntci::StreamSocket> serverStreamSocket;
+    {
+        ntca::StreamSocketOptions options;
+        options.setTransport(transport);
+
+        bsl::shared_ptr<ntsi::StreamSocket> basicClientSocket;
+        bsl::shared_ptr<ntsi::StreamSocket> basicServerSocket;
+
+        error = ntsf::System::createStreamSocketPair(&basicClientSocket,
+                                                     &basicServerSocket,
+                                                     transport);
+        NTCCFG_TEST_FALSE(error);
+
+        clientStreamSocket = interface->createStreamSocket(options, allocator);
+
+        error = clientStreamSocket->open(transport, basicClientSocket);
+        NTCCFG_TEST_FALSE(error);
+
+        serverStreamSocket = interface->createStreamSocket(options, allocator);
+
+        error = serverStreamSocket->open(transport, basicServerSocket);
+        NTCCFG_TEST_FALSE(error);
+    }
+
+    bsl::shared_ptr<rateLimit::StreamSocketSession> session;
+    {
+        session.createInplace(allocator, rateLimitSemaphore);
+        serverStreamSocket->registerSession(session);
+    }
+
+    const int k_MESSAGE_SIZE = 65000;
+    const int k_NUM_MESSAGES = 10;
+
+    NTCI_LOG_DEBUG("Generating message");
+    bsl::shared_ptr<bdlbb::Blob> message =
+        clientStreamSocket->createOutgoingBlob();
+    ntcd::DataUtil::generateData(message.get(), k_MESSAGE_SIZE, 0, 0);
+
+    NTCI_LOG_DEBUG("Generating message: OK");
+
+    {
+        bsl::shared_ptr<ntcs::RateLimiter> limiter;
+
+        //configure sustained rate limit in a way that it will be reached
+        // immediately
+        const bsl::uint64_t      sustainedRateLimit = k_MESSAGE_SIZE;
+        const bsls::TimeInterval sustainedRateWindow(0.01);
+
+        // do not care about peak limit
+        const bsl::uint64_t peakRateLimit =
+            bsl::numeric_limits<bsl::uint32_t>::max();
+        bsls::TimeInterval peakRateWindow;
+        peakRateWindow.setTotalSeconds(1);
+
+        limiter.createInplace(allocator,
+                              sustainedRateLimit,
+                              sustainedRateWindow,
+                              peakRateLimit,
+                              peakRateWindow,
+                              serverStreamSocket->currentTime());
+        serverStreamSocket->setReadRateLimiter(limiter);
+    }
+
+    NTCI_LOG_DEBUG("Sending messages");
+    {
+        for (int i = 0; i < k_NUM_MESSAGES; ++i) {
+            ntca::SendOptions sendOptions;
+
+            error = clientStreamSocket->send(*message, sendOptions);
+            NTCCFG_TEST_TRUE(!error);
+        }
+    }
+
+    NTCI_LOG_DEBUG("Receiving messages");
+    {
+        ntca::ReceiveOptions receiveOptions;
+        receiveOptions.setSize(k_MESSAGE_SIZE * k_NUM_MESSAGES);
+
+        ntci::ReceiveCallback receiveCallback =
+            serverStreamSocket->createReceiveCallback(
+                NTCCFG_BIND(&test::DatagramSocketUtil::processReceiveFailed,
+                            NTCCFG_BIND_PLACEHOLDER_1,
+                            NTCCFG_BIND_PLACEHOLDER_2,
+                            NTCCFG_BIND_PLACEHOLDER_3,
+                            &receiveSemaphore),
+                allocator);
+
+        error = serverStreamSocket->receive(receiveOptions, receiveCallback);
+        NTCCFG_TEST_OK(error);
+    }
+
+    rateLimitSemaphore.wait();
+    rateLimitSemaphore.wait();
+
+    NTCCFG_TEST_GE(session->readQueueRateLimitApplied(), 1);
+    NTCCFG_TEST_GE(session->readQueueRateLimitRelaxed(), 1);
+
+    {
+        ntci::StreamSocketCloseGuard closeGuardClient(clientStreamSocket);
+        ntci::StreamSocketCloseGuard closeGuardServer(serverStreamSocket);
+    }
+
+    receiveSemaphore.wait();
+}
+
+void concernStreamSocketSendRateLimitTimerEventNotifications(
+    const bsl::shared_ptr<ntci::Interface>& interface,
+    bslma::Allocator*                       allocator)
+{
+    // Concern: validate that e_RATE_LIMIT_APPLIED and e_RATE_LIMIT_RELAXED
+    // events are fired
+
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_DEBUG("Test started");
+
+    const ntsa::Transport::Value transport =
+        ntsa::Transport::e_TCP_IPV4_STREAM;
+
+    ntsa::Error      error;
+    bslmt::Semaphore rateLimitSemaphore;
+
+    bsl::shared_ptr<ntci::StreamSocket> clientStreamSocket;
+    bsl::shared_ptr<ntci::StreamSocket> serverStreamSocket;
+    {
+        ntca::StreamSocketOptions options;
+        options.setTransport(transport);
+
+        bsl::shared_ptr<ntsi::StreamSocket> basicClientSocket;
+        bsl::shared_ptr<ntsi::StreamSocket> basicServerSocket;
+
+        error = ntsf::System::createStreamSocketPair(&basicClientSocket,
+                                                     &basicServerSocket,
+                                                     transport);
+        NTCCFG_TEST_FALSE(error);
+
+        clientStreamSocket = interface->createStreamSocket(options, allocator);
+
+        error = clientStreamSocket->open(transport, basicClientSocket);
+        NTCCFG_TEST_FALSE(error);
+
+        serverStreamSocket = interface->createStreamSocket(options, allocator);
+
+        error = serverStreamSocket->open(transport, basicServerSocket);
+        NTCCFG_TEST_FALSE(error);
+    }
+
+    bsl::shared_ptr<rateLimit::StreamSocketSession> session;
+    {
+        session.createInplace(allocator, rateLimitSemaphore);
+        clientStreamSocket->registerSession(session);
+    }
+
+    const int k_MESSAGE_SIZE = 65000;
+    const int k_NUM_MESSAGES = 10;
+
+    NTCI_LOG_DEBUG("Generating message");
+    bsl::shared_ptr<bdlbb::Blob> message =
+        clientStreamSocket->createOutgoingBlob();
+    ntcd::DataUtil::generateData(message.get(), k_MESSAGE_SIZE, 0, 0);
+
+    NTCI_LOG_DEBUG("Generating message: OK");
+
+    {
+        bsl::shared_ptr<ntcs::RateLimiter> limiter;
+
+        //configure sustained rate limit in a way that it will be reached
+        // immediately
+        const bsl::uint64_t      sustainedRateLimit = k_MESSAGE_SIZE / 2;
+        const bsls::TimeInterval sustainedRateWindow(1.0);
+
+        // do not care about peak limit
+        const bsl::uint64_t peakRateLimit =
+            bsl::numeric_limits<bsl::uint32_t>::max();
+        bsls::TimeInterval peakRateWindow;
+        peakRateWindow.setTotalSeconds(1);
+
+        limiter.createInplace(allocator,
+                              sustainedRateLimit,
+                              sustainedRateWindow,
+                              peakRateLimit,
+                              peakRateWindow,
+                              serverStreamSocket->currentTime());
+        clientStreamSocket->setWriteRateLimiter(limiter);
+    }
+
+    NTCI_LOG_DEBUG("Sending messages");
+    {
+        for (int i = 0; i < k_NUM_MESSAGES; ++i) {
+            ntca::SendOptions sendOptions;
+
+            error = clientStreamSocket->send(*message, sendOptions);
+            NTCCFG_TEST_TRUE(!error);
+        }
+    }
+
+    rateLimitSemaphore.wait();
+    rateLimitSemaphore.wait();
+
+    NTCCFG_TEST_GE(session->writeQueueRateLimitApplied(), 1);
+    NTCCFG_TEST_GE(session->writeQueueRateLimitRelaxed(), 1);
+
+    {
+        ntci::StreamSocketCloseGuard closeGuardClient(clientStreamSocket);
+        ntci::StreamSocketCloseGuard closeGuardServer(serverStreamSocket);
+    }
+}
+
+void concernListenerSocketAcceptRateLimitTimerEventNotifications(
+    const bsl::shared_ptr<ntci::Interface>& interface,
+    bslma::Allocator*                       allocator)
+{
+    // Concern: validate that e_RATE_LIMIT_APPLIED and e_RATE_LIMIT_RELAXED
+    // events are fired
+
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_DEBUG("Test started");
+
+    const ntsa::Transport::Value transport =
+        ntsa::Transport::e_TCP_IPV4_STREAM;
+
+    ntsa::Error      error;
+    bslmt::Semaphore acceptLimitSemaphore;
+
+    bsl::shared_ptr<ntci::ListenerSocket> listenerSocket;
+    {
+        ntca::ListenerSocketOptions options;
+        options.setTransport(transport);
+        options.setSourceEndpoint(test::EndpointUtil::any(transport));
+
+        listenerSocket = interface->createListenerSocket(options, allocator);
+    }
+
+    bsl::shared_ptr<rateLimit::ListenerSocketSession> session;
+    {
+        session.createInplace(allocator, acceptLimitSemaphore);
+        listenerSocket->registerSession(session);
+    }
+
+    {
+        bsl::shared_ptr<ntcs::RateLimiter> limiter;
+
+        //configure sustained rate limit in a way that it will be reached
+        // immediately. e.g. 1 acceptance per second
+        const bsl::uint64_t sustainedRateLimit = 1;
+        bsls::TimeInterval  sustainedRateWindow;
+        sustainedRateWindow.setTotalHours(1);
+
+        // do not care about peak limit
+        const bsl::uint64_t peakRateLimit = 1;
+        bsls::TimeInterval  peakRateWindow;
+        peakRateWindow.setTotalSeconds(1);
+
+        limiter.createInplace(allocator,
+                              sustainedRateLimit,
+                              sustainedRateWindow,
+                              peakRateLimit,
+                              peakRateWindow,
+                              listenerSocket->currentTime());
+        listenerSocket->setAcceptRateLimiter(limiter);
+    }
+
+    error = listenerSocket->open();
+    NTCCFG_TEST_FALSE(error);
+
+    error = listenerSocket->listen();
+    NTCCFG_TEST_FALSE(error);
+
+    NTCI_LOG_DEBUG("Listener socket starts listening");
+
+    const int numSockets = 10;
+
+    bsl::vector<bsl::shared_ptr<ntci::StreamSocket> > clientSockets(allocator);
+    bsl::vector<bsl::shared_ptr<ntci::ConnectFuture> > connectFutures(
+        allocator);
+    bsl::vector<bsl::shared_ptr<ntci::AcceptFuture> > acceptFutures(allocator);
+
+    NTCI_LOG_DEBUG("Creating client sockets");
+
+    for (int i = 0; i < numSockets; ++i) {
+        ntca::StreamSocketOptions options;
+        options.setTransport(transport);
+
+        bsl::shared_ptr<ntci::StreamSocket> clientStreamSocket =
+            interface->createStreamSocket(options, allocator);
+
+        error = clientStreamSocket->open();
+        NTCCFG_TEST_OK(error);
+        clientSockets.push_back(clientStreamSocket);
+    }
+
+    NTCI_LOG_DEBUG("Preparing futures");
+    for (int i = 0; i < numSockets; ++i) {
+        bsl::shared_ptr<ntci::ConnectFuture> connectFuture;
+        connectFuture.createInplace(allocator);
+        connectFutures.push_back(connectFuture);
+
+        bsl::shared_ptr<ntci::AcceptFuture> acceptFuture;
+        acceptFuture.createInplace(allocator);
+        acceptFutures.push_back(acceptFuture);
+    }
+
+    NTCI_LOG_DEBUG("Accepting connections");
+    for (int i = 0; i < numSockets; ++i) {
+        error =
+            listenerSocket->accept(ntca::AcceptOptions(), *(acceptFutures[i]));
+        NTCCFG_TEST_OK(error);
+    }
+
+    NTCI_LOG_DEBUG("Initiating connections");
+    for (int i = 0; i < numSockets; ++i) {
+        error = clientSockets[i]->connect(listenerSocket->sourceEndpoint(),
+                                          ntca::ConnectOptions(),
+                                          *(connectFutures[i]));
+        NTCCFG_TEST_OK(error);
+    }
+
+    acceptLimitSemaphore.wait();
+    {
+        {
+            ntci::ListenerSocketCloseGuard listenerSocketCloseGuard(
+                listenerSocket);
+        }
+        listenerSocket.reset();
+    }
+
+    NTCI_LOG_DEBUG("Cleaning accepted connections");
+    for (size_t i = 0; i < acceptFutures.size(); ++i) {
+        const bsls::TimeInterval zero;
+        ntci::AcceptResult       acceptResult;
+        error = acceptFutures[i]->wait(&acceptResult, zero);
+        if (!error) {
+            ntci::StreamSocketCloseGuard closeGuard(
+                acceptResult.streamSocket());
+        }
+    }
+
+    for (size_t i = 0; i < clientSockets.size(); ++i) {
+        ntci::StreamSocketCloseGuard closeGuard(clientSockets[i]);
+    }
 }
 
 }  // close namespace 'test'
@@ -11926,6 +13959,166 @@ NTCCFG_TEST_CASE(65)
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
 
+NTCCFG_TEST_CASE(66)
+{
+    ntccfg::TestAllocator ta;
+    {
+        test::concern(&test::concernDatagramSocketReceiveDeadlineClose, &ta);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(67)
+{
+    ntccfg::TestAllocator ta;
+    {
+        test::concern(&test::concernStreamSocketReceiveDeadlineClose, &ta);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(68)
+{
+    ntccfg::TestAllocator ta;
+    {
+        test::concern(&test::concernStreamSocketSendDeadlineClose, &ta);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(69)
+{
+    ntccfg::TestAllocator ta;
+    {
+        test::concern(&test::concernListenerSocketAcceptClose, &ta);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(70)
+{
+    ntccfg::TestAllocator ta;
+    {
+        test::concern(&test::concernDatagramSocketReceiveRateLimitTimerClose,
+                      &ta);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(71)
+{
+    ntccfg::TestAllocator ta;
+    {
+        test::concern(&test::concernStreamSocketReceiveRateLimitTimerClose,
+                      &ta);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(72)
+{
+    ntccfg::TestAllocator ta;
+    {
+        test::concern(&test::concernDatagramSocketSendRateLimitTimerClose,
+                      &ta);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(73)
+{
+    ntccfg::TestAllocator ta;
+    {
+        test::concern(&test::concernStreamSocketSendRateLimitTimerClose, &ta);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(74)
+{
+    ntccfg::TestAllocator ta;
+    {
+        test::concern(&test::concernListenerSocketAcceptRateLimitTimerClose,
+                      &ta);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(75)
+{
+    ntccfg::TestAllocator ta;
+    {
+        test::concern(&test::concernStreamSocketConnectRetryTimerClose, &ta);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(76)
+{
+    ntccfg::TestAllocator ta;
+    {
+        test::concern(&test::concernStreamSocketConnectDeadlineTimerClose,
+                      &ta);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(77)
+{
+    ntccfg::TestAllocator ta;
+    {
+        test::concern(
+            &test::
+                concernDatagramSocketReceiveRateLimitTimerEventNotifications,
+            &ta);
+        NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+    }
+}
+
+NTCCFG_TEST_CASE(78)
+{
+    ntccfg::TestAllocator ta;
+    {
+        test::concern(
+            &test::concernDatagramSocketSendRateLimitTimerEventNotifications,
+            &ta);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(79)
+{
+    ntccfg::TestAllocator ta;
+    {
+        test::concern(
+            &test::concernStreamSocketReceiveRateLimitTimerEventNotifications,
+            &ta);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(80)
+{
+    ntccfg::TestAllocator ta;
+    {
+        test::concern(
+            &test::concernStreamSocketSendRateLimitTimerEventNotifications,
+            &ta);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(81)
+{
+    ntccfg::TestAllocator ta;
+    {
+        test::concern(
+            &test::concernListenerSocketAcceptRateLimitTimerEventNotifications,
+            &ta);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
 NTCCFG_TEST_DRIVER
 {
     NTCCFG_TEST_REGISTER(1);
@@ -11993,5 +14186,21 @@ NTCCFG_TEST_DRIVER
     NTCCFG_TEST_REGISTER(63);
     NTCCFG_TEST_REGISTER(64);
     NTCCFG_TEST_REGISTER(65);
+    NTCCFG_TEST_REGISTER(66);
+    NTCCFG_TEST_REGISTER(67);
+    NTCCFG_TEST_REGISTER(68);
+    NTCCFG_TEST_REGISTER(69);
+    NTCCFG_TEST_REGISTER(70);
+    NTCCFG_TEST_REGISTER(71);
+    NTCCFG_TEST_REGISTER(72);
+    NTCCFG_TEST_REGISTER(73);
+    NTCCFG_TEST_REGISTER(74);
+    NTCCFG_TEST_REGISTER(75);
+    NTCCFG_TEST_REGISTER(76);
+    NTCCFG_TEST_REGISTER(77);
+    NTCCFG_TEST_REGISTER(78);
+    NTCCFG_TEST_REGISTER(79);
+    NTCCFG_TEST_REGISTER(80);
+    NTCCFG_TEST_REGISTER(81);
 }
 NTCCFG_TEST_DRIVER_END;

--- a/groups/ntc/ntcf/ntcf_system.t.cpp
+++ b/groups/ntc/ntcf/ntcf_system.t.cpp
@@ -9859,8 +9859,7 @@ void concernDatagramSocketReceiveCancellation(
     const bsl::shared_ptr<ntci::Interface>& interface,
     bslma::Allocator*                       allocator)
 {
-    // Concern: validate that receive deadline timer is automatically closed
-    // when the socket is closed and then destroyed
+    // Concern: Receive cancellation.
 
     NTCI_LOG_CONTEXT();
 

--- a/groups/ntc/ntci/ntci_datagramsocketsession.cpp
+++ b/groups/ntc/ntci/ntci_datagramsocketsession.cpp
@@ -67,6 +67,22 @@ void DatagramSocketSession::processReadQueueDiscarded(
     NTCCFG_WARNING_UNUSED(event);
 }
 
+void DatagramSocketSession::processReadQueueRateLimitApplied(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::ReadQueueEvent&                  event)
+{
+    NTCCFG_WARNING_UNUSED(datagramSocket);
+    NTCCFG_WARNING_UNUSED(event);
+}
+
+void DatagramSocketSession::processReadQueueRateLimitRelaxed(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::ReadQueueEvent&                  event)
+{
+    NTCCFG_WARNING_UNUSED(datagramSocket);
+    NTCCFG_WARNING_UNUSED(event);
+}
+
 void DatagramSocketSession::processWriteQueueFlowControlRelaxed(
     const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
     const ntca::WriteQueueEvent&                 event)
@@ -100,6 +116,22 @@ void DatagramSocketSession::processWriteQueueHighWatermark(
 }
 
 void DatagramSocketSession::processWriteQueueDiscarded(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::WriteQueueEvent&                 event)
+{
+    NTCCFG_WARNING_UNUSED(datagramSocket);
+    NTCCFG_WARNING_UNUSED(event);
+}
+
+void DatagramSocketSession::processWriteQueueRateLimitApplied(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::WriteQueueEvent&                 event)
+{
+    NTCCFG_WARNING_UNUSED(datagramSocket);
+    NTCCFG_WARNING_UNUSED(event);
+}
+
+void DatagramSocketSession::processWriteQueueRateLimitRelaxed(
     const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
     const ntca::WriteQueueEvent&                 event)
 {

--- a/groups/ntc/ntci/ntci_datagramsocketsession.h
+++ b/groups/ntc/ntci/ntci_datagramsocketsession.h
@@ -84,13 +84,13 @@ class DatagramSocketSession
         const ntca::ReadQueueEvent&                  event);
 
     /// Process the condition that the read queue rate limit has been reached
-    /// and copying data into the read queue will be restricted
+    /// and copying data from the receive buffer will be restricted.
     virtual void processReadQueueRateLimitApplied(
         const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
         const ntca::ReadQueueEvent&                  event);
 
     /// Process the condition that the read queue rate limit timer has fired
-    /// and copying data into the read queue will be enabled
+    /// and copying data from the receive buffer will be enabled.
     virtual void processReadQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
         const ntca::ReadQueueEvent&                  event);
@@ -135,13 +135,13 @@ class DatagramSocketSession
         const ntca::WriteQueueEvent&                 event);
 
     /// Process the condition that the write queue rate limit has been reached
-    /// and copying data into the socket buffer will be restricted
+    /// and copying data into the send buffer will be restricted.
     virtual void processWriteQueueRateLimitApplied(
         const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
         const ntca::WriteQueueEvent&                 event);
 
     /// Process the condition that the write queue rate limit timer has fired
-    /// and copying data into the socket buffer will be enabled
+    /// and copying data into the send buffer will be enabled.
     virtual void processWriteQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
         const ntca::WriteQueueEvent&                 event);

--- a/groups/ntc/ntci/ntci_datagramsocketsession.h
+++ b/groups/ntc/ntci/ntci_datagramsocketsession.h
@@ -83,6 +83,14 @@ class DatagramSocketSession
         const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
         const ntca::ReadQueueEvent&                  event);
 
+    virtual void processReadQueueRateLimitApplied(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::ReadQueueEvent&                  event);
+
+    virtual void processReadQueueRateLimitRelaxed(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::ReadQueueEvent&                  event);
+
     /// Process the condition that write queue flow control has been
     /// relaxed: the write queue is being automatically copied to the socket
     /// send buffer.
@@ -119,6 +127,14 @@ class DatagramSocketSession
     /// Process the condition that the write queue has been discarded
     /// because a non-transient write error asynchronously occured.
     virtual void processWriteQueueDiscarded(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::WriteQueueEvent&                 event);
+
+    virtual void processWriteQueueRateLimitApplied(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::WriteQueueEvent&                 event);
+
+    virtual void processWriteQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
         const ntca::WriteQueueEvent&                 event);
 

--- a/groups/ntc/ntci/ntci_datagramsocketsession.h
+++ b/groups/ntc/ntci/ntci_datagramsocketsession.h
@@ -83,10 +83,14 @@ class DatagramSocketSession
         const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
         const ntca::ReadQueueEvent&                  event);
 
+    /// Process the condition that the read queue rate limit has been reached
+    /// and copying data into the read queue will be restricted
     virtual void processReadQueueRateLimitApplied(
         const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
         const ntca::ReadQueueEvent&                  event);
 
+    /// Process the condition that the read queue rate limit timer has fired
+    /// and copying data into the read queue will be enabled
     virtual void processReadQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
         const ntca::ReadQueueEvent&                  event);
@@ -130,10 +134,14 @@ class DatagramSocketSession
         const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
         const ntca::WriteQueueEvent&                 event);
 
+    /// Process the condition that the write queue rate limit has been reached
+    /// and copying data into the socket buffer will be restricted
     virtual void processWriteQueueRateLimitApplied(
         const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
         const ntca::WriteQueueEvent&                 event);
 
+    /// Process the condition that the write queue rate limit timer has fired
+    /// and copying data into the socket buffer will be enabled
     virtual void processWriteQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
         const ntca::WriteQueueEvent&                 event);

--- a/groups/ntc/ntci/ntci_listenersocketsession.cpp
+++ b/groups/ntc/ntci/ntci_listenersocketsession.cpp
@@ -68,6 +68,22 @@ void ListenerSocketSession::processAcceptQueueDiscarded(
     NTCCFG_WARNING_UNUSED(event);
 }
 
+void ListenerSocketSession::processAcceptQueueRateLimitApplied(
+    const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
+    const ntca::AcceptQueueEvent&                event)
+{
+    NTCCFG_WARNING_UNUSED(listenerSocket);
+    NTCCFG_WARNING_UNUSED(event);
+}
+
+void ListenerSocketSession::processAcceptQueueRateLimitRelaxed(
+    const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
+    const ntca::AcceptQueueEvent&                event)
+{
+    NTCCFG_WARNING_UNUSED(listenerSocket);
+    NTCCFG_WARNING_UNUSED(event);
+}
+
 void ListenerSocketSession::processShutdownInitiated(
     const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
     const ntca::ShutdownEvent&                   event)

--- a/groups/ntc/ntci/ntci_listenersocketsession.h
+++ b/groups/ntc/ntci/ntci_listenersocketsession.h
@@ -83,13 +83,13 @@ class ListenerSocketSession
         const ntca::AcceptQueueEvent&                event);
 
     /// Process the condition that the accept queue rate limit has been reached
-    /// and the connections in the backlog will not be automatically accepted
+    /// and the connections in the backlog will not be automatically accepted.
     virtual void processAcceptQueueRateLimitApplied(
         const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
         const ntca::AcceptQueueEvent&                event);
 
     /// Process the condition that the accept queue rate limit timer has fired
-    /// and the connections in the backlog will be automatically accepted
+    /// and the connections in the backlog will be automatically accepted.
     virtual void processAcceptQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
         const ntca::AcceptQueueEvent&                event);

--- a/groups/ntc/ntci/ntci_listenersocketsession.h
+++ b/groups/ntc/ntci/ntci_listenersocketsession.h
@@ -82,6 +82,14 @@ class ListenerSocketSession
         const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
         const ntca::AcceptQueueEvent&                event);
 
+    virtual void processAcceptQueueRateLimitApplied(
+        const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
+        const ntca::AcceptQueueEvent&                event);
+
+    virtual void processAcceptQueueRateLimitRelaxed(
+        const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
+        const ntca::AcceptQueueEvent&                event);
+
     /// Process the initiation of the shutdown sequence from the specified
     /// 'origin'.
     virtual void processShutdownInitiated(

--- a/groups/ntc/ntci/ntci_listenersocketsession.h
+++ b/groups/ntc/ntci/ntci_listenersocketsession.h
@@ -82,10 +82,14 @@ class ListenerSocketSession
         const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
         const ntca::AcceptQueueEvent&                event);
 
+    /// Process the condition that the accept queue rate limit has been reached
+    /// and the connections in the backlog will not be automatically accepted
     virtual void processAcceptQueueRateLimitApplied(
         const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
         const ntca::AcceptQueueEvent&                event);
 
+    /// Process the condition that the accept queue rate limit timer has fired
+    /// and the connections in the backlog will be automatically accepted
     virtual void processAcceptQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket,
         const ntca::AcceptQueueEvent&                event);

--- a/groups/ntc/ntci/ntci_streamsocketsession.cpp
+++ b/groups/ntc/ntci/ntci_streamsocketsession.cpp
@@ -67,6 +67,22 @@ void StreamSocketSession::processReadQueueDiscarded(
     NTCCFG_WARNING_UNUSED(event);
 }
 
+void StreamSocketSession::processReadQueueRateLimitApplied(
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const ntca::ReadQueueEvent&                event)
+{
+    NTCCFG_WARNING_UNUSED(streamSocket);
+    NTCCFG_WARNING_UNUSED(event);
+}
+
+void StreamSocketSession::processReadQueueRateLimitRelaxed(
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const ntca::ReadQueueEvent&                event)
+{
+    NTCCFG_WARNING_UNUSED(streamSocket);
+    NTCCFG_WARNING_UNUSED(event);
+}
+
 void StreamSocketSession::processWriteQueueFlowControlRelaxed(
     const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
     const ntca::WriteQueueEvent&               event)
@@ -100,6 +116,22 @@ void StreamSocketSession::processWriteQueueHighWatermark(
 }
 
 void StreamSocketSession::processWriteQueueDiscarded(
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const ntca::WriteQueueEvent&               event)
+{
+    NTCCFG_WARNING_UNUSED(streamSocket);
+    NTCCFG_WARNING_UNUSED(event);
+}
+
+void StreamSocketSession::processWriteQueueRateLimitApplied(
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const ntca::WriteQueueEvent&               event)
+{
+    NTCCFG_WARNING_UNUSED(streamSocket);
+    NTCCFG_WARNING_UNUSED(event);
+}
+
+void StreamSocketSession::processWriteQueueRateLimitRelaxed(
     const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
     const ntca::WriteQueueEvent&               event)
 {

--- a/groups/ntc/ntci/ntci_streamsocketsession.h
+++ b/groups/ntc/ntci/ntci_streamsocketsession.h
@@ -89,6 +89,14 @@ class StreamSocketSession
         const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
         const ntca::ReadQueueEvent&                event);
 
+    virtual void processReadQueueRateLimitApplied(
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const ntca::ReadQueueEvent&                event);
+
+    virtual void processReadQueueRateLimitRelaxed(
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const ntca::ReadQueueEvent&                event);
+
     /// Process the condition that write queue flow control has been
     /// relaxed: the write queue is being automatically copied to the socket
     /// send buffer.
@@ -125,6 +133,14 @@ class StreamSocketSession
     /// Process the condition that the write queue has been discarded
     /// because a non-transient write error asynchronously occured.
     virtual void processWriteQueueDiscarded(
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const ntca::WriteQueueEvent&               event);
+
+    virtual void processWriteQueueRateLimitApplied(
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const ntca::WriteQueueEvent&               event);
+
+    virtual void processWriteQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
         const ntca::WriteQueueEvent&               event);
 

--- a/groups/ntc/ntci/ntci_streamsocketsession.h
+++ b/groups/ntc/ntci/ntci_streamsocketsession.h
@@ -90,13 +90,13 @@ class StreamSocketSession
         const ntca::ReadQueueEvent&                event);
 
     /// Process the condition that the read queue rate limit has been reached
-    /// and copying data into the read queue will be restricted
+    /// and copying data from the receive buffer will be restricted.
     virtual void processReadQueueRateLimitApplied(
         const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
         const ntca::ReadQueueEvent&                event);
 
     /// Process the condition that the read queue rate limit timer has fired
-    /// and copying data into the read queue will be enabled
+    /// and copying data from the receive buffer will be enabled.
     virtual void processReadQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
         const ntca::ReadQueueEvent&                event);
@@ -141,13 +141,13 @@ class StreamSocketSession
         const ntca::WriteQueueEvent&               event);
 
     /// Process the condition that the write queue rate limit has been reached
-    /// and copying data into the socket buffer will be restricted
+    /// and copying data into the send buffer will be restricted.
     virtual void processWriteQueueRateLimitApplied(
         const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
         const ntca::WriteQueueEvent&               event);
 
     /// Process the condition that the write queue rate limit timer has fired
-    /// and copying data into the socket buffer will be enabled
+    /// and copying data into the send buffer will be enabled.
     virtual void processWriteQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
         const ntca::WriteQueueEvent&               event);

--- a/groups/ntc/ntci/ntci_streamsocketsession.h
+++ b/groups/ntc/ntci/ntci_streamsocketsession.h
@@ -89,10 +89,14 @@ class StreamSocketSession
         const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
         const ntca::ReadQueueEvent&                event);
 
+    /// Process the condition that the read queue rate limit has been reached
+    /// and copying data into the read queue will be restricted
     virtual void processReadQueueRateLimitApplied(
         const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
         const ntca::ReadQueueEvent&                event);
 
+    /// Process the condition that the read queue rate limit timer has fired
+    /// and copying data into the read queue will be enabled
     virtual void processReadQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
         const ntca::ReadQueueEvent&                event);
@@ -136,10 +140,14 @@ class StreamSocketSession
         const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
         const ntca::WriteQueueEvent&               event);
 
+    /// Process the condition that the write queue rate limit has been reached
+    /// and copying data into the socket buffer will be restricted
     virtual void processWriteQueueRateLimitApplied(
         const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
         const ntca::WriteQueueEvent&               event);
 
+    /// Process the condition that the write queue rate limit timer has fired
+    /// and copying data into the socket buffer will be enabled
     virtual void processWriteQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
         const ntca::WriteQueueEvent&               event);

--- a/groups/ntc/ntcp/ntcp_datagramsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_datagramsocket.cpp
@@ -1541,12 +1541,15 @@ ntsa::Error DatagramSocket::privateThrottleSendBuffer(
                 timerOptions.hideEvent(ntca::TimerEventType::e_CANCELED);
                 timerOptions.hideEvent(ntca::TimerEventType::e_CLOSED);
 
-                d_sendRateTimer_sp = this->createTimer(
-                    timerOptions,
-                    ntci::TimerCallback(bdlf::MemFnUtil::memFn(
+                ntci::TimerCallback timerCallback = this->createTimerCallback(
+                    bdlf::MemFnUtil::memFn(
                         &DatagramSocket::processSendRateTimer,
-                        self)),
+                        self),
                     d_allocator_p);
+
+                d_sendRateTimer_sp = this->createTimer(timerOptions,
+                                                       timerCallback,
+                                                       d_allocator_p);
             }
 
             NTCP_DATAGRAMSOCKET_LOG_SEND_BUFFER_THROTTLE_APPLIED(timeToSubmit);
@@ -1602,12 +1605,15 @@ ntsa::Error DatagramSocket::privateThrottleReceiveBuffer(
                 timerOptions.hideEvent(ntca::TimerEventType::e_CANCELED);
                 timerOptions.hideEvent(ntca::TimerEventType::e_CLOSED);
 
-                d_receiveRateTimer_sp = this->createTimer(
-                    timerOptions,
-                    ntci::TimerCallback(bdlf::MemFnUtil::memFn(
+                ntci::TimerCallback timerCallback = this->createTimerCallback(
+                    bdlf::MemFnUtil::memFn(
                         &DatagramSocket::processReceiveRateTimer,
-                        self)),
+                        self),
                     d_allocator_p);
+
+                d_receiveRateTimer_sp = this->createTimer(timerOptions,
+                                                          timerCallback,
+                                                          d_allocator_p);
             }
 
             NTCP_DATAGRAMSOCKET_LOG_RECEIVE_BUFFER_THROTTLE_APPLIED(

--- a/groups/ntc/ntcp/ntcp_datagramsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_datagramsocket.cpp
@@ -313,6 +313,11 @@ void DatagramSocket::processSendRateTimer(
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCP_DATAGRAMSOCKET_LOG_SEND_BUFFER_THROTTLE_RELAXED();
 
+        this->privateRelaxFlowControl(self,
+                                      ntca::FlowControlType::e_SEND,
+                                      false,
+                                      true);
+
         if (d_session_sp) {
             ntca::WriteQueueEvent event;
             event.setType(ntca::WriteQueueEventType::e_RATE_LIMIT_RELAXED);
@@ -325,14 +330,9 @@ void DatagramSocket::processSendRateTimer(
                 d_sessionStrand_sp,
                 ntci::Strand::unknown(),
                 self,
-                true,
+                false,
                 &d_mutex);
         }
-
-        this->privateRelaxFlowControl(self,
-                                      ntca::FlowControlType::e_SEND,
-                                      false,
-                                      true);
     }
 }
 
@@ -405,6 +405,11 @@ void DatagramSocket::processReceiveRateTimer(
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCP_DATAGRAMSOCKET_LOG_RECEIVE_BUFFER_THROTTLE_RELAXED();
 
+        this->privateRelaxFlowControl(self,
+                                      ntca::FlowControlType::e_RECEIVE,
+                                      false,
+                                      true);
+
         if (d_session_sp) {
             ntca::ReadQueueEvent event;
             event.setType(ntca::ReadQueueEventType::e_RATE_LIMIT_RELAXED);
@@ -417,14 +422,9 @@ void DatagramSocket::processReceiveRateTimer(
                 d_sessionStrand_sp,
                 ntci::Strand::unknown(),
                 self,
-                true,
+                false,
                 &d_mutex);
         }
-
-        this->privateRelaxFlowControl(self,
-                                      ntca::FlowControlType::e_RECEIVE,
-                                      false,
-                                      true);
     }
 }
 

--- a/groups/ntc/ntcp/ntcp_listenersocket.cpp
+++ b/groups/ntc/ntcp/ntcp_listenersocket.cpp
@@ -592,7 +592,7 @@ void ListenerSocket::privateFailAccept(
 
         ntci::TimerCallback timerCallback = this->createTimerCallback(
             bdlf::MemFnUtil::memFn(&ListenerSocket::processAcceptBackoffTimer,
-                                   this),
+                                   self),
             d_allocator_p);
 
         d_acceptBackoffTimer_sp =

--- a/groups/ntc/ntcp/ntcp_listenersocket.cpp
+++ b/groups/ntc/ntcp/ntcp_listenersocket.cpp
@@ -232,6 +232,11 @@ void ListenerSocket::processAcceptRateTimer(
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCP_LISTENERSOCKET_LOG_BACKLOG_THROTTLE_RELAXED();
 
+        this->privateRelaxFlowControl(self,
+                                      ntca::FlowControlType::e_RECEIVE,
+                                      false,
+                                      true);
+
         if (d_session_sp) {
             ntca::AcceptQueueEvent event;
             event.setType(ntca::AcceptQueueEventType::e_RATE_LIMIT_RELAXED);
@@ -244,14 +249,9 @@ void ListenerSocket::processAcceptRateTimer(
                 d_sessionStrand_sp,
                 ntci::Strand::unknown(),
                 self,
-                true,
+                false,
                 &d_mutex);
         }
-
-        this->privateRelaxFlowControl(self,
-                                      ntca::FlowControlType::e_RECEIVE,
-                                      false,
-                                      true);
     }
 }
 

--- a/groups/ntc/ntcp/ntcp_streamsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.cpp
@@ -4135,7 +4135,7 @@ ntsa::Error StreamSocket::upgrade(
         timerOptions.setOneShot(true);
 
         ntci::TimerCallback timerCallback = this->createTimerCallback(
-            bdlf::MemFnUtil::memFn(&StreamSocket::processUpgradeTimer, this),
+            bdlf::MemFnUtil::memFn(&StreamSocket::processUpgradeTimer, self),
             d_allocator_p);
 
         d_upgradeTimer_sp =

--- a/groups/ntc/ntcp/ntcp_streamsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.cpp
@@ -481,6 +481,11 @@ void StreamSocket::processSendRateTimer(
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCP_STREAMSOCKET_LOG_SEND_BUFFER_THROTTLE_RELAXED();
 
+        this->privateRelaxFlowControl(self,
+                                      ntca::FlowControlType::e_SEND,
+                                      false,
+                                      true);
+
         if (d_session_sp) {
             ntca::WriteQueueEvent event;
             event.setType(ntca::WriteQueueEventType::e_RATE_LIMIT_RELAXED);
@@ -493,14 +498,9 @@ void StreamSocket::processSendRateTimer(
                 d_sessionStrand_sp,
                 ntci::Strand::unknown(),
                 self,
-                true,
+                false,
                 &d_mutex);
         }
-
-        this->privateRelaxFlowControl(self,
-                                      ntca::FlowControlType::e_SEND,
-                                      false,
-                                      true);
     }
 }
 
@@ -574,6 +574,11 @@ void StreamSocket::processReceiveRateTimer(
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCP_STREAMSOCKET_LOG_RECEIVE_BUFFER_THROTTLE_RELAXED();
 
+        this->privateRelaxFlowControl(self,
+                                      ntca::FlowControlType::e_RECEIVE,
+                                      false,
+                                      true);
+
         if (d_session_sp) {
             ntca::ReadQueueEvent event;
             event.setType(ntca::ReadQueueEventType::e_RATE_LIMIT_RELAXED);
@@ -589,11 +594,6 @@ void StreamSocket::processReceiveRateTimer(
                 false,
                 &d_mutex);
         }
-
-        this->privateRelaxFlowControl(self,
-                                      ntca::FlowControlType::e_RECEIVE,
-                                      false,
-                                      true);
     }
 }
 

--- a/groups/ntc/ntcr/ntcr_datagramsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.cpp
@@ -1543,12 +1543,14 @@ ntsa::Error DatagramSocket::privateThrottleSendBuffer(
                 timerOptions.hideEvent(ntca::TimerEventType::e_CANCELED);
                 timerOptions.hideEvent(ntca::TimerEventType::e_CLOSED);
 
-                d_sendRateTimer_sp = this->createTimer(
-                    timerOptions,
-                    ntci::TimerCallback(bdlf::MemFnUtil::memFn(
+                ntci::TimerCallback timerCallback = this->createTimerCallback(
+                    bdlf::MemFnUtil::memFn(
                         &DatagramSocket::processSendRateTimer,
-                        self)),
+                        self),
                     d_allocator_p);
+                d_sendRateTimer_sp = this->createTimer(timerOptions,
+                                                       timerCallback,
+                                                       d_allocator_p);
             }
 
             NTCR_DATAGRAMSOCKET_LOG_SEND_BUFFER_THROTTLE_APPLIED(timeToSubmit);
@@ -1604,12 +1606,15 @@ ntsa::Error DatagramSocket::privateThrottleReceiveBuffer(
                 timerOptions.hideEvent(ntca::TimerEventType::e_CANCELED);
                 timerOptions.hideEvent(ntca::TimerEventType::e_CLOSED);
 
-                d_receiveRateTimer_sp = this->createTimer(
-                    timerOptions,
-                    ntci::TimerCallback(bdlf::MemFnUtil::memFn(
+                ntci::TimerCallback timerCallback = ntci::TimerCallback(
+                    bdlf::MemFnUtil::memFn(
                         &DatagramSocket::processReceiveRateTimer,
-                        self)),
+                        self),
                     d_allocator_p);
+
+                d_receiveRateTimer_sp = this->createTimer(timerOptions,
+                                                          timerCallback,
+                                                          d_allocator_p);
             }
 
             NTCR_DATAGRAMSOCKET_LOG_RECEIVE_BUFFER_THROTTLE_APPLIED(

--- a/groups/ntc/ntcr/ntcr_listenersocket.cpp
+++ b/groups/ntc/ntcr/ntcr_listenersocket.cpp
@@ -1124,7 +1124,7 @@ ntsa::Error ListenerSocket::privateDequeueBacklog(
                 ntci::TimerCallback timerCallback = this->createTimerCallback(
                     bdlf::MemFnUtil::memFn(
                         &ListenerSocket::processAcceptBackoffTimer,
-                        this),
+                        self),
                     d_allocator_p);
 
                 d_acceptBackoffTimer_sp = this->createTimer(timerOptions,

--- a/groups/ntc/ntcr/ntcr_listenersocket.cpp
+++ b/groups/ntc/ntcr/ntcr_listenersocket.cpp
@@ -248,6 +248,11 @@ void ListenerSocket::processAcceptRateTimer(
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCR_LISTENERSOCKET_LOG_BACKLOG_THROTTLE_RELAXED();
 
+        this->privateRelaxFlowControl(self,
+                                      ntca::FlowControlType::e_RECEIVE,
+                                      false,
+                                      true);
+
         if (d_session_sp) {
             ntca::AcceptQueueEvent event;
             event.setType(ntca::AcceptQueueEventType::e_RATE_LIMIT_RELAXED);
@@ -260,14 +265,9 @@ void ListenerSocket::processAcceptRateTimer(
                 d_sessionStrand_sp,
                 ntci::Strand::unknown(),
                 self,
-                true,
+                false,
                 &d_mutex);
         }
-
-        this->privateRelaxFlowControl(self,
-                                      ntca::FlowControlType::e_RECEIVE,
-                                      false,
-                                      true);
     }
 }
 

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -580,6 +580,11 @@ void StreamSocket::processSendRateTimer(
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCR_STREAMSOCKET_LOG_SEND_BUFFER_THROTTLE_RELAXED();
 
+        this->privateRelaxFlowControl(self,
+                                      ntca::FlowControlType::e_SEND,
+                                      false,
+                                      true);
+
         if (d_session_sp) {
             ntca::WriteQueueEvent event;
             event.setType(ntca::WriteQueueEventType::e_RATE_LIMIT_RELAXED);
@@ -592,14 +597,9 @@ void StreamSocket::processSendRateTimer(
                 d_sessionStrand_sp,
                 ntci::Strand::unknown(),
                 self,
-                true,
+                false,
                 &d_mutex);
         }
-
-        this->privateRelaxFlowControl(self,
-                                      ntca::FlowControlType::e_SEND,
-                                      false,
-                                      true);
     }
 }
 
@@ -673,6 +673,11 @@ void StreamSocket::processReceiveRateTimer(
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCR_STREAMSOCKET_LOG_RECEIVE_BUFFER_THROTTLE_RELAXED();
 
+        this->privateRelaxFlowControl(self,
+                                      ntca::FlowControlType::e_RECEIVE,
+                                      false,
+                                      true);
+
         if (d_session_sp) {
             ntca::ReadQueueEvent event;
             event.setType(ntca::ReadQueueEventType::e_RATE_LIMIT_RELAXED);
@@ -688,11 +693,6 @@ void StreamSocket::processReceiveRateTimer(
                 false,
                 &d_mutex);
         }
-
-        this->privateRelaxFlowControl(self,
-                                      ntca::FlowControlType::e_RECEIVE,
-                                      false,
-                                      true);
     }
 }
 

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -4868,7 +4868,7 @@ ntsa::Error StreamSocket::upgrade(
         timerOptions.setOneShot(true);
 
         ntci::TimerCallback timerCallback = this->createTimerCallback(
-            bdlf::MemFnUtil::memFn(&StreamSocket::processUpgradeTimer, this),
+            bdlf::MemFnUtil::memFn(&StreamSocket::processUpgradeTimer, self),
             d_allocator_p);
 
         d_upgradeTimer_sp =

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -580,6 +580,22 @@ void StreamSocket::processSendRateTimer(
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCR_STREAMSOCKET_LOG_SEND_BUFFER_THROTTLE_RELAXED();
 
+        if (d_session_sp) {
+            ntca::WriteQueueEvent event;
+            event.setType(ntca::WriteQueueEventType::e_RATE_LIMIT_RELAXED);
+            event.setContext(d_sendQueue.context());
+
+            ntcs::Dispatch::announceWriteQueueRateLimitRelaxed(
+                d_session_sp,
+                self,
+                event,
+                d_sessionStrand_sp,
+                ntci::Strand::unknown(),
+                self,
+                true,
+                &d_mutex);
+        }
+
         this->privateRelaxFlowControl(self,
                                       ntca::FlowControlType::e_SEND,
                                       false,
@@ -656,6 +672,22 @@ void StreamSocket::processReceiveRateTimer(
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCR_STREAMSOCKET_LOG_RECEIVE_BUFFER_THROTTLE_RELAXED();
+
+        if (d_session_sp) {
+            ntca::ReadQueueEvent event;
+            event.setType(ntca::ReadQueueEventType::e_RATE_LIMIT_RELAXED);
+            event.setContext(d_receiveQueue.context());
+
+            ntcs::Dispatch::announceReadQueueRateLimitRelaxed(
+                d_session_sp,
+                self,
+                event,
+                d_sessionStrand_sp,
+                ntci::Strand::unknown(),
+                self,
+                false,
+                &d_mutex);
+        }
 
         this->privateRelaxFlowControl(self,
                                       ntca::FlowControlType::e_RECEIVE,
@@ -2423,7 +2455,7 @@ ntsa::Error StreamSocket::privateThrottleSendBuffer(
 
                 ntci::TimerCallback timerCallback = this->createTimerCallback(
                     bdlf::MemFnUtil::memFn(&StreamSocket::processSendRateTimer,
-                                           this),
+                                           self),
                     d_allocator_p);
 
                 d_sendRateTimer_sp = this->createTimer(timerOptions,
@@ -2434,6 +2466,22 @@ ntsa::Error StreamSocket::privateThrottleSendBuffer(
             bsls::TimeInterval nextSendAttemptTime = now + timeToSubmit;
 
             d_sendRateTimer_sp->schedule(nextSendAttemptTime);
+
+            if (d_session_sp) {
+                ntca::WriteQueueEvent event;
+                event.setType(ntca::WriteQueueEventType::e_RATE_LIMIT_APPLIED);
+                event.setContext(d_sendQueue.context());
+
+                ntcs::Dispatch::announceWriteQueueRateLimitApplied(
+                    d_session_sp,
+                    self,
+                    event,
+                    d_sessionStrand_sp,
+                    ntci::Strand::unknown(),
+                    self,
+                    true,
+                    &d_mutex);
+            }
 
             return ntsa::Error(ntsa::Error::e_WOULD_BLOCK);
         }
@@ -2476,7 +2524,7 @@ ntsa::Error StreamSocket::privateThrottleReceiveBuffer(
                 ntci::TimerCallback timerCallback = this->createTimerCallback(
                     bdlf::MemFnUtil::memFn(
                         &StreamSocket::processReceiveRateTimer,
-                        this),
+                        self),
                     d_allocator_p);
 
                 d_receiveRateTimer_sp = this->createTimer(timerOptions,
@@ -2487,6 +2535,22 @@ ntsa::Error StreamSocket::privateThrottleReceiveBuffer(
             bsls::TimeInterval nextReceiveAttemptTime = now + timeToSubmit;
 
             d_receiveRateTimer_sp->schedule(nextReceiveAttemptTime);
+
+            if (d_session_sp) {
+                ntca::ReadQueueEvent event;
+                event.setType(ntca::ReadQueueEventType::e_RATE_LIMIT_APPLIED);
+                event.setContext(d_receiveQueue.context());
+
+                ntcs::Dispatch::announceReadQueueRateLimitApplied(
+                    d_session_sp,
+                    self,
+                    event,
+                    d_sessionStrand_sp,
+                    ntci::Strand::unknown(),
+                    self,
+                    true,
+                    &d_mutex);
+            }
 
             return ntsa::Error(ntsa::Error::e_WOULD_BLOCK);
         }

--- a/groups/ntc/ntcs/ntcs_dispatch.cpp
+++ b/groups/ntc/ntcs/ntcs_dispatch.cpp
@@ -284,6 +284,80 @@ void Dispatch::announceReadQueueDiscarded(
     }
 }
 
+void Dispatch::announceReadQueueRateLimitApplied(
+    const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
+    const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
+    const ntca::ReadQueueEvent&                         event,
+    const bsl::shared_ptr<ntci::Strand>&                destination,
+    const bsl::shared_ptr<ntci::Strand>&                source,
+    const bsl::shared_ptr<ntci::Executor>&              executor,
+    bool                                                defer,
+    bslmt::Mutex*                                       mutex)
+{
+    if (!session) {
+        return;
+    }
+
+    if (NTCCFG_LIKELY(!defer &&
+                      ntci::Strand::passthrough(destination, source)))
+    {
+        bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
+        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        sessionGuard->processReadQueueRateLimitApplied(socket, event);
+    }
+    else if (destination) {
+        destination->execute(NTCCFG_BIND(
+            &ntci::DatagramSocketSession::processReadQueueRateLimitApplied,
+            session,
+            socket,
+            event));
+    }
+    else {
+        executor->execute(NTCCFG_BIND(
+            &ntci::DatagramSocketSession::processReadQueueRateLimitApplied,
+            session,
+            socket,
+            event));
+    }
+}
+
+void Dispatch::announceReadQueueRateLimitRelaxed(
+    const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
+    const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
+    const ntca::ReadQueueEvent&                         event,
+    const bsl::shared_ptr<ntci::Strand>&                destination,
+    const bsl::shared_ptr<ntci::Strand>&                source,
+    const bsl::shared_ptr<ntci::Executor>&              executor,
+    bool                                                defer,
+    bslmt::Mutex*                                       mutex)
+{
+    if (!session) {
+        return;
+    }
+
+    if (NTCCFG_LIKELY(!defer &&
+                      ntci::Strand::passthrough(destination, source)))
+    {
+        bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
+        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        sessionGuard->processReadQueueRateLimitRelaxed(socket, event);
+    }
+    else if (destination) {
+        destination->execute(NTCCFG_BIND(
+            &ntci::DatagramSocketSession::processReadQueueRateLimitRelaxed,
+            session,
+            socket,
+            event));
+    }
+    else {
+        executor->execute(NTCCFG_BIND(
+            &ntci::DatagramSocketSession::processReadQueueRateLimitRelaxed,
+            session,
+            socket,
+            event));
+    }
+}
+
 void Dispatch::announceWriteQueueFlowControlRelaxed(
     const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
     const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
@@ -463,6 +537,80 @@ void Dispatch::announceWriteQueueDiscarded(
     else {
         executor->execute(NTCCFG_BIND(
             &ntci::DatagramSocketSession::processWriteQueueDiscarded,
+            session,
+            socket,
+            event));
+    }
+}
+
+void Dispatch::announceWriteQueueRateLimitApplied(
+    const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
+    const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
+    const ntca::WriteQueueEvent&                        event,
+    const bsl::shared_ptr<ntci::Strand>&                destination,
+    const bsl::shared_ptr<ntci::Strand>&                source,
+    const bsl::shared_ptr<ntci::Executor>&              executor,
+    bool                                                defer,
+    bslmt::Mutex*                                       mutex)
+{
+    if (!session) {
+        return;
+    }
+
+    if (NTCCFG_LIKELY(!defer &&
+                      ntci::Strand::passthrough(destination, source)))
+    {
+        bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
+        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        sessionGuard->processWriteQueueRateLimitApplied(socket, event);
+    }
+    else if (destination) {
+        destination->execute(NTCCFG_BIND(
+            &ntci::DatagramSocketSession::processWriteQueueRateLimitApplied,
+            session,
+            socket,
+            event));
+    }
+    else {
+        executor->execute(NTCCFG_BIND(
+            &ntci::DatagramSocketSession::processWriteQueueRateLimitApplied,
+            session,
+            socket,
+            event));
+    }
+}
+
+void Dispatch::announceWriteQueueRateLimitRelaxed(
+    const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
+    const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
+    const ntca::WriteQueueEvent&                        event,
+    const bsl::shared_ptr<ntci::Strand>&                destination,
+    const bsl::shared_ptr<ntci::Strand>&                source,
+    const bsl::shared_ptr<ntci::Executor>&              executor,
+    bool                                                defer,
+    bslmt::Mutex*                                       mutex)
+{
+    if (!session) {
+        return;
+    }
+
+    if (NTCCFG_LIKELY(!defer &&
+                      ntci::Strand::passthrough(destination, source)))
+    {
+        bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
+        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        sessionGuard->processWriteQueueRateLimitRelaxed(socket, event);
+    }
+    else if (destination) {
+        destination->execute(NTCCFG_BIND(
+            &ntci::DatagramSocketSession::processWriteQueueRateLimitRelaxed,
+            session,
+            socket,
+            event));
+    }
+    else {
+        executor->execute(NTCCFG_BIND(
+            &ntci::DatagramSocketSession::processWriteQueueRateLimitRelaxed,
             session,
             socket,
             event));
@@ -909,6 +1057,80 @@ void Dispatch::announceAcceptQueueDiscarded(
     }
 }
 
+void Dispatch::announceAcceptQueueRateLimitApplied(
+    const bsl::shared_ptr<ntci::ListenerSocketSession>& session,
+    const bsl::shared_ptr<ntci::ListenerSocket>&        socket,
+    const ntca::AcceptQueueEvent&                       event,
+    const bsl::shared_ptr<ntci::Strand>&                destination,
+    const bsl::shared_ptr<ntci::Strand>&                source,
+    const bsl::shared_ptr<ntci::Executor>&              executor,
+    bool                                                defer,
+    bslmt::Mutex*                                       mutex)
+{
+    if (!session) {
+        return;
+    }
+
+    if (NTCCFG_LIKELY(!defer &&
+                      ntci::Strand::passthrough(destination, source)))
+    {
+        bsl::shared_ptr<ntci::ListenerSocketSession> sessionGuard = session;
+        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        sessionGuard->processAcceptQueueRateLimitApplied(socket, event);
+    }
+    else if (destination) {
+        destination->execute(NTCCFG_BIND(
+            &ntci::ListenerSocketSession::processAcceptQueueRateLimitApplied,
+            session,
+            socket,
+            event));
+    }
+    else {
+        executor->execute(NTCCFG_BIND(
+            &ntci::ListenerSocketSession::processAcceptQueueRateLimitApplied,
+            session,
+            socket,
+            event));
+    }
+}
+
+void Dispatch::announceAcceptQueueRateLimitRelaxed(
+    const bsl::shared_ptr<ntci::ListenerSocketSession>& session,
+    const bsl::shared_ptr<ntci::ListenerSocket>&        socket,
+    const ntca::AcceptQueueEvent&                       event,
+    const bsl::shared_ptr<ntci::Strand>&                destination,
+    const bsl::shared_ptr<ntci::Strand>&                source,
+    const bsl::shared_ptr<ntci::Executor>&              executor,
+    bool                                                defer,
+    bslmt::Mutex*                                       mutex)
+{
+    if (!session) {
+        return;
+    }
+
+    if (NTCCFG_LIKELY(!defer &&
+                      ntci::Strand::passthrough(destination, source)))
+    {
+        bsl::shared_ptr<ntci::ListenerSocketSession> sessionGuard = session;
+        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        sessionGuard->processAcceptQueueRateLimitRelaxed(socket, event);
+    }
+    else if (destination) {
+        destination->execute(NTCCFG_BIND(
+            &ntci::ListenerSocketSession::processAcceptQueueRateLimitRelaxed,
+            session,
+            socket,
+            event));
+    }
+    else {
+        executor->execute(NTCCFG_BIND(
+            &ntci::ListenerSocketSession::processAcceptQueueRateLimitRelaxed,
+            session,
+            socket,
+            event));
+    }
+}
+
 void Dispatch::announceShutdownInitiated(
     const bsl::shared_ptr<ntci::ListenerSocketSession>& session,
     const bsl::shared_ptr<ntci::ListenerSocket>&        socket,
@@ -1349,6 +1571,80 @@ void Dispatch::announceReadQueueDiscarded(
     }
 }
 
+void Dispatch::announceReadQueueRateLimitApplied(
+    const bsl::shared_ptr<ntci::StreamSocketSession>& session,
+    const bsl::shared_ptr<ntci::StreamSocket>&        socket,
+    const ntca::ReadQueueEvent&                       event,
+    const bsl::shared_ptr<ntci::Strand>&              destination,
+    const bsl::shared_ptr<ntci::Strand>&              source,
+    const bsl::shared_ptr<ntci::Executor>&            executor,
+    bool                                              defer,
+    bslmt::Mutex*                                     mutex)
+{
+    if (!session) {
+        return;
+    }
+
+    if (NTCCFG_LIKELY(!defer &&
+                      ntci::Strand::passthrough(destination, source)))
+    {
+        bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
+        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        sessionGuard->processReadQueueRateLimitApplied(socket, event);
+    }
+    else if (destination) {
+        destination->execute(NTCCFG_BIND(
+            &ntci::StreamSocketSession::processReadQueueRateLimitApplied,
+            session,
+            socket,
+            event));
+    }
+    else {
+        executor->execute(NTCCFG_BIND(
+            &ntci::StreamSocketSession::processReadQueueRateLimitApplied,
+            session,
+            socket,
+            event));
+    }
+}
+
+void Dispatch::announceReadQueueRateLimitRelaxed(
+    const bsl::shared_ptr<ntci::StreamSocketSession>& session,
+    const bsl::shared_ptr<ntci::StreamSocket>&        socket,
+    const ntca::ReadQueueEvent&                       event,
+    const bsl::shared_ptr<ntci::Strand>&              destination,
+    const bsl::shared_ptr<ntci::Strand>&              source,
+    const bsl::shared_ptr<ntci::Executor>&            executor,
+    bool                                              defer,
+    bslmt::Mutex*                                     mutex)
+{
+    if (!session) {
+        return;
+    }
+
+    if (NTCCFG_LIKELY(!defer &&
+                      ntci::Strand::passthrough(destination, source)))
+    {
+        bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
+        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        sessionGuard->processReadQueueRateLimitRelaxed(socket, event);
+    }
+    else if (destination) {
+        destination->execute(NTCCFG_BIND(
+            &ntci::StreamSocketSession::processReadQueueRateLimitRelaxed,
+            session,
+            socket,
+            event));
+    }
+    else {
+        executor->execute(NTCCFG_BIND(
+            &ntci::StreamSocketSession::processReadQueueRateLimitRelaxed,
+            session,
+            socket,
+            event));
+    }
+}
+
 void Dispatch::announceWriteQueueFlowControlRelaxed(
     const bsl::shared_ptr<ntci::StreamSocketSession>& session,
     const bsl::shared_ptr<ntci::StreamSocket>&        socket,
@@ -1531,6 +1827,80 @@ void Dispatch::announceWriteQueueDiscarded(
                         session,
                         socket,
                         event));
+    }
+}
+
+void Dispatch::announceWriteQueueRateLimitApplied(
+    const bsl::shared_ptr<ntci::StreamSocketSession>& session,
+    const bsl::shared_ptr<ntci::StreamSocket>&        socket,
+    const ntca::WriteQueueEvent&                      event,
+    const bsl::shared_ptr<ntci::Strand>&              destination,
+    const bsl::shared_ptr<ntci::Strand>&              source,
+    const bsl::shared_ptr<ntci::Executor>&            executor,
+    bool                                              defer,
+    bslmt::Mutex*                                     mutex)
+{
+    if (!session) {
+        return;
+    }
+
+    if (NTCCFG_LIKELY(!defer &&
+                      ntci::Strand::passthrough(destination, source)))
+    {
+        bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
+        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        sessionGuard->processWriteQueueRateLimitApplied(socket, event);
+    }
+    else if (destination) {
+        destination->execute(NTCCFG_BIND(
+            &ntci::StreamSocketSession::processWriteQueueRateLimitApplied,
+            session,
+            socket,
+            event));
+    }
+    else {
+        executor->execute(NTCCFG_BIND(
+            &ntci::StreamSocketSession::processWriteQueueRateLimitApplied,
+            session,
+            socket,
+            event));
+    }
+}
+
+void Dispatch::announceWriteQueueRateLimitRelaxed(
+    const bsl::shared_ptr<ntci::StreamSocketSession>& session,
+    const bsl::shared_ptr<ntci::StreamSocket>&        socket,
+    const ntca::WriteQueueEvent&                      event,
+    const bsl::shared_ptr<ntci::Strand>&              destination,
+    const bsl::shared_ptr<ntci::Strand>&              source,
+    const bsl::shared_ptr<ntci::Executor>&            executor,
+    bool                                              defer,
+    bslmt::Mutex*                                     mutex)
+{
+    if (!session) {
+        return;
+    }
+
+    if (NTCCFG_LIKELY(!defer &&
+                      ntci::Strand::passthrough(destination, source)))
+    {
+        bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
+        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        sessionGuard->processWriteQueueRateLimitRelaxed(socket, event);
+    }
+    else if (destination) {
+        destination->execute(NTCCFG_BIND(
+            &ntci::StreamSocketSession::processWriteQueueRateLimitRelaxed,
+            session,
+            socket,
+            event));
+    }
+    else {
+        executor->execute(NTCCFG_BIND(
+            &ntci::StreamSocketSession::processWriteQueueRateLimitRelaxed,
+            session,
+            socket,
+            event));
     }
 }
 

--- a/groups/ntc/ntcs/ntcs_dispatch.h
+++ b/groups/ntc/ntcs/ntcs_dispatch.h
@@ -220,6 +220,19 @@ struct Dispatch {
         bool                                                defer,
         bslmt::Mutex*                                       mutex);
 
+    /// Announce to the specified 'session' the condition that read queue
+    /// rate limit has been reached. If the specified 'defer' flag is
+    /// false and the requirements of the specified 'destination' strand
+    /// permits the announcement to be executed immediately by the specified
+    /// 'source' strand, unlock the specified 'mutex', execute the
+    /// announcement, then relock the 'mutex'. Otherwise, enqueue the
+    /// announcement to be executed on the 'destination' strand, if not
+    /// null, or by the specified 'executor' otherwise. The behavior is
+    /// undefined if 'mutex' is null or not locked. The behavior is *not*
+    /// undefined if either the 'destination' strand is null or the 'source'
+    /// strand is null; a null 'destination' strand indicates the
+    /// announcement may be invoked on any strand by any thread; a null
+    /// 'source' strand indicates the source strand is unknown.
     static void announceReadQueueRateLimitApplied(
         const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
         const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
@@ -230,6 +243,19 @@ struct Dispatch {
         bool                                                defer,
         bslmt::Mutex*                                       mutex);
 
+    /// Announce to the specified 'session' the condition that read queue
+    /// rate limit timer has fired. If the specified 'defer' flag is
+    /// false and the requirements of the specified 'destination' strand
+    /// permits the announcement to be executed immediately by the specified
+    /// 'source' strand, unlock the specified 'mutex', execute the
+    /// announcement, then relock the 'mutex'. Otherwise, enqueue the
+    /// announcement to be executed on the 'destination' strand, if not
+    /// null, or by the specified 'executor' otherwise. The behavior is
+    /// undefined if 'mutex' is null or not locked. The behavior is *not*
+    /// undefined if either the 'destination' strand is null or the 'source'
+    /// strand is null; a null 'destination' strand indicates the
+    /// announcement may be invoked on any strand by any thread; a null
+    /// 'source' strand indicates the source strand is unknown.
     static void announceReadQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
         const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
@@ -359,6 +385,19 @@ struct Dispatch {
         bool                                                defer,
         bslmt::Mutex*                                       mutex);
 
+    /// Announce to the specified 'session' the condition that write queue
+    /// rate limit has been reached. If the specified 'defer' flag is
+    /// false and the requirements of the specified 'destination' strand
+    /// permits the announcement to be executed immediately by the specified
+    /// 'source' strand, unlock the specified 'mutex', execute the
+    /// announcement, then relock the 'mutex'. Otherwise, enqueue the
+    /// announcement to be executed on the 'destination' strand, if not
+    /// null, or by the specified 'executor' otherwise. The behavior is
+    /// undefined if 'mutex' is null or not locked. The behavior is *not*
+    /// undefined if either the 'destination' strand is null or the 'source'
+    /// strand is null; a null 'destination' strand indicates the
+    /// announcement may be invoked on any strand by any thread; a null
+    /// 'source' strand indicates the source strand is unknown.
     static void announceWriteQueueRateLimitApplied(
         const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
         const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
@@ -369,6 +408,19 @@ struct Dispatch {
         bool                                                defer,
         bslmt::Mutex*                                       mutex);
 
+    /// Announce to the specified 'session' the condition that write queue
+    /// rate limit timer has fired. If the specified 'defer' flag is
+    /// false and the requirements of the specified 'destination' strand
+    /// permits the announcement to be executed immediately by the specified
+    /// 'source' strand, unlock the specified 'mutex', execute the
+    /// announcement, then relock the 'mutex'. Otherwise, enqueue the
+    /// announcement to be executed on the 'destination' strand, if not
+    /// null, or by the specified 'executor' otherwise. The behavior is
+    /// undefined if 'mutex' is null or not locked. The behavior is *not*
+    /// undefined if either the 'destination' strand is null or the 'source'
+    /// strand is null; a null 'destination' strand indicates the
+    /// announcement may be invoked on any strand by any thread; a null
+    /// 'source' strand indicates the source strand is unknown.
     static void announceWriteQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
         const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
@@ -660,6 +712,19 @@ struct Dispatch {
         bool                                                defer,
         bslmt::Mutex*                                       mutex);
 
+    /// Announce to the specified 'session' the condition that acccept queue
+    /// rate limit has been reached. If the specified 'defer' flag is
+    /// false and the requirements of the specified 'destination' strand
+    /// permits the announcement to be executed immediately by the specified
+    /// 'source' strand, unlock the specified 'mutex', execute the
+    /// announcement, then relock the 'mutex'. Otherwise, enqueue the
+    /// announcement to be executed on the 'destination' strand, if not
+    /// null, or by the specified 'executor' otherwise. The behavior is
+    /// undefined if 'mutex' is null or not locked. The behavior is *not*
+    /// undefined if either the 'destination' strand is null or the 'source'
+    /// strand is null; a null 'destination' strand indicates the
+    /// announcement may be invoked on any strand by any thread; a null
+    /// 'source' strand indicates the source strand is unknown.
     static void announceAcceptQueueRateLimitApplied(
         const bsl::shared_ptr<ntci::ListenerSocketSession>& session,
         const bsl::shared_ptr<ntci::ListenerSocket>&        socket,
@@ -670,6 +735,19 @@ struct Dispatch {
         bool                                                defer,
         bslmt::Mutex*                                       mutex);
 
+    /// Announce to the specified 'session' the condition that accept queue
+    /// rate limit timer has fired. If the specified 'defer' flag is
+    /// false and the requirements of the specified 'destination' strand
+    /// permits the announcement to be executed immediately by the specified
+    /// 'source' strand, unlock the specified 'mutex', execute the
+    /// announcement, then relock the 'mutex'. Otherwise, enqueue the
+    /// announcement to be executed on the 'destination' strand, if not
+    /// null, or by the specified 'executor' otherwise. The behavior is
+    /// undefined if 'mutex' is null or not locked. The behavior is *not*
+    /// undefined if either the 'destination' strand is null or the 'source'
+    /// strand is null; a null 'destination' strand indicates the
+    /// announcement may be invoked on any strand by any thread; a null
+    /// 'source' strand indicates the source strand is unknown.
     static void announceAcceptQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::ListenerSocketSession>& session,
         const bsl::shared_ptr<ntci::ListenerSocket>&        socket,
@@ -961,6 +1039,19 @@ struct Dispatch {
         bool                                              defer,
         bslmt::Mutex*                                     mutex);
 
+    /// Announce to the specified 'session' the condition that read queue
+    /// rate limit has been reached. If the specified 'defer' flag is
+    /// false and the requirements of the specified 'destination' strand
+    /// permits the announcement to be executed immediately by the specified
+    /// 'source' strand, unlock the specified 'mutex', execute the
+    /// announcement, then relock the 'mutex'. Otherwise, enqueue the
+    /// announcement to be executed on the 'destination' strand, if not
+    /// null, or by the specified 'executor' otherwise. The behavior is
+    /// undefined if 'mutex' is null or not locked. The behavior is *not*
+    /// undefined if either the 'destination' strand is null or the 'source'
+    /// strand is null; a null 'destination' strand indicates the
+    /// announcement may be invoked on any strand by any thread; a null
+    /// 'source' strand indicates the source strand is unknown.
     static void announceReadQueueRateLimitApplied(
         const bsl::shared_ptr<ntci::StreamSocketSession>& session,
         const bsl::shared_ptr<ntci::StreamSocket>&        socket,
@@ -971,6 +1062,19 @@ struct Dispatch {
         bool                                              defer,
         bslmt::Mutex*                                     mutex);
 
+    /// Announce to the specified 'session' the condition that read queue
+    /// rate limit timer has fired. If the specified 'defer' flag is
+    /// false and the requirements of the specified 'destination' strand
+    /// permits the announcement to be executed immediately by the specified
+    /// 'source' strand, unlock the specified 'mutex', execute the
+    /// announcement, then relock the 'mutex'. Otherwise, enqueue the
+    /// announcement to be executed on the 'destination' strand, if not
+    /// null, or by the specified 'executor' otherwise. The behavior is
+    /// undefined if 'mutex' is null or not locked. The behavior is *not*
+    /// undefined if either the 'destination' strand is null or the 'source'
+    /// strand is null; a null 'destination' strand indicates the
+    /// announcement may be invoked on any strand by any thread; a null
+    /// 'source' strand indicates the source strand is unknown.
     static void announceReadQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::StreamSocketSession>& session,
         const bsl::shared_ptr<ntci::StreamSocket>&        socket,
@@ -1100,6 +1204,19 @@ struct Dispatch {
         bool                                              defer,
         bslmt::Mutex*                                     mutex);
 
+    /// Announce to the specified 'session' the condition that write queue
+    /// rate limit has been reached. If the specified 'defer' flag is
+    /// false and the requirements of the specified 'destination' strand
+    /// permits the announcement to be executed immediately by the specified
+    /// 'source' strand, unlock the specified 'mutex', execute the
+    /// announcement, then relock the 'mutex'. Otherwise, enqueue the
+    /// announcement to be executed on the 'destination' strand, if not
+    /// null, or by the specified 'executor' otherwise. The behavior is
+    /// undefined if 'mutex' is null or not locked. The behavior is *not*
+    /// undefined if either the 'destination' strand is null or the 'source'
+    /// strand is null; a null 'destination' strand indicates the
+    /// announcement may be invoked on any strand by any thread; a null
+    /// 'source' strand indicates the source strand is unknown.
     static void announceWriteQueueRateLimitApplied(
         const bsl::shared_ptr<ntci::StreamSocketSession>& session,
         const bsl::shared_ptr<ntci::StreamSocket>&        socket,
@@ -1110,6 +1227,19 @@ struct Dispatch {
         bool                                              defer,
         bslmt::Mutex*                                     mutex);
 
+    /// Announce to the specified 'session' the condition that write queue
+    /// rate limit timer has fired. If the specified 'defer' flag is
+    /// false and the requirements of the specified 'destination' strand
+    /// permits the announcement to be executed immediately by the specified
+    /// 'source' strand, unlock the specified 'mutex', execute the
+    /// announcement, then relock the 'mutex'. Otherwise, enqueue the
+    /// announcement to be executed on the 'destination' strand, if not
+    /// null, or by the specified 'executor' otherwise. The behavior is
+    /// undefined if 'mutex' is null or not locked. The behavior is *not*
+    /// undefined if either the 'destination' strand is null or the 'source'
+    /// strand is null; a null 'destination' strand indicates the
+    /// announcement may be invoked on any strand by any thread; a null
+    /// 'source' strand indicates the source strand is unknown.
     static void announceWriteQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::StreamSocketSession>& session,
         const bsl::shared_ptr<ntci::StreamSocket>&        socket,

--- a/groups/ntc/ntcs/ntcs_dispatch.h
+++ b/groups/ntc/ntcs/ntcs_dispatch.h
@@ -220,6 +220,26 @@ struct Dispatch {
         bool                                                defer,
         bslmt::Mutex*                                       mutex);
 
+    static void announceReadQueueRateLimitApplied(
+        const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
+        const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
+        const ntca::ReadQueueEvent&                         event,
+        const bsl::shared_ptr<ntci::Strand>&                destination,
+        const bsl::shared_ptr<ntci::Strand>&                source,
+        const bsl::shared_ptr<ntci::Executor>&              executor,
+        bool                                                defer,
+        bslmt::Mutex*                                       mutex);
+
+    static void announceReadQueueRateLimitRelaxed(
+        const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
+        const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
+        const ntca::ReadQueueEvent&                         event,
+        const bsl::shared_ptr<ntci::Strand>&                destination,
+        const bsl::shared_ptr<ntci::Strand>&                source,
+        const bsl::shared_ptr<ntci::Executor>&              executor,
+        bool                                                defer,
+        bslmt::Mutex*                                       mutex);
+
     /// Announce to the specified 'session' the condition that write queue
     /// flow control has been relaxed. If the specified 'defer' flag is
     /// false and the requirements of the specified 'destination' strand
@@ -330,6 +350,26 @@ struct Dispatch {
     /// any thread; a null 'source' strand indicates the source strand is
     /// unknown.
     static void announceWriteQueueDiscarded(
+        const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
+        const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
+        const ntca::WriteQueueEvent&                        event,
+        const bsl::shared_ptr<ntci::Strand>&                destination,
+        const bsl::shared_ptr<ntci::Strand>&                source,
+        const bsl::shared_ptr<ntci::Executor>&              executor,
+        bool                                                defer,
+        bslmt::Mutex*                                       mutex);
+
+    static void announceWriteQueueRateLimitApplied(
+        const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
+        const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
+        const ntca::WriteQueueEvent&                        event,
+        const bsl::shared_ptr<ntci::Strand>&                destination,
+        const bsl::shared_ptr<ntci::Strand>&                source,
+        const bsl::shared_ptr<ntci::Executor>&              executor,
+        bool                                                defer,
+        bslmt::Mutex*                                       mutex);
+
+    static void announceWriteQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
         const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
         const ntca::WriteQueueEvent&                        event,
@@ -620,6 +660,26 @@ struct Dispatch {
         bool                                                defer,
         bslmt::Mutex*                                       mutex);
 
+    static void announceAcceptQueueRateLimitApplied(
+        const bsl::shared_ptr<ntci::ListenerSocketSession>& session,
+        const bsl::shared_ptr<ntci::ListenerSocket>&        socket,
+        const ntca::AcceptQueueEvent&                       event,
+        const bsl::shared_ptr<ntci::Strand>&                destination,
+        const bsl::shared_ptr<ntci::Strand>&                source,
+        const bsl::shared_ptr<ntci::Executor>&              executor,
+        bool                                                defer,
+        bslmt::Mutex*                                       mutex);
+
+    static void announceAcceptQueueRateLimitRelaxed(
+        const bsl::shared_ptr<ntci::ListenerSocketSession>& session,
+        const bsl::shared_ptr<ntci::ListenerSocket>&        socket,
+        const ntca::AcceptQueueEvent&                       event,
+        const bsl::shared_ptr<ntci::Strand>&                destination,
+        const bsl::shared_ptr<ntci::Strand>&                source,
+        const bsl::shared_ptr<ntci::Executor>&              executor,
+        bool                                                defer,
+        bslmt::Mutex*                                       mutex);
+
     /// Announce to the specified 'session' the initiation of the shutdown
     /// sequence of the specified 'socket' from the specified 'origin'. If
     /// the specified 'defer' flag is false and the requirements of the
@@ -901,6 +961,26 @@ struct Dispatch {
         bool                                              defer,
         bslmt::Mutex*                                     mutex);
 
+    static void announceReadQueueRateLimitApplied(
+        const bsl::shared_ptr<ntci::StreamSocketSession>& session,
+        const bsl::shared_ptr<ntci::StreamSocket>&        socket,
+        const ntca::ReadQueueEvent&                       event,
+        const bsl::shared_ptr<ntci::Strand>&              destination,
+        const bsl::shared_ptr<ntci::Strand>&              source,
+        const bsl::shared_ptr<ntci::Executor>&            executor,
+        bool                                              defer,
+        bslmt::Mutex*                                     mutex);
+
+    static void announceReadQueueRateLimitRelaxed(
+        const bsl::shared_ptr<ntci::StreamSocketSession>& session,
+        const bsl::shared_ptr<ntci::StreamSocket>&        socket,
+        const ntca::ReadQueueEvent&                       event,
+        const bsl::shared_ptr<ntci::Strand>&              destination,
+        const bsl::shared_ptr<ntci::Strand>&              source,
+        const bsl::shared_ptr<ntci::Executor>&            executor,
+        bool                                              defer,
+        bslmt::Mutex*                                     mutex);
+
     /// Announce to the specified 'session' the condition that write queue
     /// flow control has been relaxed. If the specified 'defer' flag is
     /// false and the requirements of the specified 'destination' strand
@@ -1011,6 +1091,26 @@ struct Dispatch {
     /// any thread; a null 'source' strand indicates the source strand is
     /// unknown.
     static void announceWriteQueueDiscarded(
+        const bsl::shared_ptr<ntci::StreamSocketSession>& session,
+        const bsl::shared_ptr<ntci::StreamSocket>&        socket,
+        const ntca::WriteQueueEvent&                      event,
+        const bsl::shared_ptr<ntci::Strand>&              destination,
+        const bsl::shared_ptr<ntci::Strand>&              source,
+        const bsl::shared_ptr<ntci::Executor>&            executor,
+        bool                                              defer,
+        bslmt::Mutex*                                     mutex);
+
+    static void announceWriteQueueRateLimitApplied(
+        const bsl::shared_ptr<ntci::StreamSocketSession>& session,
+        const bsl::shared_ptr<ntci::StreamSocket>&        socket,
+        const ntca::WriteQueueEvent&                      event,
+        const bsl::shared_ptr<ntci::Strand>&              destination,
+        const bsl::shared_ptr<ntci::Strand>&              source,
+        const bsl::shared_ptr<ntci::Executor>&            executor,
+        bool                                              defer,
+        bslmt::Mutex*                                     mutex);
+
+    static void announceWriteQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::StreamSocketSession>& session,
         const bsl::shared_ptr<ntci::StreamSocket>&        socket,
         const ntca::WriteQueueEvent&                      event,


### PR DESCRIPTION
The aim of this PR is to resolve a data race happining during destruction of a socket on a system with dynamic load balancing.
The issue is mentioned here: [issue 62](https://github.com/bloomberg/ntf-core/issues/62)

It can happen that one thread (e.g. main thread) is destroying a socket while timer callback function still exists inside another thread which is processing timer callback. The timer callback itself can contain some data allocated from the pool inside of e.g. `DatagramSocket`: `ntcq::ReceiveCallbackQueueEntry`

This PR introduces the following changes:
1. For all the sockets all the bindings in timer callbacks now use `bsl::shared_ptr<>` instead of `this` as the first argument. This helps to sequence destruction of objects and ensure that any timer callback entity is destroyed before the destruction of a socket.
2. Also, all timer callbacks uses `this->strand()` to avoid a situation when ina dynamically load balanced system diferent IO threads concurrently try to execute soket methods
3. Due to point 1 it is now important to ensure that all socket timers are closed when the socket is closed. So new tests were added to `ntcf_system` test driver.
4. In order to help with testing (point 3) new events were added for all the socket queues: `e_RATE_LIMIT_APPLIED` and `e_RATE_LIMIT_RELAXED`


