### PR TITLE
Do not exclude network devices that do not have IFF_RUNNING set enumerating network devices.

### DIFF
--- a/groups/nts/ntsu/ntsu_adapterutil.cpp
+++ b/groups/nts/ntsu/ntsu_adapterutil.cpp
@@ -199,6 +199,9 @@ void AdapterUtil::discoverAdapterList(bsl::vector<ntsa::Adapter>* result)
 #if defined(BSLS_PLATFORM_OS_DARWIN) || defined(BSLS_PLATFORM_OS_FREEBSD) ||  \
     defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_SOLARIS)
 
+    // Note: Not all devices that are operational must be marked as RUNNING,
+    // e.g. TUN/TAP devices. Do not exclude device that are not RUNNING.
+
     result->clear();
 
     struct ifaddrs* interfaceAddressList = 0;
@@ -233,17 +236,9 @@ void AdapterUtil::discoverAdapterList(bsl::vector<ntsa::Adapter>* result)
             continue;
         }
 
-        BSLS_LOG_TRACE("Interface '%s' found", interfaceAddress->ifa_name);
-
         bsl::string adapterName = interfaceAddress->ifa_name;
 
         if ((interfaceAddress->ifa_flags & IFF_UP) == 0) {
-            BSLS_LOG_TRACE("Interface '%s' is NOT UP", interfaceAddress->ifa_name);
-            continue;
-        }
-
-        if ((interfaceAddress->ifa_flags & IFF_RUNNING) == 0) {
-            BSLS_LOG_TRACE("Interface '%s' is NOT RUNNING", interfaceAddress->ifa_name);
             continue;
         }
 

--- a/groups/nts/ntsu/ntsu_adapterutil.cpp
+++ b/groups/nts/ntsu/ntsu_adapterutil.cpp
@@ -233,13 +233,17 @@ void AdapterUtil::discoverAdapterList(bsl::vector<ntsa::Adapter>* result)
             continue;
         }
 
+        BSLS_LOG_TRACE("Interface '%s' found", interfaceAddress->ifa_name);
+
         bsl::string adapterName = interfaceAddress->ifa_name;
 
         if ((interfaceAddress->ifa_flags & IFF_UP) == 0) {
+            BSLS_LOG_TRACE("Interface '%s' is NOT UP", interfaceAddress->ifa_name);
             continue;
         }
 
         if ((interfaceAddress->ifa_flags & IFF_RUNNING) == 0) {
+            BSLS_LOG_TRACE("Interface '%s' is NOT RUNNING", interfaceAddress->ifa_name);
             continue;
         }
 


### PR DESCRIPTION
Previously, `ntsu::AdapterUtil::discoverAdapterList()` skipped over network devices that did not have the flag IFF_RUNNING set. However, certain virtual network devices, such as TUN/TAP devices on Linux, do not have IFF_RUNNING set but are nonetheless operational.