### PR TITLE
Implement support for Linux MSG_ZEROCOPY in NTS

### DIFF
--- a/groups/ntc/ntcd/ntcd_machine.h
+++ b/groups/ntc/ntcd/ntcd_machine.h
@@ -871,7 +871,8 @@ class Session : public ntsi::DatagramSocket,
     /// Read data from the socket error queue. Then if the specified
     /// 'notifications' is not null parse fetched data to extract control
     /// messages into the specified 'notifications'. Return the error.
-    ntsa::Error receiveNotifications(ntsa::NotificationQueue* notifications);
+    ntsa::Error receiveNotifications(ntsa::NotificationQueue* notifications)
+        BSLS_KEYWORD_OVERRIDE;
 
     /// Shutdown the stream socket in the specified 'direction'. Return the
     /// error.

--- a/groups/nts/ntsa/ntsa_notification.cpp
+++ b/groups/nts/ntsa/ntsa_notification.cpp
@@ -31,6 +31,9 @@ Notification::Notification(const Notification& original)
         new (d_timestamp.buffer())
             ntsa::Timestamp(original.d_timestamp.object());
         break;
+    case (ntsa::NotificationType::e_ZERO_COPY):
+        new (d_zeroCopy.buffer()) ntsa::ZeroCopy(original.d_zeroCopy.object());
+        break;
     default:
         BSLS_ASSERT(d_type == ntsa::NotificationType::e_UNDEFINED);
     }
@@ -50,6 +53,9 @@ Notification& Notification::operator=(const Notification& other)
     case (ntsa::NotificationType::e_TIMESTAMP):
         new (d_timestamp.buffer()) ntsa::Timestamp(other.d_timestamp.object());
         break;
+    case (ntsa::NotificationType::e_ZERO_COPY):
+        new (d_zeroCopy.buffer()) ntsa::ZeroCopy(other.d_zeroCopy.object());
+        break;
     default:
         BSLS_ASSERT(d_type == ntsa::NotificationType::e_UNDEFINED);
     }
@@ -66,6 +72,8 @@ bool Notification::equals(const Notification& other) const
     switch (d_type) {
     case ntsa::NotificationType::e_TIMESTAMP:
         return d_timestamp.object() == other.d_timestamp.object();
+    case ntsa::NotificationType::e_ZERO_COPY:
+        return d_zeroCopy.object() == other.d_zeroCopy.object();
     default:
         return true;
     }
@@ -80,6 +88,8 @@ bool Notification::less(const Notification& other) const
     switch (d_type) {
     case ntsa::NotificationType::e_TIMESTAMP:
         return d_timestamp.object() < other.d_timestamp.object();
+    case ntsa::NotificationType::e_ZERO_COPY:
+        return d_zeroCopy.object() < other.d_zeroCopy.object();
     default:
         return true;
     }
@@ -92,6 +102,9 @@ bsl::ostream& Notification::print(bsl::ostream& stream,
     switch (d_type) {
     case ntsa::NotificationType::e_TIMESTAMP:
         d_timestamp.object().print(stream, level, spacesPerLevel);
+        break;
+    case ntsa::NotificationType::e_ZERO_COPY:
+        d_zeroCopy.object().print(stream, level, spacesPerLevel);
         break;
     default:
         BSLS_ASSERT(d_type == ntsa::NotificationType::e_UNDEFINED);

--- a/groups/nts/ntsa/ntsa_notification.h
+++ b/groups/nts/ntsa/ntsa_notification.h
@@ -21,6 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #include <ntsa_notificationtype.h>
 #include <ntsa_timestamp.h>
+#include <ntsa_zerocopy.h>
 #include <ntscfg_platform.h>
 #include <ntsscm_version.h>
 #include <bsls_objectbuffer.h>
@@ -31,8 +32,8 @@ namespace ntsa {
 /// Provide a union of notifications.
 ///
 /// @details
-/// Provide a value-semantic type that represents a discriminated
-/// union of notifications.
+/// Provide a value-semantic type that represents a discriminated union of
+/// notifications.
 //
 /// @par Thread Safety
 /// This class is not thread safe.
@@ -42,6 +43,7 @@ class Notification
 {
     union {
         bsls::ObjectBuffer<ntsa::Timestamp> d_timestamp;
+        bsls::ObjectBuffer<ntsa::ZeroCopy>  d_zeroCopy;
     };
 
     ntsa::NotificationType::Value d_type;
@@ -50,19 +52,18 @@ class Notification
     /// Create a new notification having an undefined type.
     Notification();
 
-    /// Create a new notification the same value as the specified 'other'
-    /// object.
+    /// Create a new notification having the same value as the specified
+    /// 'other' object.
     Notification(const Notification& other);
 
     /// Destroy this object.
     ~Notification();
 
-    /// Assign the value of the specified 'other' object to this object.
-    /// Return a reference to this modifiable object.
+    /// Assign the value of the specified 'other' object to this object. Return
+    /// a reference to this modifiable object.
     Notification& operator=(const Notification& other);
 
-    /// Reset the value of this object to its value upon default
-    /// construction.
+    /// Reset the value of this object to its value upon default construction.
     void reset();
 
     /// Select the "timestamp" representation. Return a reference to the
@@ -71,11 +72,23 @@ class Notification
 
     /// Select the "timestamp" representation initially having the specified
     /// 'value'. Return a reference to the modifiable representation.
-    ntsa::Timestamp& makeTimestamp(const ntsa::Timestamp& ts);
+    ntsa::Timestamp& makeTimestamp(const ntsa::Timestamp& value);
 
-    /// Return a reference to the modifiable "timestamp" representation.
-    /// The behavior is undefined unless 'isTimestamp()' is true.
+    /// Select the "zeroCopy" representation. Return a reference to the
+    /// modifiable representation.
+    ntsa::ZeroCopy& makeZeroCopy();
+
+    /// Select the "zeroCopy" representation initially having the specified
+    /// 'value'. Return a reference to the modifiable representation.
+    ntsa::ZeroCopy& makeZeroCopy(const ntsa::ZeroCopy& value);
+
+    /// Return a reference to the "timestamp" representation. The behavior is
+    /// undefined unless 'isTimestamp()' is true.
     const ntsa::Timestamp& timestamp() const;
+
+    /// Return a reference to the "zeroCopy" representation. The behavior is
+    /// undefined unless 'isZeroCopy()' is true.
+    const ntsa::ZeroCopy& zeroCopy() const;
 
     /// Return the type of the notification representation.
     ntsa::NotificationType::Value type() const;
@@ -84,41 +97,44 @@ class Notification
     /// otherwise return false.
     bool isTimestamp() const;
 
+    /// Return true if the "zeroCopy" representation is currently selected,
+    /// otherwise return false.
+    bool isZeroCopy() const;
+
     /// Return true if the notification representation is undefined, otherwise
     /// return false.
     bool isUndefined() const;
 
-    /// Return true if this object has the same value as the specified
-    /// 'other' object, otherwise return false.
+    /// Return true if this object has the same value as the specified 'other'
+    /// object, otherwise return false.
     bool equals(const Notification& other) const;
 
-    /// Return true if the value of this object is less than the value of
-    /// the specified 'other' object, otherwise return false.
+    /// Return true if the value of this object is less than the value of the
+    /// specified 'other' object, otherwise return false.
     bool less(const Notification& other) const;
 
-    /// Format this object to the specified output 'stream' at the
-    /// optionally specified indentation 'level' and return a reference to
-    /// the modifiable 'stream'.  If 'level' is specified, optionally
-    /// specify 'spacesPerLevel', the number of spaces per indentation level
-    /// for this and all of its nested objects.  Each line is indented by
-    /// the absolute value of 'level * spacesPerLevel'.  If 'level' is
-    /// negative, suppress indentation of the first line.  If
-    /// 'spacesPerLevel' is negative, suppress line breaks and format the
-    /// entire output on one line.  If 'stream' is initially invalid, this
-    /// operation has no effect.  Note that a trailing newline is provided
-    /// in multiline mode only.
+    /// Format this object to the specified output 'stream' at the optionally
+    /// specified indentation 'level' and return a reference to the modifiable
+    /// 'stream'.  If 'level' is specified, optionally specify
+    /// 'spacesPerLevel', the number of spaces per indentation level for this
+    /// and all of its nested objects.  Each line is indented by the absolute
+    /// value of 'level * spacesPerLevel'.  If 'level' is negative, suppress
+    /// indentation of the first line.  If 'spacesPerLevel' is negative,
+    /// suppress line breaks and format the entire output on one line.  If
+    /// 'stream' is initially invalid, this operation has no effect.  Note that
+    /// a trailing newline is provided in multiline mode only.
     bsl::ostream& print(bsl::ostream& stream,
                         int           level          = 0,
                         int           spacesPerLevel = 4) const;
 
-    /// Defines the traits of this type. These traits can be used to select,
-    /// at compile-time, the most efficient algorithm to manipulate objects
-    /// of this type.
+    /// Defines the traits of this type. These traits can be used to select, at
+    /// compile-time, the most efficient algorithm to manipulate objects of
+    /// this type.
     NTSCFG_DECLARE_NESTED_BITWISE_MOVABLE_TRAITS(Notification);
 };
 
-/// Write the specified 'object' to the specified 'stream'. Return a
-/// modifiable reference to the 'stream'.
+/// Write the specified 'object' to the specified 'stream'. Return a modifiable
+/// reference to the 'stream'.
 ///
 /// @related ntsa::Notification
 bsl::ostream& operator<<(bsl::ostream& stream, const Notification& object);
@@ -141,8 +157,8 @@ bool operator!=(const Notification& lhs, const Notification& rhs);
 /// @related ntsa::Notification
 bool operator<(const Notification& lhs, const Notification& rhs);
 
-/// Contribute the values of the salient attributes of the specified 'value'
-/// to the specified hash 'algorithm'.
+/// Contribute the values of the salient attributes of the specified 'value' to
+/// the specified hash 'algorithm'.
 ///
 /// @related ntsa::Notification
 template <typename HASH_ALGORITHM>
@@ -181,14 +197,14 @@ ntsa::Timestamp& Notification::makeTimestamp()
 }
 
 NTSCFG_INLINE
-ntsa::Timestamp& Notification::makeTimestamp(const ntsa::Timestamp& ts)
+ntsa::Timestamp& Notification::makeTimestamp(const ntsa::Timestamp& value)
 {
     if (d_type == ntsa::NotificationType::e_TIMESTAMP) {
-        d_timestamp.object() = ts;
+        d_timestamp.object() = value;
     }
     else {
         this->reset();
-        new (d_timestamp.buffer()) ntsa::Timestamp(ts);
+        new (d_timestamp.buffer()) ntsa::Timestamp(value);
         d_type = ntsa::NotificationType::e_TIMESTAMP;
     }
 
@@ -196,10 +212,47 @@ ntsa::Timestamp& Notification::makeTimestamp(const ntsa::Timestamp& ts)
 }
 
 NTSCFG_INLINE
+ntsa::ZeroCopy& Notification::makeZeroCopy()
+{
+    if (d_type == ntsa::NotificationType::e_ZERO_COPY) {
+        d_zeroCopy.object() = ntsa::ZeroCopy();
+    }
+    else {
+        this->reset();
+        new (d_zeroCopy.buffer()) ntsa::ZeroCopy();
+        d_type = ntsa::NotificationType::e_ZERO_COPY;
+    }
+
+    return d_zeroCopy.object();
+}
+
+NTSCFG_INLINE
+ntsa::ZeroCopy& Notification::makeZeroCopy(const ntsa::ZeroCopy& value)
+{
+    if (d_type == ntsa::NotificationType::e_ZERO_COPY) {
+        d_zeroCopy.object() = value;
+    }
+    else {
+        this->reset();
+        new (d_zeroCopy.buffer()) ntsa::ZeroCopy(value);
+        d_type = ntsa::NotificationType::e_ZERO_COPY;
+    }
+
+    return d_zeroCopy.object();
+}
+
+NTSCFG_INLINE
 const ntsa::Timestamp& Notification::timestamp() const
 {
     BSLS_ASSERT(d_type == ntsa::NotificationType::e_TIMESTAMP);
     return d_timestamp.object();
+}
+
+NTSCFG_INLINE
+const ntsa::ZeroCopy& Notification::zeroCopy() const
+{
+    BSLS_ASSERT(d_type == ntsa::NotificationType::e_ZERO_COPY);
+    return d_zeroCopy.object();
 }
 
 NTSCFG_INLINE
@@ -215,6 +268,12 @@ bool Notification::isTimestamp() const
 }
 
 NTSCFG_INLINE
+bool Notification::isZeroCopy() const
+{
+    return d_type == ntsa::NotificationType::e_ZERO_COPY;
+}
+
+NTSCFG_INLINE
 bool Notification::isUndefined() const
 {
     return d_type == ntsa::NotificationType::e_UNDEFINED;
@@ -227,6 +286,9 @@ void hashAppend(HASH_ALGORITHM& algorithm, const Notification& value)
 
     if (value.isTimestamp()) {
         hashAppend(algorithm, value.timestamp());
+    }
+    else if (value.isZeroCopy()) {
+        hashAppend(algorithm, value.zeroCopy());
     }
 }
 

--- a/groups/nts/ntsa/ntsa_notification.t.cpp
+++ b/groups/nts/ntsa/ntsa_notification.t.cpp
@@ -28,11 +28,13 @@ NTSCFG_TEST_CASE(1)
     Notification n;
     NTSCFG_TEST_TRUE(n.isUndefined());
     NTSCFG_TEST_FALSE(n.isTimestamp());
+    NTSCFG_TEST_FALSE(n.isZeroCopy());
     NTSCFG_TEST_EQ(n.type(), NotificationType::e_UNDEFINED);
 
     Timestamp& ts = n.makeTimestamp();
     NTSCFG_TEST_TRUE(n.isTimestamp());
     NTSCFG_TEST_FALSE(n.isUndefined());
+    NTSCFG_TEST_FALSE(n.isZeroCopy());
     NTSCFG_TEST_EQ(n.type(), NotificationType::e_TIMESTAMP);
 
     ts.setId(id);
@@ -90,6 +92,9 @@ NTSCFG_TEST_CASE(4)
     n1.makeTimestamp();
 
     NTSCFG_TEST_NE(n1, n2);
+
+    n2.makeZeroCopy();
+    NTSCFG_TEST_NE(n1, n2);
 }
 
 NTSCFG_TEST_CASE(5)
@@ -112,6 +117,43 @@ NTSCFG_TEST_CASE(5)
     NTSCFG_TEST_EQ(n2.timestamp(), t);
 }
 
+NTSCFG_TEST_CASE(6)
+{
+    Notification n;
+    NTSCFG_TEST_TRUE(n.isUndefined());
+    NTSCFG_TEST_FALSE(n.isZeroCopy());
+    NTSCFG_TEST_EQ(n.type(), NotificationType::e_UNDEFINED);
+
+    ZeroCopy& zc = n.makeZeroCopy();
+    NTSCFG_TEST_TRUE(n.isZeroCopy());
+    NTSCFG_TEST_FALSE(n.isUndefined());
+    NTSCFG_TEST_FALSE(n.isTimestamp());
+    NTSCFG_TEST_EQ(n.type(), NotificationType::e_ZERO_COPY);
+
+    zc.setFrom(1);
+    zc.setTo(22);
+    zc.setCode(1);
+    NTSCFG_TEST_EQ(n.zeroCopy(), zc);
+}
+
+NTSCFG_TEST_CASE(7)
+{
+    ZeroCopy zc;
+    zc.setFrom(1);
+    zc.setTo(22);
+    zc.setCode(1);
+
+    Notification n;
+    n.makeZeroCopy(zc);
+
+    NTSCFG_TEST_TRUE(n.isZeroCopy());
+
+    n.reset();
+    NTSCFG_TEST_TRUE(n.isUndefined());
+    NTSCFG_TEST_FALSE(n.isZeroCopy());
+    NTSCFG_TEST_EQ(n.type(), NotificationType::e_UNDEFINED);
+}
+
 NTSCFG_TEST_DRIVER
 {
     NTSCFG_TEST_REGISTER(1);
@@ -119,5 +161,7 @@ NTSCFG_TEST_DRIVER
     NTSCFG_TEST_REGISTER(3);
     NTSCFG_TEST_REGISTER(4);
     NTSCFG_TEST_REGISTER(5);
+    NTSCFG_TEST_REGISTER(6);
+    NTSCFG_TEST_REGISTER(7);
 }
 NTSCFG_TEST_DRIVER_END;

--- a/groups/nts/ntsa/ntsa_notificationtype.cpp
+++ b/groups/nts/ntsa/ntsa_notificationtype.cpp
@@ -28,6 +28,7 @@ int NotificationType::fromInt(NotificationType::Value* result, int number)
     switch (number) {
     case NotificationType::e_UNDEFINED:
     case NotificationType::e_TIMESTAMP:
+    case NotificationType::e_ZERO_COPY:
         *result = static_cast<NotificationType::Value>(number);
         return 0;
     default:
@@ -46,6 +47,10 @@ int NotificationType::fromString(NotificationType::Value* result,
         *result = e_TIMESTAMP;
         return 0;
     }
+    if (bdlb::String::areEqualCaseless(string, "ZERO_COPY")) {
+        *result = e_ZERO_COPY;
+        return 0;
+    }
 
     return -1;
 }
@@ -58,6 +63,9 @@ const char* NotificationType::toString(NotificationType::Value value)
     } break;
     case e_TIMESTAMP: {
         return "TIMESTAMP";
+    } break;
+    case e_ZERO_COPY: {
+        return "ZERO_COPY";
     } break;
     }
 

--- a/groups/nts/ntsa/ntsa_notificationtype.h
+++ b/groups/nts/ntsa/ntsa_notificationtype.h
@@ -34,7 +34,17 @@ namespace ntsa {
 struct NotificationType {
   public:
     /// Provide an enumeration of the notification types.
-    enum Value { e_UNDEFINED = 0, e_TIMESTAMP = 1 };
+    enum Value { 
+        /// The notification type is not defined.
+        e_UNDEFINED = 0, 
+
+        /// The notification describes a timestamp for outgoing data.
+        e_TIMESTAMP = 1, 
+
+        /// The notification describes the completion of one or more zero-copy
+        /// operations to enqueue data to the socket send buffer.
+        e_ZERO_COPY = 2 
+    };
 
     /// Return the string representation exactly matching the enumerator
     /// name corresponding to the specified enumeration 'value'.

--- a/groups/nts/ntsa/ntsa_notificationtype.t.cpp
+++ b/groups/nts/ntsa/ntsa_notificationtype.t.cpp
@@ -30,6 +30,10 @@ NTSCFG_TEST_CASE(1)
         bsl::strcmp(NotificationType::toString(NotificationType::e_TIMESTAMP),
                     "TIMESTAMP"),
         0);
+    NTSCFG_TEST_EQ(bsl::strcmp(NotificationType::toString(
+                                   NotificationType::e_ZERO_COPY),
+                               "ZERO_COPY"),
+                   0);
 }
 
 NTSCFG_TEST_CASE(2)
@@ -45,14 +49,18 @@ NTSCFG_TEST_CASE(2)
     NTSCFG_TEST_EQ(NotificationType::fromInt(&v, 1), 0);
     NTSCFG_TEST_EQ(v, NotificationType::e_TIMESTAMP);
 
-    NTSCFG_TEST_EQ(NotificationType::fromInt(&v, 2), -1);
-    NTSCFG_TEST_EQ(v, NotificationType::e_TIMESTAMP);
+    NTSCFG_TEST_EQ(NotificationType::fromInt(&v, 2), 0);
+    NTSCFG_TEST_EQ(v, NotificationType::e_ZERO_COPY);
+
+    NTSCFG_TEST_EQ(NotificationType::fromInt(&v, 3), -1);
+    NTSCFG_TEST_EQ(v, NotificationType::e_ZERO_COPY);
 }
 
 NTSCFG_TEST_CASE(3)
 {
     const bsl::string undefined = "undefined";
     const bsl::string timestamp = "timestamp";
+    const bsl::string zerocopy  = "zero_copy";
     const bsl::string random    = "random_string";
 
     NotificationType::Value v = NotificationType::e_TIMESTAMP;
@@ -65,6 +73,9 @@ NTSCFG_TEST_CASE(3)
 
     NTSCFG_TEST_EQ(NotificationType::fromString(&v, timestamp), 0);
     NTSCFG_TEST_EQ(v, NotificationType::e_TIMESTAMP);
+
+    NTSCFG_TEST_EQ(NotificationType::fromString(&v, zerocopy), 0);
+    NTSCFG_TEST_EQ(v, NotificationType::e_ZERO_COPY);
 }
 
 NTSCFG_TEST_CASE(4)
@@ -72,9 +83,10 @@ NTSCFG_TEST_CASE(4)
     bsl::stringstream ss;
 
     ss << NotificationType::e_TIMESTAMP << ", "
-       << NotificationType::e_UNDEFINED;
+       << NotificationType::e_UNDEFINED << ", "
+       << NotificationType::e_ZERO_COPY;
 
-    NTSCFG_TEST_EQ(ss.str(), "TIMESTAMP, UNDEFINED");
+    NTSCFG_TEST_EQ(ss.str(), "TIMESTAMP, UNDEFINED, ZERO_COPY");
 }
 
 NTSCFG_TEST_DRIVER

--- a/groups/nts/ntsa/ntsa_sendoptions.cpp
+++ b/groups/nts/ntsa/ntsa_sendoptions.cpp
@@ -28,7 +28,8 @@ bool SendOptions::equals(const SendOptions& other) const
     return (d_endpoint == other.d_endpoint && 
             d_foreignHandle == other.d_foreignHandle &&
             d_maxBytes == other.d_maxBytes &&
-            d_maxBuffers == other.d_maxBuffers);
+            d_maxBuffers == other.d_maxBuffers &&
+            d_zeroCopy == other.d_zeroCopy);
 }
 
 bool SendOptions::less(const SendOptions& other) const
@@ -57,7 +58,14 @@ bool SendOptions::less(const SendOptions& other) const
         return false;
     }
 
-    return d_maxBuffers < other.d_maxBuffers;
+    if (d_maxBuffers < other.d_maxBuffers) {
+        return true;
+    }
+
+    if (other.d_maxBuffers < d_maxBuffers) {
+        return false;
+    }
+    return d_zeroCopy < other.d_zeroCopy;
 }
 
 bsl::ostream& SendOptions::print(bsl::ostream& stream,
@@ -70,6 +78,7 @@ bsl::ostream& SendOptions::print(bsl::ostream& stream,
     printer.printAttribute("foreignHandle", d_foreignHandle);
     printer.printAttribute("maxBytes", d_maxBytes);
     printer.printAttribute("maxBuffers", d_maxBuffers);
+    printer.printAttribute("zeroCopy", d_zeroCopy);
     printer.end();
     return stream;
 }

--- a/groups/nts/ntsa/ntsa_sendoptions.h
+++ b/groups/nts/ntsa/ntsa_sendoptions.h
@@ -79,6 +79,19 @@ namespace ntsa {
 /// zero, or, for stream sockets only, to NTSCFG_DEFAULT_MAX_INPLACE_BUFFERS.
 /// Note that this value is currently only honored when sending blobs.
 ///
+/// @li @b zeroCopy:
+/// The flag to request the data-to-send be referenced in-place rather than
+/// copied to the send buffer to the specified 'value'. Note that this flag is
+/// advisory; the operating system may neither support nor decide to allow
+/// zero-copy semantics. Regardless, if zero-copy semantics are requested the
+/// application must ensure the data-to-send is neither overwritten nor
+/// invalidated (i.e. freed) until the completion of the send operation is
+/// indicated in a subsequent notification (which also indicates whether the
+/// data was referenced in-place or copied.) Also note that this option is only
+/// supported on platforms where 'ntscfg::Platform::supportsZeroCopy()' returns
+/// true. Send operations requesting zero-copy semantics on platforms that do
+/// not support zero-copy will result in an error.
+///
 /// @par Thread Safety
 /// This class is not thread safe.
 ///
@@ -89,6 +102,7 @@ class SendOptions
     bdlb::NullableValue<ntsa::Handle>   d_foreignHandle;
     bsl::size_t                         d_maxBytes;
     bsl::size_t                         d_maxBuffers;
+    bool                                d_zeroCopy;
 
   public:
     /// Create new send options having the default value.
@@ -117,11 +131,14 @@ class SendOptions
     // 'value'.
     void setForeignHandle(ntsa::Handle value);
 
-    /// Set the maximum number of bytes to copy to the specified 'value'.
+    /// Set the maximum number of bytes to send to the specified 'value'.
     void setMaxBytes(bsl::size_t value);
 
-    /// Set the maximum number of buffers to copy to the specified 'value'.
+    /// Set the maximum number of buffers to send to the specified 'value'.
     void setMaxBuffers(bsl::size_t value);
+
+    /// Set the flag to request zero-copy semantics to the specified 'value'.
+    void setZeroCopy(bool value);
 
     /// Return the remote endpoint to which the data should be sent.
     const bdlb::NullableValue<ntsa::Endpoint>& endpoint() const;
@@ -129,11 +146,14 @@ class SendOptions
     /// Return the handle to the open socket to send to the peer.
     const bdlb::NullableValue<ntsa::Handle>& foreignHandle() const;
 
-    /// Return the maximum number of bytes to copy.
+    /// Return the maximum number of bytes to send.
     bsl::size_t maxBytes() const;
 
-    /// Return the maximum number of buffers to copy.
+    /// Return the maximum number of buffers to send.
     bsl::size_t maxBuffers() const;
+
+    /// Return the flag that indicates zero-copy semantics are requested.
+    bool zeroCopy() const;
 
     /// Return true if this object has the same value as the specified
     /// 'other' object, otherwise return false.
@@ -201,6 +221,7 @@ SendOptions::SendOptions()
 , d_foreignHandle()
 , d_maxBytes(0)
 , d_maxBuffers(0)
+, d_zeroCopy(false)
 {
 }
 
@@ -210,6 +231,7 @@ SendOptions::SendOptions(const SendOptions& original)
 , d_foreignHandle(original.d_foreignHandle)
 , d_maxBytes(original.d_maxBytes)
 , d_maxBuffers(original.d_maxBuffers)
+, d_zeroCopy(original.d_zeroCopy)
 {
 }
 
@@ -225,6 +247,7 @@ SendOptions& SendOptions::operator=(const SendOptions& other)
     d_foreignHandle = other.d_foreignHandle;
     d_maxBytes   = other.d_maxBytes;
     d_maxBuffers = other.d_maxBuffers;
+    d_zeroCopy   = other.d_zeroCopy;
     return *this;
 }
 
@@ -235,6 +258,7 @@ void SendOptions::reset()
     d_foreignHandle.reset();
     d_maxBytes   = 0;
     d_maxBuffers = 0;
+    d_zeroCopy   = false;
 }
 
 NTSCFG_INLINE
@@ -262,6 +286,12 @@ void SendOptions::setMaxBuffers(bsl::size_t value)
 }
 
 NTSCFG_INLINE
+void SendOptions::setZeroCopy(bool value)
+{
+    d_zeroCopy = value;
+}
+
+NTSCFG_INLINE
 const bdlb::NullableValue<ntsa::Endpoint>& SendOptions::endpoint() const
 {
     return d_endpoint;
@@ -283,6 +313,12 @@ NTSCFG_INLINE
 bsl::size_t SendOptions::maxBuffers() const
 {
     return d_maxBuffers;
+}
+
+NTSCFG_INLINE
+bool SendOptions::zeroCopy() const
+{
+    return d_zeroCopy;
 }
 
 NTSCFG_INLINE
@@ -318,6 +354,7 @@ void hashAppend(HASH_ALGORITHM& algorithm, const SendOptions& value)
     hashAppend(algorithm, value.foreignHandle());
     hashAppend(algorithm, value.maxBytes());
     hashAppend(algorithm, value.maxBuffers());
+    hashAppend(algorithm, value.zeroCopy());
 }
 
 }  // close package namespace

--- a/groups/nts/ntsa/ntsa_sendoptions.h
+++ b/groups/nts/ntsa/ntsa_sendoptions.h
@@ -87,10 +87,7 @@ namespace ntsa {
 /// application must ensure the data-to-send is neither overwritten nor
 /// invalidated (i.e. freed) until the completion of the send operation is
 /// indicated in a subsequent notification (which also indicates whether the
-/// data was referenced in-place or copied.) Also note that this option is only
-/// supported on platforms where 'ntscfg::Platform::supportsZeroCopy()' returns
-/// true. Send operations requesting zero-copy semantics on platforms that do
-/// not support zero-copy will result in an error.
+/// data was referenced in-place or copied.)
 ///
 /// @par Thread Safety
 /// This class is not thread safe.

--- a/groups/nts/ntsa/ntsa_socketconfig.cpp
+++ b/groups/nts/ntsa/ntsa_socketconfig.cpp
@@ -73,6 +73,9 @@ void SocketConfig::setOption(const ntsa::SocketOption& option)
     else if (option.isTimestampOutgoingData()) {
         d_timestampOutgoingData = option.timestampOutgoingData();
     }
+    else if (option.isZeroCopy()) {
+        d_zeroCopy = option.zeroCopy();
+    }
 }
 
 void SocketConfig::getOption(ntsa::SocketOption*           option,
@@ -162,6 +165,11 @@ void SocketConfig::getOption(ntsa::SocketOption*           option,
             option->makeTimestampOutgoingData(d_timestampOutgoingData.value());
         }
     }
+    else if (type == ntsa::SocketOptionType::e_ZERO_COPY) {
+        if (!d_zeroCopy.isNull()) {
+            option->makeZeroCopy(d_zeroCopy.value());
+        }
+    }
 }
 
 bool SocketConfig::equals(const SocketConfig& other) const
@@ -179,7 +187,8 @@ bool SocketConfig::equals(const SocketConfig& other) const
            d_bypassRouting == other.d_bypassRouting &&
            d_inlineOutOfBandData == other.d_inlineOutOfBandData &&
            d_timestampIncomingData == other.d_timestampIncomingData &&
-           d_timestampOutgoingData == other.d_timestampOutgoingData;
+           d_timestampOutgoingData == other.d_timestampOutgoingData &&
+           d_zeroCopy == other.d_zeroCopy;
 }
 
 bool SocketConfig::less(const SocketConfig& other) const
@@ -304,7 +313,15 @@ bool SocketConfig::less(const SocketConfig& other) const
         return false;
     }
 
-    return d_timestampOutgoingData < other.d_timestampOutgoingData;
+    if (d_timestampOutgoingData < other.d_timestampOutgoingData) {
+        return true;
+    }
+
+    if (other.d_timestampOutgoingData < d_timestampOutgoingData) {
+        return false;
+    }
+
+    return d_zeroCopy < other.d_zeroCopy;
 }
 
 bsl::ostream& SocketConfig::print(bsl::ostream& stream,
@@ -313,24 +330,83 @@ bsl::ostream& SocketConfig::print(bsl::ostream& stream,
 {
     bslim::Printer printer(&stream, level, spacesPerLevel);
     printer.start();
-    printer.printAttribute("reuseAddress", d_reuseAddress);
-    printer.printAttribute("d_keepAlive", d_keepAlive);
-    printer.printAttribute("d_cork", d_cork);
-    printer.printAttribute("d_delayTransmission", d_delayTransmission);
-    printer.printAttribute("d_delayAcknowledgement", d_delayAcknowledgement);
-    printer.printAttribute("d_sendBufferSize", d_sendBufferSize);
-    printer.printAttribute("d_sendBufferLowWatermark",
-                           d_sendBufferLowWatermark);
-    printer.printAttribute("d_receiveBufferSize", d_receiveBufferSize);
-    printer.printAttribute("d_receiveBufferLowWatermark",
-                           d_receiveBufferLowWatermark);
-    printer.printAttribute("d_debug", d_debug);
-    printer.printAttribute("d_linger", d_linger);
-    printer.printAttribute("d_broadcast", d_broadcast);
-    printer.printAttribute("d_bypassRouting", d_bypassRouting);
-    printer.printAttribute("d_inlineOutOfBandData", d_inlineOutOfBandData);
-    printer.printAttribute("d_timestampIncomingData", d_timestampIncomingData);
-    printer.printAttribute("d_timestampOutgoingData", d_timestampOutgoingData);
+
+    if (!d_reuseAddress.isNull()) {
+        printer.printAttribute("reuseAddress", d_reuseAddress.value());
+    }
+
+    if (!d_keepAlive.isNull()) {
+        printer.printAttribute("keepAlive", d_keepAlive.value());
+    }
+
+    if (!d_cork.isNull()) {
+        printer.printAttribute("cork", d_cork.value());
+    }
+
+    if (!d_delayTransmission.isNull()) {
+        printer.printAttribute("delayTransmission", 
+                               d_delayTransmission.value());
+    }
+
+    if (!d_delayAcknowledgement.isNull()) {
+        printer.printAttribute("delayAcknowledgement", 
+                               d_delayAcknowledgement.value());
+    }
+
+    if (!d_sendBufferSize.isNull()) {
+        printer.printAttribute("sendBufferSize", d_sendBufferSize.value());
+    }
+
+    if (!d_sendBufferLowWatermark.isNull()) {
+        printer.printAttribute("sendBufferLowWatermark",
+                               d_sendBufferLowWatermark.value());
+    }
+
+    if (!d_receiveBufferSize.isNull()) {
+        printer.printAttribute("receiveBufferSize", 
+                               d_receiveBufferSize.value());
+    }
+
+    if (!d_receiveBufferLowWatermark.isNull()) {
+        printer.printAttribute("receiveBufferLowWatermark",
+                               d_receiveBufferLowWatermark.value());
+    }
+
+    if (!d_debug.isNull()) {
+        printer.printAttribute("debug", d_debug.value());
+    }
+
+    if (!d_linger.isNull()) {
+        printer.printAttribute("linger", d_linger.value());
+    }
+
+    if (!d_broadcast.isNull()) {
+        printer.printAttribute("broadcast", d_broadcast.value());
+    }
+
+    if (!d_bypassRouting.isNull()) {
+        printer.printAttribute("bypassRouting", d_bypassRouting.value());
+    }
+
+    if (!d_inlineOutOfBandData.isNull()) {
+        printer.printAttribute("inlineOutOfBandData", 
+                               d_inlineOutOfBandData.value());
+    }
+
+    if (!d_timestampIncomingData.isNull()) {
+        printer.printAttribute("timestampIncomingData", 
+                               d_timestampIncomingData.value());
+    }
+
+    if (!d_timestampOutgoingData.isNull()) {
+        printer.printAttribute("timestampOutgoingData", 
+                               d_timestampOutgoingData.value());
+    }
+
+    if (!d_zeroCopy.isNull()) {
+        printer.printAttribute("zeroCopy", d_zeroCopy.value());
+    }
+
     printer.end();
     return stream;
 }

--- a/groups/nts/ntsa/ntsa_socketconfig.h
+++ b/groups/nts/ntsa/ntsa_socketconfig.h
@@ -44,18 +44,26 @@ namespace ntsa {
 /// That flag that indicates the operating system implementation should
 /// periodically emit transport-level "keep-alive" packets.
 ///
-/// @li @b  cork:
-/// TODO.
+/// @li @b cork:
+/// The flag that indicates that successive writes should be coalesced into the
+/// largest packets that can be formed. When set to true, this option indicates
+/// the user favors better network efficiency at the expense of worse latency.
+/// When set to false, this option indicates the user favors better latency at
+/// the expense of worse network efficiency.
 ///
 /// @li @b delayTransmission:
-/// The flag that indicates that subsequent writes should be coalesced into the
+/// The flag that indicates that successive writes should be coalesced into
 /// larger packets that would otherwise form. When set to true, this option
-/// indicates the user favors smaller latency at the expense of less network
-/// efficiency. When set to false, this option indicates the user favors
-/// greater network efficiency at the expense of greater latency.
+/// indicates the user favors better network efficiency at the expense of worse
+/// latency. When set to false, this option indicates the user favors better
+/// latency at the expense of worse network efficiency.
 ///
 /// @li @b delayAcknowledgement:
-/// TODO.
+/// The flag that indicates acknowledgement of successively-received packets
+/// should be coalesced. When set to true, this option indicates the user
+/// favors better network efficiency at the expense of worse latency. When set
+/// to false, this option indicates the user favors better latency at the
+/// expense of worse network efficiency.
 ///
 /// @li @b sendBufferSize:
 /// The maximum size of each socket send buffer. On some platforms, this
@@ -94,6 +102,16 @@ namespace ntsa {
 /// The flag that indicates out-of-band data should be placed into the normal
 /// data input queue.
 ///
+/// @li @b timestampIncomingData:
+/// The flag that indicates timestamps should be generated for outgoing data.
+///
+/// @li @b timestampOutgoingData:
+/// The flag that indicates timestamps should be generated for incoming data.
+///
+/// @li @b zeroCopy:
+/// The flag that indicates each send operation can request copy avoidance when
+/// enqueing data to the socket send buffer.
+///
 /// @par Thread Safety
 /// This class is not thread safe.
 ///
@@ -116,6 +134,7 @@ class SocketConfig
     bdlb::NullableValue<bool>         d_inlineOutOfBandData;
     bdlb::NullableValue<bool>         d_timestampIncomingData;
     bdlb::NullableValue<bool>         d_timestampOutgoingData;
+    bdlb::NullableValue<bool>         d_zeroCopy;
 
   public:
     /// Create new send options having the default value.
@@ -197,11 +216,18 @@ class SocketConfig
     /// the normal data input queue to the specified 'value'.
     void setInlineOutOfBandData(bool value);
 
-    /// Return the flag that indicates incoming data should be timestamped.
+    /// Set the flag that indicates incoming data should be timestamped to the
+    /// specified 'value'.
     void setTimestampIncomingData(bool value);
 
-    /// Set the flag that indicates outgoing data should be timestamped.
+    /// Set the flag that indicates outgoing data should be timestamped to the
+    /// specified 'value'.
     void setTimestampOutgoingData(bool value);
+
+    /// Set the flag that indicates each send operation can request copy
+    /// avoidance when enqueing data to the socket send buffer to the specified
+    /// 'value'.
+    void setZeroCopy(bool value);
 
     /// Load into the specified 'option' the option for the specified
     /// 'type'. Note that if the option for the 'type' is not set, the
@@ -266,6 +292,10 @@ class SocketConfig
 
     /// Return the flag that indicates outgoing data should be timestamped.
     const bdlb::NullableValue<bool>& timestampOutgoingData() const;
+
+    /// Return the flag that indicates each send operation can request copy
+    /// avoidance when enqueing data to the socket send buffer.
+    const bdlb::NullableValue<bool>& zeroCopy() const;
 
     /// Return true if this object has the same value as the specified
     /// 'other' object, otherwise return false.
@@ -345,6 +375,7 @@ SocketConfig::SocketConfig()
 , d_inlineOutOfBandData()
 , d_timestampIncomingData()
 , d_timestampOutgoingData()
+, d_zeroCopy()
 {
 }
 
@@ -366,6 +397,7 @@ SocketConfig::SocketConfig(const SocketConfig& original)
 , d_inlineOutOfBandData(original.d_inlineOutOfBandData)
 , d_timestampIncomingData(original.d_timestampIncomingData)
 , d_timestampOutgoingData(original.d_timestampOutgoingData)
+, d_zeroCopy(original.d_zeroCopy)
 {
 }
 
@@ -393,6 +425,7 @@ SocketConfig& SocketConfig::operator=(const SocketConfig& other)
     d_inlineOutOfBandData       = other.d_inlineOutOfBandData;
     d_timestampIncomingData     = other.d_timestampIncomingData;
     d_timestampOutgoingData     = other.d_timestampOutgoingData;
+    d_zeroCopy                  = other.d_zeroCopy;
 
     return *this;
 }
@@ -416,6 +449,7 @@ void SocketConfig::reset()
     d_inlineOutOfBandData.reset();
     d_timestampIncomingData.reset();
     d_timestampOutgoingData.reset();
+    d_zeroCopy.reset();
 }
 
 NTSCFG_INLINE
@@ -512,6 +546,12 @@ NTSCFG_INLINE
 void SocketConfig::setTimestampOutgoingData(bool value)
 {
     d_timestampOutgoingData = value;
+}
+
+NTSCFG_INLINE
+void SocketConfig::setZeroCopy(bool value)
+{
+    d_zeroCopy = value;
 }
 
 NTSCFG_INLINE
@@ -613,6 +653,12 @@ const bdlb::NullableValue<bool>& SocketConfig::timestampOutgoingData() const
 }
 
 NTSCFG_INLINE
+const bdlb::NullableValue<bool>& SocketConfig::zeroCopy() const
+{
+    return d_zeroCopy;
+}
+
+NTSCFG_INLINE
 bsl::ostream& operator<<(bsl::ostream& stream, const SocketConfig& object)
 {
     return object.print(stream, 0, -1);
@@ -657,6 +703,7 @@ void hashAppend(HASH_ALGORITHM& algorithm, const SocketConfig& value)
     hashAppend(algorithm, value.inlineOutOfBandData());
     hashAppend(algorithm, value.timestampIncomingData());
     hashAppend(algorithm, value.timestampOutgoingData());
+    hashAppend(algorithm, value.zeroCopy());
 }
 
 }  // close package namespace

--- a/groups/nts/ntsa/ntsa_socketoption.cpp
+++ b/groups/nts/ntsa/ntsa_socketoption.cpp
@@ -81,6 +81,14 @@ SocketOption::SocketOption(const SocketOption& other)
         new (d_timestampOutgoingData.buffer()) bool(
             other.d_timestampOutgoingData.object());
         break;
+    case ntsa::SocketOptionType::e_RX_TIMESTAMPING:
+        new (d_timestampIncomingData.buffer()) bool(
+            other.d_timestampIncomingData.object());
+        break;
+    case ntsa::SocketOptionType::e_ZERO_COPY:
+        new (d_zeroCopy.buffer()) bool(
+            other.d_zeroCopy.object());
+        break;
     default:
         BSLS_ASSERT(d_type == ntsa::SocketOptionType::e_UNDEFINED);
     }
@@ -144,9 +152,17 @@ SocketOption& SocketOption::operator=(const SocketOption& other)
         new (d_inlineOutOfBandData.buffer()) bool(
             other.d_inlineOutOfBandData.object());
         break;
+    case ntsa::SocketOptionType::e_RX_TIMESTAMPING:
+        new (d_timestampIncomingData.buffer()) bool(
+            other.d_timestampIncomingData.object());
+        break;
     case ntsa::SocketOptionType::e_TX_TIMESTAMPING:
         new (d_timestampOutgoingData.buffer()) bool(
             other.d_timestampOutgoingData.object());
+        break;
+    case ntsa::SocketOptionType::e_ZERO_COPY:
+        new (d_zeroCopy.buffer()) bool(
+            other.d_zeroCopy.object());
         break;
     default:
         BSLS_ASSERT(d_type == ntsa::SocketOptionType::e_UNDEFINED);
@@ -605,6 +621,34 @@ bool& SocketOption::makeTimestampOutgoingData(bool value)
     return d_timestampOutgoingData.object();
 }
 
+bool& SocketOption::makeZeroCopy()
+{
+    if (d_type == ntsa::SocketOptionType::e_ZERO_COPY) {
+        d_zeroCopy.object() = false;
+    }
+    else {
+        this->reset();
+        new (d_zeroCopy.buffer()) bool();
+        d_type = ntsa::SocketOptionType::e_ZERO_COPY;
+    }
+
+    return d_zeroCopy.object();
+}
+
+bool& SocketOption::makeZeroCopy(bool value)
+{
+    if (d_type == ntsa::SocketOptionType::e_ZERO_COPY) {
+        d_zeroCopy.object() = value;
+    }
+    else {
+        this->reset();
+        new (d_zeroCopy.buffer()) bool(value);
+        d_type = ntsa::SocketOptionType::e_ZERO_COPY;
+    }
+
+    return d_zeroCopy.object();
+}
+
 bool SocketOption::equals(const SocketOption& other) const
 {
     if (d_type != other.d_type) {
@@ -614,10 +658,48 @@ bool SocketOption::equals(const SocketOption& other) const
     switch (d_type) {
     case ntsa::SocketOptionType::e_REUSE_ADDRESS:
         return d_reuseAddress.object() == other.d_reuseAddress.object();
-        // TODO
+    case ntsa::SocketOptionType::e_KEEP_ALIVE:
+        return d_keepAlive.object() == other.d_keepAlive.object();
+    case ntsa::SocketOptionType::e_CORK:
+        return d_cork.object() == other.d_cork.object();
+    case ntsa::SocketOptionType::e_DELAY_TRANSMISSION:
+        return d_delayTransmission.object() == 
+               other.d_delayTransmission.object();
+    case ntsa::SocketOptionType::e_DELAY_ACKNOWLEDGEMENT:
+        return d_delayAcknowledgement.object() == 
+               other.d_delayAcknowledgement.object();
+    case ntsa::SocketOptionType::e_SEND_BUFFER_SIZE:
+        return d_sendBufferSize.object() == 
+               other.d_sendBufferSize.object();
+    case ntsa::SocketOptionType::e_SEND_BUFFER_LOW_WATERMARK:
+        return d_sendBufferLowWatermark.object() == 
+               other.d_sendBufferLowWatermark.object();
+    case ntsa::SocketOptionType::e_RECEIVE_BUFFER_SIZE:
+        return d_receiveBufferSize.object() == 
+               other.d_receiveBufferSize.object();
+    case ntsa::SocketOptionType::e_RECEIVE_BUFFER_LOW_WATERMARK:
+        return d_receiveBufferLowWatermark.object() == 
+               other.d_receiveBufferLowWatermark.object();
+    case ntsa::SocketOptionType::e_DEBUG:
+        return d_debug.object() == other.d_debug.object();
     case ntsa::SocketOptionType::e_LINGER:
         return d_linger.object().equals(other.d_linger.object());
-        // TODO
+    case ntsa::SocketOptionType::e_BROADCAST:
+        return d_broadcast.object() == other.d_broadcast.object();
+    case ntsa::SocketOptionType::e_BYPASS_ROUTING:
+        return d_bypassRouting.object() == other.d_bypassRouting.object();
+    case ntsa::SocketOptionType::e_INLINE_OUT_OF_BAND_DATA:
+        return d_inlineOutOfBandData.object() == 
+               other.d_inlineOutOfBandData.object();
+    case ntsa::SocketOptionType::e_RX_TIMESTAMPING:
+        return d_timestampIncomingData.object() == 
+               other.d_timestampIncomingData.object();
+    case ntsa::SocketOptionType::e_TX_TIMESTAMPING:
+        return d_timestampOutgoingData.object() == 
+               other.d_timestampOutgoingData.object();
+    case ntsa::SocketOptionType::e_ZERO_COPY:
+        return d_zeroCopy.object() == 
+               other.d_zeroCopy.object();
     default:
         return true;
     }
@@ -632,10 +714,47 @@ bool SocketOption::less(const SocketOption& other) const
     switch (d_type) {
     case ntsa::SocketOptionType::e_REUSE_ADDRESS:
         return d_reuseAddress.object() < other.d_reuseAddress.object();
-        // TODO
+    case ntsa::SocketOptionType::e_KEEP_ALIVE:
+        return d_keepAlive.object() < other.d_keepAlive.object();
+    case ntsa::SocketOptionType::e_CORK:
+        return d_cork.object() < other.d_cork.object();
+    case ntsa::SocketOptionType::e_DELAY_TRANSMISSION:
+        return d_delayTransmission.object() < 
+               other.d_delayTransmission.object();
+    case ntsa::SocketOptionType::e_DELAY_ACKNOWLEDGEMENT:
+        return d_delayAcknowledgement.object() < 
+               other.d_delayAcknowledgement.object();
+    case ntsa::SocketOptionType::e_SEND_BUFFER_SIZE:
+        return d_sendBufferSize.object() < 
+               other.d_sendBufferSize.object();
+    case ntsa::SocketOptionType::e_SEND_BUFFER_LOW_WATERMARK:
+        return d_sendBufferLowWatermark.object() < 
+               other.d_sendBufferLowWatermark.object();
+    case ntsa::SocketOptionType::e_RECEIVE_BUFFER_SIZE:
+        return d_receiveBufferSize.object() < 
+               other.d_receiveBufferSize.object();
+    case ntsa::SocketOptionType::e_RECEIVE_BUFFER_LOW_WATERMARK:
+        return d_receiveBufferLowWatermark.object() < 
+               other.d_receiveBufferLowWatermark.object();
+    case ntsa::SocketOptionType::e_DEBUG:
+        return d_debug.object() < other.d_debug.object();
     case ntsa::SocketOptionType::e_LINGER:
         return d_linger.object().less(other.d_linger.object());
-        // TODO
+    case ntsa::SocketOptionType::e_BROADCAST:
+        return d_broadcast.object() < other.d_broadcast.object();
+    case ntsa::SocketOptionType::e_BYPASS_ROUTING:
+        return d_bypassRouting.object() < other.d_bypassRouting.object();
+    case ntsa::SocketOptionType::e_INLINE_OUT_OF_BAND_DATA:
+        return d_inlineOutOfBandData.object() < 
+               other.d_inlineOutOfBandData.object();
+    case ntsa::SocketOptionType::e_RX_TIMESTAMPING:
+        return d_timestampIncomingData.object() < 
+               other.d_timestampIncomingData.object();
+    case ntsa::SocketOptionType::e_TX_TIMESTAMPING:
+        return d_timestampOutgoingData.object() < 
+               other.d_timestampOutgoingData.object();
+    case ntsa::SocketOptionType::e_ZERO_COPY:
+        return d_zeroCopy.object() < other.d_zeroCopy.object();
     default:
         return true;
     }
@@ -649,11 +768,54 @@ bsl::ostream& SocketOption::print(bsl::ostream& stream,
     case ntsa::SocketOptionType::e_REUSE_ADDRESS:
         stream << d_reuseAddress.object();
         break;
-        // TODO
+    case ntsa::SocketOptionType::e_KEEP_ALIVE:
+        stream << d_keepAlive.object();
+        break;
+    case ntsa::SocketOptionType::e_CORK:
+        stream << d_cork.object();
+        break;
+    case ntsa::SocketOptionType::e_DELAY_TRANSMISSION:
+        stream << d_delayTransmission.object();
+        break;
+    case ntsa::SocketOptionType::e_DELAY_ACKNOWLEDGEMENT:
+        stream << d_delayAcknowledgement.object();
+        break;
+    case ntsa::SocketOptionType::e_SEND_BUFFER_SIZE:
+        stream << d_sendBufferSize.object();
+        break;
+    case ntsa::SocketOptionType::e_SEND_BUFFER_LOW_WATERMARK:
+        stream << d_sendBufferLowWatermark.object();
+        break;
+    case ntsa::SocketOptionType::e_RECEIVE_BUFFER_SIZE:
+        stream << d_receiveBufferSize.object();
+        break;
+    case ntsa::SocketOptionType::e_RECEIVE_BUFFER_LOW_WATERMARK:
+        stream << d_receiveBufferLowWatermark.object();
+        break;
+    case ntsa::SocketOptionType::e_DEBUG:
+        stream << d_debug.object();
+        break;
     case ntsa::SocketOptionType::e_LINGER:
         d_linger.object().print(stream, level, spacesPerLevel);
         break;
-        // TODO
+    case ntsa::SocketOptionType::e_BROADCAST:
+        stream << d_broadcast.object();
+        break;
+    case ntsa::SocketOptionType::e_BYPASS_ROUTING:
+        stream << d_bypassRouting.object();
+        break;
+    case ntsa::SocketOptionType::e_INLINE_OUT_OF_BAND_DATA:
+        stream << d_inlineOutOfBandData.object();
+        break;
+    case ntsa::SocketOptionType::e_RX_TIMESTAMPING:
+        stream << d_timestampIncomingData.object();
+        break;
+    case ntsa::SocketOptionType::e_TX_TIMESTAMPING:
+        stream << d_timestampOutgoingData.object();
+        break;
+    case ntsa::SocketOptionType::e_ZERO_COPY:
+        stream << d_zeroCopy.object();
+        break;
     default:
         BSLS_ASSERT(d_type == ntsa::SocketOptionType::e_UNDEFINED);
         stream << "UNDEFINED";

--- a/groups/nts/ntsa/ntsa_socketoption.h
+++ b/groups/nts/ntsa/ntsa_socketoption.h
@@ -35,9 +35,88 @@ namespace ntsa {
 /// Provide a union of socket options.
 ///
 /// @details
-/// Provide a value-semantic type that represents a discriminated
-/// union of socket options.
-//
+/// Provide a value-semantic type that represents a discriminated union of 
+/// socket options.
+///
+/// @par Attributes
+/// This class is composed of the following attributes.
+///
+/// @li @b reuseAddress:
+/// The flag that indicates the operating system should allow the user to
+/// rebind a socket to reuse local addresses.
+///
+/// @li @b keepAlive:
+/// That flag that indicates the operating system implementation should
+/// periodically emit transport-level "keep-alive" packets.
+///
+/// @li @b cork:
+/// The flag that indicates that successive writes should be coalesced into the
+/// largest packets that can be formed. When set to true, this option indicates
+/// the user favors better network efficiency at the expense of worse latency.
+/// When set to false, this option indicates the user favors better latency at
+/// the expense of worse network efficiency.
+///
+/// @li @b delayTransmission:
+/// The flag that indicates that successive writes should be coalesced into
+/// larger packets that would otherwise form. When set to true, this option
+/// indicates the user favors better network efficiency at the expense of worse
+/// latency. When set to false, this option indicates the user favors better
+/// latency at the expense of worse network efficiency.
+///
+/// @li @b delayAcknowledgement:
+/// The flag that indicates acknowledgement of successively-received packets
+/// should be coalesced. When set to true, this option indicates the user
+/// favors better network efficiency at the expense of worse latency. When set
+/// to false, this option indicates the user favors better latency at the
+/// expense of worse network efficiency.
+///
+/// @li @b sendBufferSize:
+/// The maximum size of each socket send buffer. On some platforms, this
+/// options may serve simply as a hint.
+///
+/// @li @b sendBufferLowWatermark:
+/// The amount of available capacity that must exist in the socket send buffer
+/// for the operating system to indicate the socket is writable.
+///
+/// @li @b receiveBufferSize:
+/// The maximum size of each socket receive buffer. On some platforms, this
+/// options may serve simply as a hint.
+///
+/// @li @b receiveBufferLowWatermark:
+/// The amount of available data that must exist in the socket receive buffer
+/// for the operating system to indicate the socket is readable.
+///
+/// @li @b debug:
+/// This flag indicates that each socket should be put into debug mode in the
+/// operating system. The support and meaning of this option is
+/// platform-specific.
+///
+/// @li @b linger:
+/// The options that control whether the operating system should gracefully
+/// attempt to transmit any data remaining in the socket send buffer before
+/// closing the connection.
+///
+/// @li @b broadcast:
+/// The flag that indicates the socket supports sending to a broadcast address.
+///
+/// @li @b bypassRouting:
+/// The flag that indicates that normal routing rules are not used, the route
+/// is based upon the destination address only.
+///
+/// @li @b inlineOutOfBandData:
+/// The flag that indicates out-of-band data should be placed into the normal
+/// data input queue.
+///
+/// @li @b timestampIncomingData:
+/// The flag that indicates timestamps should be generated for outgoing data.
+///
+/// @li @b timestampOutgoingData:
+/// The flag that indicates timestamps should be generated for incoming data.
+///
+/// @li @b zeroCopy:
+/// The flag that indicates each send operation can request copy avoidance when
+/// enqueing data to the socket send buffer.
+///
 /// @par Thread Safety
 /// This class is not thread safe.
 ///
@@ -61,6 +140,7 @@ class SocketOption
         bsls::ObjectBuffer<bool>         d_inlineOutOfBandData;
         bsls::ObjectBuffer<bool>         d_timestampIncomingData;
         bsls::ObjectBuffer<bool>         d_timestampOutgoingData;
+        bsls::ObjectBuffer<bool>         d_zeroCopy;
     };
 
     ntsa::SocketOptionType::Value d_type;
@@ -76,97 +156,88 @@ class SocketOption
     /// Destroy this object.
     ~SocketOption();
 
-    /// Assign the value of the specified 'other' object to this object.
-    /// Return a reference to this modifiable object.
+    /// Assign the value of the specified 'other' object to this object. Return
+    /// a reference to this modifiable object.
     SocketOption& operator=(const SocketOption& other);
 
-    /// Reset the value of this object to its value upon default
-    /// construction.
+    /// Reset the value of this object to its value upon default construction.
     void reset();
 
     /// Select the "reuseAddress" representation. Return a reference to the
     /// modifiable representation.
     bool& makeReuseAddress();
 
-    /// Select the "reuseAddress" representation initially having the
-    /// specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// Select the "reuseAddress" representation initially having the specified
+    /// 'value'. Return a reference to the modifiable representation.
     bool& makeReuseAddress(bool value);
 
     /// Select the "keepAlive" representation. Return a reference to the
     /// modifiable representation.
     bool& makeKeepAlive();
 
-    /// Select the "keepAlive" representation initially having the
-    /// specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// Select the "keepAlive" representation initially having the specified
+    /// 'value'. Return a reference to the modifiable representation.
     bool& makeKeepAlive(bool value);
 
-    /// Select the "cork" representation. Return a reference to the
-    /// modifiable representation.
+    /// Select the "cork" representation. Return a reference to the modifiable
+    /// representation.
     bool& makeCork();
 
-    /// Select the "cork" representation initially having the
-    /// specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// Select the "cork" representation initially having the specified
+    /// 'value'. Return a reference to the modifiable representation.
     bool& makeCork(bool value);
 
-    /// Select the "delayTransmission" representation. Return a reference
-    /// to the modifiable representation.
+    /// Select the "delayTransmission" representation. Return a reference to
+    /// the modifiable representation.
     bool& makeDelayTransmission();
 
     /// Select the "delayTransmission" representation initially having the
-    /// specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// specified 'value'. Return a reference to the modifiable representation.
     bool& makeDelayTransmission(bool value);
 
-    /// Select the "delayAcknowledgement" representation. Return a reference
-    /// to the modifiable representation.
+    /// Select the "delayAcknowledgement" representation. Return a reference to
+    /// the modifiable representation.
     bool& makeDelayAcknowledgement();
 
-    /// Select the "delayAcknowledgement" representation initially having
-    /// the specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// Select the "delayAcknowledgement" representation initially having the
+    /// specified 'value'. Return a reference to the modifiable representation.
     bool& makeDelayAcknowledgement(bool value);
 
-    /// Select the "sendBufferSize" representation. Return a reference
-    /// to the modifiable representation.
+    /// Select the "sendBufferSize" representation. Return a reference to the
+    /// modifiable representation.
     bsl::size_t& makeSendBufferSize();
 
-    /// Select the "sendBufferSize" representation initially having
-    /// the specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// Select the "sendBufferSize" representation initially having the
+    /// specified 'value'. Return a reference to the modifiable representation.
     bsl::size_t& makeSendBufferSize(bsl::size_t value);
 
-    /// Select the "sendBufferLowWatermark" representation. Return a
-    /// reference to the modifiable representation.
+    /// Select the "sendBufferLowWatermark" representation. Return a reference
+    /// to the modifiable representation.
     bsl::size_t& makeSendBufferLowWatermark();
 
-    /// Select the "sendBufferLowWatermark" representation initially having
-    /// the specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// Select the "sendBufferLowWatermark" representation initially having the
+    /// specified 'value'. Return a reference to the modifiable representation.
     bsl::size_t& makeSendBufferLowWatermark(bsl::size_t value);
 
-    /// Select the "receiveBufferSize" representation. Return a reference
-    /// to the modifiable representation.
+    /// Select the "receiveBufferSize" representation. Return a reference to
+    /// the modifiable representation.
     bsl::size_t& makeReceiveBufferSize();
 
-    /// Select the "receiveBufferSize" representation initially having
-    /// the specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// Select the "receiveBufferSize" representation initially having the
+    /// specified 'value'. Return a reference to the modifiable representation.
     bsl::size_t& makeReceiveBufferSize(bsl::size_t value);
 
     /// Select the "receiveBufferLowWatermark" representation. Return a
     /// reference to the modifiable representation.
     bsl::size_t& makeReceiveBufferLowWatermark();
 
-    /// Select the "receiveBufferLowWatermark" representation initially
-    /// having the specified 'value'. Return a reference to the modifiable
+    /// Select the "receiveBufferLowWatermark" representation initially having
+    /// the specified 'value'. Return a reference to the modifiable
     /// representation.
     bsl::size_t& makeReceiveBufferLowWatermark(bsl::size_t value);
 
-    /// Select the "debug" representation. Return a reference to the
-    /// modifiable representation.
+    /// Select the "debug" representation. Return a reference to the modifiable
+    /// representation.
     bool& makeDebug();
 
     /// Select the "debug" representation initially having the specified
@@ -194,47 +265,51 @@ class SocketOption
     bool& makeBypassRouting();
 
     /// Select the "bypassRouting" representation initially having the
-    /// specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// specified 'value'. Return a reference to the modifiable representation.
     bool& makeBypassRouting(bool value);
 
-    /// Select the "inlineOutOfBandData" representation. Return a reference
-    /// to the modifiable representation.
+    /// Select the "inlineOutOfBandData" representation. Return a reference to
+    /// the modifiable representation.
     bool& makeInlineOutOfBandData();
 
     /// Select the "inlineOutOfBandData" representation initially having the
-    /// specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// specified 'value'. Return a reference to the modifiable representation.
     bool& makeInlineOutOfBandData(bool value);
 
-    /// Select the "timestampIncomingData" representation. Return a
-    /// reference to the modifiable representation.
+    /// Select the "timestampIncomingData" representation. Return a reference
+    /// to the modifiable representation.
     bool& makeTimestampIncomingData();
 
-    /// Select the "timestampIncomingData" representation initially having
-    /// the specified 'value'. Return a reference to the modifiable
-    /// representation
+    /// Select the "timestampIncomingData" representation initially having the
+    /// specified 'value'. Return a reference to the modifiable representation.
     bool& makeTimestampIncomingData(bool value);
 
     /// Select the "timestampOutgoingData" representation. Return a reference
     /// to the modifiable representation.
     bool& makeTimestampOutgoingData();
 
-    // Select the "timestampOutgoingData" representation initially having the
-    // specified 'value'. Return a reference to the modifiable
-    // representation.
+    /// Select the "timestampOutgoingData" representation initially having the
+    /// specified 'value'. Return a reference to the modifiable representation.
     bool& makeTimestampOutgoingData(bool value);
 
-    /// Return a reference to the modifiable "reuseAddress" representation.
-    /// The behavior is undefined unless 'isReuseAddress()' is true.
+    /// Select the "zeroCopy" representation. Return a reference to the
+    /// modifiable representation.
+    bool& makeZeroCopy();
+
+    /// Select the "zeroCopy" representation initially having the specified
+    /// 'value'. Return a reference to the modifiable representation.
+    bool& makeZeroCopy(bool value);
+
+    /// Return a reference to the modifiable "reuseAddress" representation. The
+    /// behavior is undefined unless 'isReuseAddress()' is true.
     bool& reuseAddress();
 
-    /// Return a reference to the modifiable "keepAlive" representation.
-    /// The behavior is undefined unless 'isKeepAlive()' is true.
+    /// Return a reference to the modifiable "keepAlive" representation. The
+    /// behavior is undefined unless 'isKeepAlive()' is true.
     bool& keepAlive();
 
-    /// Return a reference to the modifiable "cork" representation.
-    /// The behavior is undefined unless 'isCork()' is true.
+    /// Return a reference to the modifiable "cork" representation. The
+    /// behavior is undefined unless 'isCork()' is true.
     bool& cork();
 
     /// Return a reference to the modifiable "delayTransmission"
@@ -247,9 +322,8 @@ class SocketOption
     /// 'isDelayAcknowledgement()' is true.
     bool& delayAcknowledgement();
 
-    /// Return a reference to the modifiable "sendBufferSize"
-    /// representation. The behavior is undefined unless
-    /// 'isSendBufferSize()' is true.
+    /// Return a reference to the modifiable "sendBufferSize" representation.
+    /// The behavior is undefined unless 'isSendBufferSize()' is true.
     bsl::size_t& sendBufferSize();
 
     /// Return a reference to the modifiable "sendBufferLowWatermark"
@@ -267,16 +341,16 @@ class SocketOption
     /// 'isReceiveBufferLowWatermark()' is true.
     bsl::size_t& receiveBufferLowWatermark();
 
-    /// Return a reference to the modifiable "debug" representation.
-    /// The behavior is undefined unless 'isDebug()' is true.
+    /// Return a reference to the modifiable "debug" representation. The
+    /// behavior is undefined unless 'isDebug()' is true.
     bool& debug();
 
-    /// Return a reference to the modifiable "linger" representation.
-    /// The behavior is undefined unless 'isLinger()' is true.
+    /// Return a reference to the modifiable "linger" representation. The
+    /// behavior is undefined unless 'isLinger()' is true.
     ntsa::Linger& linger();
 
-    /// Return a reference to the modifiable "broadcast" representation.
-    /// The behavior is undefined unless 'isBroadcast()' is true.
+    /// Return a reference to the modifiable "broadcast" representation. The
+    /// behavior is undefined unless 'isBroadcast()' is true.
     bool& broadcast();
 
     /// Return a reference to the modifiable "bypassRouting" representation.
@@ -298,12 +372,16 @@ class SocketOption
     /// 'isTimestampOutOutgoingData()' is true.
     bool& timestampOutgoingData();
 
-    /// Return the non-modifiable "reuseAddress" representation. The
-    /// behavior is undefined unless 'isReuseAddress()' is true.
+    /// Return a reference to the modifiable "zeroCopy" representation. The
+    /// behavior is undefined unless 'isZeroCopy()' is true.
+    bool& zeroCopy();
+
+    /// Return the non-modifiable "reuseAddress" representation. The behavior
+    /// is undefined unless 'isReuseAddress()' is true.
     bool reuseAddress() const;
 
-    /// Return the non-modifiable "keepAlive" representation. The behavior
-    /// is undefined unless 'isKeepAlive()' is true.
+    /// Return the non-modifiable "keepAlive" representation. The behavior is
+    /// undefined unless 'isKeepAlive()' is true.
     bool keepAlive() const;
 
     /// Return the non-modifiable "cork" representation. The behavior is
@@ -318,62 +396,64 @@ class SocketOption
     /// behavior is undefined unless 'isDelayAcknowledgement()' is true.
     bool delayAcknowledgement() const;
 
-    /// Return the non-modifiable "sendBufferSize" representation. The
-    /// behavior is undefined unless 'isSendBufferSize()' is true.
+    /// Return the non-modifiable "sendBufferSize" representation. The behavior
+    /// is undefined unless 'isSendBufferSize()' is true.
     bsl::size_t sendBufferSize() const;
 
-    /// Return the non-modifiable "sendBufferLowWatermark" representation.
-    /// The behavior is undefined unless 'isSendBufferLowWatermark()' is
-    /// true.
+    /// Return the non-modifiable "sendBufferLowWatermark" representation. The
+    /// behavior is undefined unless 'isSendBufferLowWatermark()' is true.
     bsl::size_t sendBufferLowWatermark() const;
 
     /// Return the non-modifiable "receiveBufferSize" representation. The
     /// behavior is undefined unless 'isReceiveBufferSize()' is true.
     bsl::size_t receiveBufferSize() const;
 
-    /// Return the non-modifiable "receiveBufferLowWatermark"
-    /// representation. The behavior is undefined unless
-    /// 'isReceiveBufferLowWatermark()' is true.
+    /// Return the non-modifiable "receiveBufferLowWatermark" representation.
+    /// The behavior is undefined unless 'isReceiveBufferLowWatermark()' is
+    /// true.
     bsl::size_t receiveBufferLowWatermark() const;
 
     /// Return the non-modifiable "debug" representation. The behavior is
     /// undefined unless 'isDebug()' is true.
     bool debug() const;
 
-    /// Return a reference to the non-modifiable "linger" representation.
-    /// The behavior is undefined unless 'isLinger()' is true.
+    /// Return a reference to the non-modifiable "linger" representation. The
+    /// behavior is undefined unless 'isLinger()' is true.
     const ntsa::Linger& linger() const;
 
-    /// Return the non-modifiable "broadcast" representation. The behavior
-    /// is undefined unless 'isBroadcast()' is true.
+    /// Return the non-modifiable "broadcast" representation. The behavior is
+    /// undefined unless 'isBroadcast()' is true.
     bool broadcast() const;
 
-    /// Return the non-modifiable "bypassRouting" representation. The
-    /// behavior is undefined unless 'isBypassRouting()' is true.
+    /// Return the non-modifiable "bypassRouting" representation. The behavior
+    /// is undefined unless 'isBypassRouting()' is true.
     bool bypassRouting() const;
 
     /// Return the non-modifiable "inlineOutOfBandData" representation. The
     /// behavior is undefined unless 'isInlineOutOfBandData()' is true.
     bool inlineOutOfBandData() const;
 
-    /// Return the non-modifiable "timestampIncomingData" representation.
-    /// The behavior is undefined unless 'isTimestampIncomingData()' is
-    /// true.
+    /// Return the non-modifiable "timestampIncomingData" representation. The
+    /// behavior is undefined unless 'isTimestampIncomingData()' is true.
     bool timestampIncomingData() const;
 
     /// Return the non-modifiable "timestampOutgoingData" representation. The
     /// behavior is undefined unless 'isTimestampOutgoingData()' is true.
     bool timestampOutgoingData() const;
 
+    /// Return the non-modifiable "zeroCopy" representation. The behavior is
+    /// undefined unless 'isZeroCopy()' is true.
+    bool zeroCopy() const;
+
     /// Return the type of the option representation.
     enum ntsa::SocketOptionType::Value type() const;
 
-    /// Return true if the option representation is undefined, otherwise
-    /// return false.
+    /// Return true if the option representation is undefined, otherwise return
+    /// false.
     bool isUndefined() const;
 
-    /// Return true if the "reuseAddress" representation is currently
-    /// selected, otherwise return false.
+    /// Return true if the "reuseAddress" representation is currently selected,
+    /// otherwise return false.
     bool isReuseAddress() const;
 
     /// Return true if the "keepAlive" representation is currently selected,
@@ -396,8 +476,8 @@ class SocketOption
     /// selected, otherwise return false.
     bool isSendBufferSize() const;
 
-    /// Return true if the "sendBufferLowWatermark" representation is
-    /// currently selected, otherwise return false.
+    /// Return true if the "sendBufferLowWatermark" representation is currently
+    /// selected, otherwise return false.
     bool isSendBufferLowWatermark() const;
 
     /// Return true if the "receiveBufferSize" representation is currently
@@ -428,45 +508,48 @@ class SocketOption
     /// selected, otherwise return false.
     bool isInlineOutOfBandData() const;
 
-    /// Return true if the "timestampIncomingData" representation is
-    /// currently selected, otherwise return false.
+    /// Return true if the "timestampIncomingData" representation is currently
+    /// selected, otherwise return false.
     bool isTimestampIncomingData() const;
 
-    /// Return true if the "timestampOutgoingData" representation is
-    /// currently selected, otherwise return false.
+    /// Return true if the "timestampOutgoingData" representation is currently
+    /// selected, otherwise return false.
     bool isTimestampOutgoingData() const;
 
-    /// Return true if this object has the same value as the specified
-    /// 'other' object, otherwise return false.
+    /// Return true if the "zeroCopy" representation is currently selected,
+    /// otherwise return false.
+    bool isZeroCopy() const;
+
+    /// Return true if this object has the same value as the specified 'other'
+    /// object, otherwise return false.
     bool equals(const SocketOption& other) const;
 
-    /// Return true if the value of this object is less than the value of
-    /// the specified 'other' object, otherwise return false.
+    /// Return true if the value of this object is less than the value of the
+    /// specified 'other' object, otherwise return false.
     bool less(const SocketOption& other) const;
 
-    /// Format this object to the specified output 'stream' at the
-    /// optionally specified indentation 'level' and return a reference to
-    /// the modifiable 'stream'.  If 'level' is specified, optionally
-    /// specify 'spacesPerLevel', the number of spaces per indentation level
-    /// for this and all of its nested objects.  Each line is indented by
-    /// the absolute value of 'level * spacesPerLevel'.  If 'level' is
-    /// negative, suppress indentation of the first line.  If
-    /// 'spacesPerLevel' is negative, suppress line breaks and format the
-    /// entire output on one line.  If 'stream' is initially invalid, this
-    /// operation has no effect.  Note that a trailing newline is provided
-    /// in multiline mode only.
+    /// Format this object to the specified output 'stream' at the optionally
+    /// specified indentation 'level' and return a reference to the modifiable
+    /// 'stream'.  If 'level' is specified, optionally specify
+    /// 'spacesPerLevel', the number of spaces per indentation level for this
+    /// and all of its nested objects.  Each line is indented by the absolute
+    /// value of 'level * spacesPerLevel'.  If 'level' is negative, suppress
+    /// indentation of the first line.  If 'spacesPerLevel' is negative,
+    /// suppress line breaks and format the entire output on one line.  If
+    /// 'stream' is initially invalid, this operation has no effect.  Note that
+    /// a trailing newline is provided in multiline mode only.
     bsl::ostream& print(bsl::ostream& stream,
                         int           level          = 0,
                         int           spacesPerLevel = 4) const;
 
-    /// Defines the traits of this type. These traits can be used to select,
-    /// at compile-time, the most efficient algorithm to manipulate objects
-    /// of this type.
+    /// Defines the traits of this type. These traits can be used to select, at
+    /// compile-time, the most efficient algorithm to manipulate objects of
+    /// this type.
     NTSCFG_DECLARE_NESTED_BITWISE_MOVABLE_TRAITS(SocketOption);
 };
 
-/// Write the specified 'object' to the specified 'stream'. Return a
-/// modifiable reference to the 'stream'.
+/// Write the specified 'object' to the specified 'stream'. Return a modifiable
+/// reference to the 'stream'.
 ///
 /// @related ntsa::SocketOption
 bsl::ostream& operator<<(bsl::ostream& stream, const SocketOption& object);
@@ -483,8 +566,8 @@ bool operator==(const SocketOption& lhs, const SocketOption& rhs);
 /// @related ntsa::SocketOption
 bool operator!=(const SocketOption& lhs, const SocketOption& rhs);
 
-/// Contribute the values of the salient attributes of the specified 'value'
-/// to the specified hash 'algorithm'.
+/// Contribute the values of the salient attributes of the specified 'value' to
+/// the specified hash 'algorithm'.
 ///
 /// @related ntsa::SocketOption
 template <typename HASH_ALGORITHM>
@@ -621,6 +704,13 @@ bool& SocketOption::timestampOutgoingData()
 }
 
 NTSCFG_INLINE
+bool& SocketOption::zeroCopy()
+{
+    BSLS_ASSERT(d_type == ntsa::SocketOptionType::e_ZERO_COPY);
+    return d_zeroCopy.object();
+}
+
+NTSCFG_INLINE
 bool SocketOption::reuseAddress() const
 {
     BSLS_ASSERT(d_type == ntsa::SocketOptionType::e_REUSE_ADDRESS);
@@ -734,6 +824,13 @@ bool SocketOption::timestampOutgoingData() const
 }
 
 NTSCFG_INLINE
+bool SocketOption::zeroCopy() const
+{
+    BSLS_ASSERT(d_type == ntsa::SocketOptionType::e_ZERO_COPY);
+    return d_zeroCopy.object();
+}
+
+NTSCFG_INLINE
 ntsa::SocketOptionType::Value SocketOption::type() const
 {
     return d_type;
@@ -842,6 +939,12 @@ bool SocketOption::isTimestampOutgoingData() const
 }
 
 NTSCFG_INLINE
+bool SocketOption::isZeroCopy() const
+{
+    return (d_type == ntsa::SocketOptionType::e_ZERO_COPY);
+}
+
+NTSCFG_INLINE
 bsl::ostream& operator<<(bsl::ostream& stream, const SocketOption& object)
 {
     return object.print(stream, 0, -1);
@@ -917,6 +1020,9 @@ void hashAppend(HASH_ALGORITHM& algorithm, const SocketOption& value)
     }
     else if (value.isTimestampOutgoingData()) {
         hashAppend(algorithm, value.timestampOutgoingData());
+    }
+    else if (value.isZeroCopy()) {
+        hashAppend(algorithm, value.zeroCopy());
     }
 }
 

--- a/groups/nts/ntsa/ntsa_socketoption.t.cpp
+++ b/groups/nts/ntsa/ntsa_socketoption.t.cpp
@@ -83,9 +83,35 @@ NTSCFG_TEST_CASE(2)
     NTSCFG_TEST_FALSE(so.isTimestampOutgoingData());
 }
 
+NTSCFG_TEST_CASE(3)
+{
+    // Concern: test allowMsgZeroCopy option
+
+    ntsa::SocketOption so;
+    NTSCFG_TEST_FALSE(so.isZeroCopy());
+
+    so.makeZeroCopy(true);
+    NTSCFG_TEST_TRUE(so.isZeroCopy());
+
+    bool& val = so.zeroCopy();
+    NTSCFG_TEST_TRUE(val);
+    val = false;
+    NTSCFG_TEST_FALSE(so.zeroCopy());
+
+    val = true;
+    NTSCFG_TEST_TRUE(so.zeroCopy());
+
+    so.makeZeroCopy();
+    NTSCFG_TEST_FALSE(so.zeroCopy());
+
+    so.reset();
+    NTSCFG_TEST_FALSE(so.isZeroCopy());
+}
+
 NTSCFG_TEST_DRIVER
 {
     NTSCFG_TEST_REGISTER(1);
     NTSCFG_TEST_REGISTER(2);
+    NTSCFG_TEST_REGISTER(3);
 }
 NTSCFG_TEST_DRIVER_END;

--- a/groups/nts/ntsa/ntsa_socketoptiontype.cpp
+++ b/groups/nts/ntsa/ntsa_socketoptiontype.cpp
@@ -43,6 +43,7 @@ int SocketOptionType::fromInt(SocketOptionType::Value* result, int number)
     case SocketOptionType::e_INLINE_OUT_OF_BAND_DATA:
     case SocketOptionType::e_RX_TIMESTAMPING:
     case SocketOptionType::e_TX_TIMESTAMPING:
+    case SocketOptionType::e_ZERO_COPY:
         *result = static_cast<SocketOptionType::Value>(number);
         return 0;
     default:
@@ -122,6 +123,10 @@ int SocketOptionType::fromString(SocketOptionType::Value* result,
         *result = e_TX_TIMESTAMPING;
         return 0;
     }
+    if (bdlb::String::areEqualCaseless(string, "ZERO_COPY")) {
+        *result = e_ZERO_COPY;
+        return 0;
+    }
 
     return -1;
 }
@@ -179,6 +184,9 @@ const char* SocketOptionType::toString(SocketOptionType::Value value)
     } break;
     case e_TX_TIMESTAMPING: {
         return "TX_TIMESTAMPING";
+    } break;
+    case e_ZERO_COPY: {
+        return "ZERO_COPY";
     } break;
     }
 

--- a/groups/nts/ntsa/ntsa_socketoptiontype.h
+++ b/groups/nts/ntsa/ntsa_socketoptiontype.h
@@ -86,11 +86,15 @@ struct SocketOptionType {
         /// Place out-of-band data into the normal incoming data stream.
         e_INLINE_OUT_OF_BAND_DATA = 14,
 
-        /// This option type allows to enable or disable receive timestamps.
+        /// Generate timestamps for incoming data.
         e_RX_TIMESTAMPING = 15,
 
-        /// This option type allows to enable or disable transmit timestamps.
-        e_TX_TIMESTAMPING = 16
+        /// Generate timestamps for outgoing data.
+        e_TX_TIMESTAMPING = 16,
+
+        /// Allow each send operation to request copy avoidance when enqueing
+        /// data to the socket send buffer.
+        e_ZERO_COPY = 17
     };
 
     /// Return the string representation exactly matching the enumerator

--- a/groups/nts/ntsa/ntsa_timestamp.h
+++ b/groups/nts/ntsa/ntsa_timestamp.h
@@ -19,30 +19,29 @@
 #include <bsls_ident.h>
 BSLS_IDENT("$Id: $")
 
+#include <ntscfg_platform.h>
 #include <ntsscm_version.h>
-
+#include <ntsa_timestamptype.h>
 #include <bslh_hash.h>
 #include <bsls_timeinterval.h>
-
-#include <ntsa_timestamptype.h>
 
 namespace BloombergLP {
 namespace ntsa {
 
-/// Provide a type holding a transmit timestamp.
-///
-/// @details
-/// Provide a value-semantic type that holds a timestamp.
+/// Describe a notification of a timestamp of outgoing data.
 ///
 /// @par Attributes
-/// This class is composed of the following attributes..
+/// This class is composed of the following attributes.
 ///
 /// @li @b type:
-/// Type of the timestamp. It describes source of the timestamp. Default value
-/// is e_UNDEFINED.
+/// The type of the timestamp, indicating where the timestamp was measured in
+/// the transmission and acknowledgement process.
+///
+/// @li @b id:
+/// The data identifier.
 ///
 /// @li @b time:
-/// The timestamp value. Default value is 0.
+/// The timestamp, in absolute time since the Unix epoch.
 ///
 /// @par Thread Safety
 /// This class is not thread safe.
@@ -56,54 +55,54 @@ class Timestamp
     /// Create new timestamp having the default value.
     Timestamp();
 
-    /// Create new timestamp having the same value as the specified
-    /// 'original' object.
+    /// Create new timestamp having the same value as the specified 'original'
+    /// object.
     Timestamp(const Timestamp& original);
 
     /// Destroy this object.
     ~Timestamp();
 
-    /// Assign the value of the specified 'other' object to this object.
-    /// Return a reference to this modifiable object.
+    /// Assign the value of the specified 'other' object to this object. Return
+    /// a reference to this modifiable object.
     Timestamp& operator=(const Timestamp& other);
 
-    /// Set timestamp type to the specifued 'value'.
+    /// Set the timestamp type to the specified 'value'.
     void setType(ntsa::TimestampType::Value value);
 
-    /// Set id of the timestamp to the specified 'value'.
+    /// Set the identifier of the data for which the timestamp applies to the
+    /// specified 'value'.
     void setId(bsl::uint32_t value);
 
-    /// Set timestamp time to the specified 'value'.
+    /// Set the timestamp time to the specified 'value'.
     void setTime(const bsls::TimeInterval& value);
 
-    /// Return type of the timestamp.
+    /// Return the type of the timestamp.
     ntsa::TimestampType::Value type() const;
 
-    /// Get id of the timestamp.
+    /// Return the identifier of the data to which the timestamp applies.
     bsl::uint32_t id() const;
 
-    /// Return time of the timestamp.
+    /// Return time of the timestamp, in absolute time since the Unix epoch.
     const bsls::TimeInterval& time() const;
 
-    /// Return true if this object has the same value as the specified
-    /// 'other' object, otherwise return false.
+    /// Return true if this object has the same value as the specified 'other'
+    /// object, otherwise return false.
     bool equals(const Timestamp& other) const;
 
-    /// Return true if the value of this object is less than the value of
-    /// the specified 'other' object, otherwise return false.
+    /// Return true if the value of this object is less than the value of the
+    /// specified 'other' object, otherwise return false.
     bool less(const Timestamp& other) const;
 
-    /// Format this object to the specified output 'stream' at the
-    /// optionally specified indentation 'level' and return a reference to
-    /// the modifiable 'stream'.  If 'level' is specified, optionally
-    /// specify 'spacesPerLevel', the number of spaces per indentation level
-    /// for this and all of its nested objects.  Each line is indented by
-    /// the absolute value of 'level * spacesPerLevel'.  If 'level' is
-    /// negative, suppress indentation of the first line.  If
-    /// 'spacesPerLevel' is negative, suppress line breaks and format the
-    /// entire output on one line.  If 'stream' is initially invalid, this
-    /// operation has no effect.  Note that a trailing newline is provided
-    /// in multiline mode only.
+    /// Format this object to the specified output 'stream' at the optionally
+    /// specified indentation 'level' and return a reference to the modifiable
+    /// 'stream'.  If 'level' is specified, optionally specify
+    /// 'spacesPerLevel', the number of spaces per indentation level for this
+    /// and all of its nested objects.  Each line is indented by the absolute
+    /// value of 'level * spacesPerLevel'.  If 'level' is negative, suppress
+    /// indentation of the first line.  If 'spacesPerLevel' is negative,
+    /// suppress line breaks and format the entire output on one line.  If
+    /// 'stream' is initially invalid, this operation has no effect.  Note that
+    /// a trailing newline is provided in multiline mode only.
     bsl::ostream& print(bsl::ostream& stream,
                         int           level          = 0,
                         int           spacesPerLevel = 4) const;

--- a/groups/nts/ntsa/ntsa_timestamptype.h
+++ b/groups/nts/ntsa/ntsa_timestamptype.h
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 namespace BloombergLP {
 namespace ntsa {
 
-/// Provide an enumeration of the timestamp types.
+/// Provide an enumeration of the outgoing timestamp types.
 ///
 /// @par Thread Safety
 /// This struct is thread safe.
@@ -33,11 +33,27 @@ namespace ntsa {
 /// @ingroup module_ntsa_identity
 struct TimestampType {
   public:
-    /// Provide an enumeration of the endpoint types.
+    /// Provide an enumeration of the timestamp types.
     enum Value {
-        e_UNDEFINED    = 0,
+        /// The timestamp type is undefined.
+        e_UNDEFINED = 0,
+
+        /// The timestamp measured at the time when the data enters the 
+        /// packet scheduler. The delta between such a timestamp and the time
+        /// immediately before the data is enqueued to the send buffer is the
+        /// time spent processing the data required by transport protocol.
         e_SCHEDULED    = 1,
-        e_SENT         = 2,
+
+        /// The timestamp measured at the time when the data leaves the
+        /// operating system and is enqueue in the network device for 
+        /// transmission. The delta between such a timestamp and the scheduled
+        /// timestamp is the time spending processing the data independant of
+        /// the transport protocol.
+        e_SENT = 2,
+
+        /// The timestamp measured at the time when the ackowledgement of the
+        /// outgoing data has been received from the peer, for positive 
+        /// acknowledgement transport protocols such as TCP.
         e_ACKNOWLEDGED = 3
     };
 

--- a/groups/nts/ntsa/ntsa_zerocopy.cpp
+++ b/groups/nts/ntsa/ntsa_zerocopy.cpp
@@ -1,0 +1,67 @@
+// Copyright 2020-2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ntsa_zerocopy.h>
+
+#include <bsls_ident.h>
+BSLS_IDENT_RCSID(ntsa_zerocopy_cpp, "$Id$ $CSID$")
+
+#include <bslim_printer.h>
+
+namespace BloombergLP {
+namespace ntsa {
+
+bool ZeroCopy::equals(const ZeroCopy& other) const
+{
+    return (d_from == other.d_from && d_to == other.d_to &&
+            d_code == other.d_code);
+}
+
+bool ZeroCopy::less(const ZeroCopy& other) const
+{
+    if (d_from < other.d_from) {
+        return true;
+    }
+
+    if (other.d_from < d_from) {
+        return false;
+    }
+
+    if (d_to < other.d_to) {
+        return true;
+    }
+
+    if (other.d_to < d_to) {
+        return false;
+    }
+
+    return d_code < other.d_code;
+}
+
+bsl::ostream& ZeroCopy::print(bsl::ostream& stream,
+                              int           level,
+                              int           spacesPerLevel) const
+{
+    bslim::Printer printer(&stream, level, spacesPerLevel);
+    printer.start();
+    printer.printAttribute("from", d_from);
+    printer.printAttribute("to", d_to);
+    printer.printAttribute("code", d_code);
+    printer.end();
+    return stream;
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/groups/nts/ntsa/ntsa_zerocopy.h
+++ b/groups/nts/ntsa/ntsa_zerocopy.h
@@ -1,0 +1,265 @@
+// Copyright 2020-2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_NTSA_ZEROCOPY
+#define INCLUDED_NTSA_ZEROCOPY
+
+#include <bsls_ident.h>
+BSLS_IDENT("$Id: $")
+
+#include <ntscfg_platform.h>
+#include <ntsscm_version.h>
+#include <bslh_hash.h>
+#include <bsl_ostream.h>
+
+namespace BloombergLP {
+namespace ntsa {
+
+/// Describe a notification for the completion of one or more send operations
+/// with zero-copy semantics.
+///
+/// @par Attributes
+/// This class is composed of the following attributes:
+///
+/// @li @b from:
+/// The identifier of the first zero-copy send that completed, inclusive.
+///
+/// @li @b to:
+/// The identifier of the last zero-copy send that completed, inclusive.
+///
+/// @li @b code:
+/// The code indicating whether the copy was avoided or was performed.
+///
+/// @par Thread Safety
+/// This class is not thread safe.
+class ZeroCopy
+{
+    bsl::uint32_t d_from;
+    bsl::uint32_t d_to;
+    bsl::uint8_t  d_code;
+
+  public:
+    /// Create a new instance having the default value.
+    ZeroCopy();
+
+    /// Create a new instance using the specified 'from', the specified 'to'
+    /// and the specified 'code' as initial values.
+    ZeroCopy(bsl::uint32_t from, bsl::uint32_t to, bsl::uint8_t code);
+
+    /// Create new object having the same value as the specified 'original'
+    /// object.
+    ZeroCopy(const ZeroCopy& original);
+
+    /// Destroy this object.
+    ~ZeroCopy();
+
+    /// Assign the value of the specified 'other' object to this object. Return
+    /// a reference to this modifiable object.
+    ZeroCopy& operator=(const ZeroCopy& other);
+
+    /// Set the identifier of the first zero-copy send that completed, 
+    /// inclusive, to the specified 'value'. 
+    void setFrom(bsl::uint32_t value);
+
+    /// Set the identifier of the last zero-copy send that completed, 
+    /// inclusive, to the specified 'value'. 
+    void setTo(bsl::uint32_t value);
+
+    /// Set the code indicating whether the copy was avoided or was performed
+    /// to the specified 'value'.
+    void setCode(bsl::uint8_t value);
+
+    /// Return the identifier of the first zero-copy send that completed, 
+    /// inclusive.
+    BSLS_ANNOTATION_NODISCARD bsl::uint32_t from() const;
+
+    /// Return the identifier of the last zero-copy send that completed, 
+    /// inclusive.
+    BSLS_ANNOTATION_NODISCARD bsl::uint32_t to() const;
+
+    /// Return the code indicating whether the copy was avoided or was 
+    /// performed.
+    BSLS_ANNOTATION_NODISCARD bsl::uint8_t code() const;
+
+    /// Return true if this object has the same value as the specified
+    /// 'other' object, otherwise return false.
+    BSLS_ANNOTATION_NODISCARD bool equals(const ZeroCopy& other) const;
+
+    /// Return true if the value of this object is less than the value of
+    /// the specified 'other' object, otherwise return false.
+    BSLS_ANNOTATION_NODISCARD bool less(const ZeroCopy& other) const;
+
+    /// Format this object to the specified output 'stream' at the optionally
+    /// specified indentation 'level' and return a reference to the modifiable
+    /// 'stream'.  If 'level' is specified, optionally specify
+    /// 'spacesPerLevel', the number of spaces per indentation level for this
+    /// and all of its nested objects.  Each line is indented by the absolute
+    /// value of 'level * spacesPerLevel'.  If 'level' is negative, suppress
+    /// indentation of the first line.  If 'spacesPerLevel' is negative,
+    /// suppress line breaks and format the entire output on one line.  If
+    /// 'stream' is initially invalid, this operation has no effect.  Note that
+    /// a trailing newline is provided in multiline mode only.
+    bsl::ostream& print(bsl::ostream& stream,
+                        int           level          = 0,
+                        int           spacesPerLevel = 4) const;
+
+    /// Defines the traits of this type. These traits can be used to select,
+    /// at compile-time, the most efficient algorithm to manipulate objects
+    /// of this type.
+    NTSCFG_DECLARE_NESTED_BITWISE_MOVABLE_TRAITS(ZeroCopy);
+};
+
+/// Write the specified 'object' to the specified 'stream'. Return
+/// a modifiable reference to the 'stream'.
+///
+/// @related ntsa::ZeroCopy
+bsl::ostream& operator<<(bsl::ostream& stream, const ZeroCopy& object);
+
+/// Return true if the specified 'lhs' has the same value as the specified
+/// 'rhs', otherwise return false.
+///
+/// @related ntsa::ZeroCopy
+bool operator==(const ZeroCopy& lhs, const ZeroCopy& rhs);
+
+/// Return true if the specified 'lhs' does not have the same value as the
+/// specified 'rhs', otherwise return false.
+///
+/// @related ntsa::ZeroCopy
+bool operator!=(const ZeroCopy& lhs, const ZeroCopy& rhs);
+
+/// Return true if the value of the specified 'lhs' is less than the value
+/// of the specified 'rhs', otherwise return false.
+///
+/// @related ntsa::ZeroCopy
+bool operator<(const ZeroCopy& lhs, const ZeroCopy& rhs);
+
+/// Contribute the values of the salient attributes of the specified 'value'
+/// to the specified hash 'algorithm'.
+///
+/// @related ntsa::ZeroCopy
+template <typename HASH_ALGORITHM>
+void hashAppend(HASH_ALGORITHM& algorithm, const ZeroCopy& value);
+
+NTSCFG_INLINE
+ZeroCopy::ZeroCopy()
+: d_from(0)
+, d_to(0)
+, d_code(0)
+{
+}
+
+NTSCFG_INLINE
+ZeroCopy::ZeroCopy(bsl::uint32_t from, bsl::uint32_t to, bsl::uint8_t code)
+: d_from(from)
+, d_to(to)
+, d_code(code)
+{
+}
+
+NTSCFG_INLINE
+ZeroCopy::ZeroCopy(const ZeroCopy& original)
+: d_from(original.d_from)
+, d_to(original.d_to)
+, d_code(original.d_code)
+{
+}
+
+NTSCFG_INLINE
+ZeroCopy::~ZeroCopy()
+{
+}
+
+NTSCFG_INLINE
+ZeroCopy& ZeroCopy::operator=(const ZeroCopy& other)
+{
+    d_from = other.d_from;
+    d_to   = other.d_to;
+    d_code = other.d_code;
+    return *this;
+}
+
+NTSCFG_INLINE
+void ZeroCopy::setFrom(bsl::uint32_t value)
+{
+    d_from = value;
+}
+
+NTSCFG_INLINE
+void ZeroCopy::setTo(bsl::uint32_t value)
+{
+    d_to = value;
+}
+
+NTSCFG_INLINE
+void ZeroCopy::setCode(bsl::uint8_t value)
+{
+    d_code = value;
+}
+
+NTSCFG_INLINE
+bsl::uint32_t ZeroCopy::from() const
+{
+    return d_from;
+}
+
+NTSCFG_INLINE
+bsl::uint32_t ZeroCopy::to() const
+{
+    return d_to;
+}
+
+NTSCFG_INLINE
+bsl::uint8_t ZeroCopy::code() const
+{
+    return d_code;
+}
+
+NTSCFG_INLINE
+bsl::ostream& operator<<(bsl::ostream& stream, const ZeroCopy& object)
+{
+    return object.print(stream, 0, -1);
+}
+
+NTSCFG_INLINE
+bool operator==(const ZeroCopy& lhs, const ZeroCopy& rhs)
+{
+    return lhs.equals(rhs);
+}
+
+NTSCFG_INLINE
+bool operator!=(const ZeroCopy& lhs, const ZeroCopy& rhs)
+{
+    return !operator==(lhs, rhs);
+}
+
+NTSCFG_INLINE
+bool operator<(const ZeroCopy& lhs, const ZeroCopy& rhs)
+{
+    return lhs.less(rhs);
+}
+
+template <typename HASH_ALGORITHM>
+void hashAppend(HASH_ALGORITHM& algorithm, const ZeroCopy& value)
+{
+    using bslh::hashAppend;
+
+    hashAppend(algorithm, value.from());
+    hashAppend(algorithm, value.to());
+    hashAppend(algorithm, value.code());
+}
+
+}  // close package namespace
+}  // close enterprise namespace
+#endif

--- a/groups/nts/ntsa/ntsa_zerocopy.t.cpp
+++ b/groups/nts/ntsa/ntsa_zerocopy.t.cpp
@@ -1,0 +1,63 @@
+// Copyright 2020-2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ntsa_zerocopy.h>
+
+#include <ntscfg_test.h>
+
+using namespace BloombergLP;
+using namespace ntsa;
+
+NTSCFG_TEST_CASE(1)
+{
+    {
+        ZeroCopy zc;
+        NTSCFG_TEST_EQ(zc.from(), 0);
+        NTSCFG_TEST_EQ(zc.to(), 0);
+        NTSCFG_TEST_EQ(zc.code(), 0);
+    }
+    {
+        const bsl::uint32_t from = 5;
+        const bsl::uint32_t to   = 15;
+        const bsl::uint8_t  code = 1;
+
+        ZeroCopy zc(from, to, code);
+        NTSCFG_TEST_EQ(zc.from(), from);
+        NTSCFG_TEST_EQ(zc.to(), to);
+        NTSCFG_TEST_EQ(zc.code(), code);
+    }
+    {
+        const bsl::uint32_t from = 10;
+        const bsl::uint32_t to   = 22;
+        const bsl::uint8_t  code = 1;
+        
+        ZeroCopy zc;
+        zc.setFrom(from);
+        zc.setTo(to);
+        zc.setCode(code);
+        NTSCFG_TEST_EQ(zc.from(), from);
+        NTSCFG_TEST_EQ(zc.to(), to);
+        NTSCFG_TEST_EQ(zc.code(), code);
+
+        ZeroCopy copy(zc);
+        NTSCFG_TEST_EQ(copy, zc);
+    }
+}
+
+NTSCFG_TEST_DRIVER
+{
+    NTSCFG_TEST_REGISTER(1);
+}
+NTSCFG_TEST_DRIVER_END;

--- a/groups/nts/ntsa/package/ntsa.mem
+++ b/groups/nts/ntsa/package/ntsa.mem
@@ -53,3 +53,4 @@ ntsa_transport
 ntsa_timestamp
 ntsa_timestamptype
 ntsa_uri
+ntsa_zerocopy

--- a/groups/nts/ntsb/ntsb_datagramsocket.cpp
+++ b/groups/nts/ntsb/ntsb_datagramsocket.cpp
@@ -122,6 +122,12 @@ ntsa::Error DatagramSocket::receive(ntsa::ReceiveContext*       context,
     return ntsu::SocketUtil::receive(context, data, options, d_handle);
 }
 
+ntsa::Error DatagramSocket::receiveNotifications(
+    ntsa::NotificationQueue* notifications)
+{
+    return ntsu::SocketUtil::receiveNotifications(notifications, d_handle);
+}
+
 ntsa::Error DatagramSocket::shutdown(ntsa::ShutdownType::Value direction)
 {
     return ntsu::SocketUtil::shutdown(direction, d_handle);

--- a/groups/nts/ntsb/ntsb_datagramsocket.h
+++ b/groups/nts/ntsb/ntsb_datagramsocket.h
@@ -123,6 +123,12 @@ class DatagramSocket : public ntsi::DatagramSocket
                         const ntsa::ReceiveOptions& options)
         BSLS_KEYWORD_OVERRIDE;
 
+    /// Read data from the socket error queue. Then if the specified
+    /// 'notifications' is not null parse fetched data to extract control
+    /// messages into the specified 'notifications'. Return the error.
+    ntsa::Error receiveNotifications(ntsa::NotificationQueue* notifications)
+        BSLS_KEYWORD_OVERRIDE;
+
     /// Shutdown the stream socket in the specified 'direction'. Return the
     /// error.
     ntsa::Error shutdown(ntsa::ShutdownType::Value direction)

--- a/groups/nts/ntsb/ntsb_listenersocket.cpp
+++ b/groups/nts/ntsb/ntsb_listenersocket.cpp
@@ -147,6 +147,12 @@ ntsa::Error ListenerSocket::accept(bsl::shared_ptr<ntsi::StreamSocket>* result,
     return ntsa::Error();
 }
 
+ntsa::Error ListenerSocket::receiveNotifications(
+    ntsa::NotificationQueue* notifications)
+{
+    return ntsu::SocketUtil::receiveNotifications(notifications, d_handle);
+}
+
 ntsa::Error ListenerSocket::shutdown(ntsa::ShutdownType::Value direction)
 {
     return ntsu::SocketUtil::shutdown(direction, d_handle);

--- a/groups/nts/ntsb/ntsb_listenersocket.h
+++ b/groups/nts/ntsb/ntsb_listenersocket.h
@@ -113,6 +113,12 @@ class ListenerSocket : public ntsi::ListenerSocket
                        bslma::Allocator*                    basicAllocator = 0)
         BSLS_KEYWORD_OVERRIDE;
 
+    /// Read data from the socket error queue. Then if the specified
+    /// 'notifications' is not null parse fetched data to extract control
+    /// messages into the specified 'notifications'. Return the error.
+    ntsa::Error receiveNotifications(ntsa::NotificationQueue* notifications)
+        BSLS_KEYWORD_OVERRIDE;
+
     /// Shutdown the stream socket in the specified 'direction'. Return the
     /// error.
     ntsa::Error shutdown(ntsa::ShutdownType::Value direction)

--- a/groups/nts/ntsb/ntsb_streamsocket.cpp
+++ b/groups/nts/ntsb/ntsb_streamsocket.cpp
@@ -122,6 +122,12 @@ ntsa::Error StreamSocket::receive(ntsa::ReceiveContext*       context,
     return ntsu::SocketUtil::receive(context, data, options, d_handle);
 }
 
+ntsa::Error StreamSocket::receiveNotifications(
+    ntsa::NotificationQueue* notifications)
+{
+    return ntsu::SocketUtil::receiveNotifications(notifications, d_handle);
+}
+
 ntsa::Error StreamSocket::shutdown(ntsa::ShutdownType::Value direction)
 {
     return ntsu::SocketUtil::shutdown(direction, d_handle);

--- a/groups/nts/ntsb/ntsb_streamsocket.h
+++ b/groups/nts/ntsb/ntsb_streamsocket.h
@@ -117,6 +117,12 @@ class StreamSocket : public ntsi::StreamSocket
                         const ntsa::ReceiveOptions& options)
         BSLS_KEYWORD_OVERRIDE;
 
+    /// Read data from the socket error queue. Then if the specified
+    /// 'notifications' is not null parse fetched data to extract control
+    /// messages into the specified 'notifications'. Return the error.
+    ntsa::Error receiveNotifications(ntsa::NotificationQueue* notifications)
+        BSLS_KEYWORD_OVERRIDE;
+
     /// Shutdown the stream socket in the specified 'direction'. Return the
     /// error.
     ntsa::Error shutdown(ntsa::ShutdownType::Value direction)

--- a/groups/nts/ntscfg/ntscfg_platform.h
+++ b/groups/nts/ntscfg/ntscfg_platform.h
@@ -217,7 +217,8 @@ struct Platform {
     static int exit();
 
     /// Return true if the version of the operating system running the current
-    /// process supports timestamping incoming and outgoing data, otherwise return false.
+    /// process supports timestamping incoming and outgoing data, otherwise
+    /// return false.
     static bool supportsTimestamps();
 };
 

--- a/groups/nts/ntsi/ntsi_datagramsocket.cpp
+++ b/groups/nts/ntsi/ntsi_datagramsocket.cpp
@@ -94,6 +94,14 @@ ntsa::Error DatagramSocket::receive(ntsa::ReceiveContext*       context,
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 
+ntsa::Error DatagramSocket::receiveNotifications(
+    ntsa::NotificationQueue* notifications)
+{
+    NTSCFG_WARNING_UNUSED(notifications);
+
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
 ntsa::Error DatagramSocket::shutdown(ntsa::ShutdownType::Value direction)
 {
     NTSCFG_WARNING_UNUSED(direction);

--- a/groups/nts/ntsi/ntsi_datagramsocket.h
+++ b/groups/nts/ntsi/ntsi_datagramsocket.h
@@ -23,6 +23,7 @@ BSLS_IDENT("$Id: $")
 #include <ntsa_endpoint.h>
 #include <ntsa_error.h>
 #include <ntsa_message.h>
+#include <ntsa_notificationqueue.h>
 #include <ntsa_receivecontext.h>
 #include <ntsa_receiveoptions.h>
 #include <ntsa_sendcontext.h>
@@ -501,6 +502,12 @@ class DatagramSocket : public ntsi::Channel
                         void*                       data,
                         bsl::size_t                 capacity,
                         const ntsa::ReceiveOptions& options);
+
+    /// Read data from the socket error queue. Then if the specified
+    /// 'notifications' is not null parse fetched data to extract control
+    /// messages into the specified 'notifications'. Return the error.
+    virtual ntsa::Error receiveNotifications(
+        ntsa::NotificationQueue* notifications);
 
     /// Shutdown the stream socket in the specified 'direction'. Return the
     /// error.

--- a/groups/nts/ntsi/ntsi_listenersocket.cpp
+++ b/groups/nts/ntsi/ntsi_listenersocket.cpp
@@ -76,6 +76,14 @@ ntsa::Error ListenerSocket::accept(bsl::shared_ptr<ntsi::StreamSocket>* result,
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 
+ntsa::Error ListenerSocket::receiveNotifications(
+    ntsa::NotificationQueue* notifications)
+{
+    NTSCFG_WARNING_UNUSED(notifications);
+
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
 ntsa::Error ListenerSocket::shutdown(ntsa::ShutdownType::Value direction)
 {
     NTSCFG_WARNING_UNUSED(direction);

--- a/groups/nts/ntsi/ntsi_listenersocket.h
+++ b/groups/nts/ntsi/ntsi_listenersocket.h
@@ -21,6 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #include <ntsa_endpoint.h>
 #include <ntsa_error.h>
+#include <ntsa_notificationqueue.h>
 #include <ntsa_shutdowntype.h>
 #include <ntsa_socketoption.h>
 #include <ntsa_transport.h>
@@ -146,6 +147,12 @@ class ListenerSocket : public ntsi::Descriptor
     /// the currently installed default allocator is used.
     virtual ntsa::Error accept(bsl::shared_ptr<ntsi::StreamSocket>* result,
                                bslma::Allocator* basicAllocator = 0);
+
+    /// Read data from the socket error queue. Then if the specified
+    /// 'notifications' is not null parse fetched data to extract control
+    /// messages into the specified 'notifications'. Return the error.
+    virtual ntsa::Error receiveNotifications(
+        ntsa::NotificationQueue* notifications);
 
     /// Shutdown the stream socket in the specified 'direction'. Return the
     /// error.

--- a/groups/nts/ntsi/ntsi_streamsocket.cpp
+++ b/groups/nts/ntsi/ntsi_streamsocket.cpp
@@ -94,6 +94,14 @@ ntsa::Error StreamSocket::receive(ntsa::ReceiveContext*       context,
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 
+ntsa::Error StreamSocket::receiveNotifications(
+    ntsa::NotificationQueue* notifications)
+{
+    NTSCFG_WARNING_UNUSED(notifications);
+
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
 ntsa::Error StreamSocket::shutdown(ntsa::ShutdownType::Value direction)
 {
     NTSCFG_WARNING_UNUSED(direction);

--- a/groups/nts/ntsi/ntsi_streamsocket.h
+++ b/groups/nts/ntsi/ntsi_streamsocket.h
@@ -22,6 +22,7 @@ BSLS_IDENT("$Id: $")
 #include <ntsa_buffer.h>
 #include <ntsa_endpoint.h>
 #include <ntsa_error.h>
+#include <ntsa_notificationqueue.h>
 #include <ntsa_shutdowntype.h>
 #include <ntsa_socketoption.h>
 #include <ntsa_transport.h>
@@ -296,6 +297,12 @@ class StreamSocket : public ntsi::Channel
                         void*                       data,
                         bsl::size_t                 capacity,
                         const ntsa::ReceiveOptions& options);
+
+    /// Read data from the socket error queue. Then if the specified
+    /// 'notifications' is not null parse fetched data to extract control
+    /// messages into the specified 'notifications'. Return the error.
+    virtual ntsa::Error receiveNotifications(
+        ntsa::NotificationQueue* notifications);
 
     /// Shutdown the stream socket in the specified 'direction'. Return the
     /// error.

--- a/groups/nts/ntsu/ntsu_msgzerocopyutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_msgzerocopyutil.t.cpp
@@ -1,0 +1,28 @@
+// Copyright 2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ntscfg_test.h>
+
+using namespace BloombergLP;
+
+NTSCFG_TEST_CASE(1)
+{
+}
+
+NTSCFG_TEST_DRIVER
+{
+    NTSCFG_TEST_REGISTER(1);
+}
+NTSCFG_TEST_DRIVER_END;

--- a/groups/nts/ntsu/ntsu_socketoptionutil.h
+++ b/groups/nts/ntsu/ntsu_socketoptionutil.h
@@ -71,15 +71,6 @@ struct SocketOptionUtil {
     /// according to the specified 'reuseAddress' flag. Return the error.
     static ntsa::Error setReuseAddress(ntsa::Handle socket, bool reuseAddress);
 
-    /// Set the option for the specified 'socket' that enables or disables
-    /// application of both software and hardware timestamps for incoming
-    /// data according to the specified 'timestampIncomingData' flag. Note
-    /// that if an error is returned then timestamps will never be
-    /// generated. If there is no error returned then in some cases OS can
-    /// also refuse to generate timestamps.
-    static ntsa::Error setTimestampIncomingData(ntsa::Handle socket,
-                                                bool timestampIncomingData);
-
     /// Set the option for the specified 'oscket' that controls how the
     /// operating system will linger its underlying resources after it has
     /// been closed to the specified 'linger' flag for the specified
@@ -130,12 +121,26 @@ struct SocketOptionUtil {
                                               bool         inlineFlag);
 
     /// Set the option for the specified 'socket' that enables or disables
+    /// application of both software and hardware timestamps for incoming
+    /// data according to the specified 'timestampIncomingData' flag. Note
+    /// that if an error is returned then timestamps will never be
+    /// generated. If there is no error returned then in some cases OS can
+    /// also refuse to generate timestamps.
+    static ntsa::Error setTimestampIncomingData(ntsa::Handle socket,
+                                                bool timestampIncomingData);
+
+    /// Set the option for the specified 'socket' that enables or disables
     /// application of timestamps for outgoing data according to the specified
     /// 'timestampOutgoingData' flag. Note that if an error is returned then
     /// timestamps will never be generated. If there is no error returned then
     /// in some cases OS can also refuse to generate timestamps.
     static ntsa::Error setTimestampOutgoingData(ntsa::Handle socket,
                                                 bool timestampOutgoingData);
+
+    /// Set the option for the specified 'socket' that allows Linux
+    /// MSG_ZEROCOPY mechanism usage according to the specified 'zeroCopy'
+    /// flag. Return the error.
+    static ntsa::Error setZeroCopy(ntsa::Handle socket, bool zeroCopy);
 
     /// Load into the specified 'option' the socket option of the specified
     /// 'type' for the specified 'socket'. Return the error.
@@ -218,6 +223,12 @@ struct SocketOptionUtil {
     /// timestamps for incoming data.  Return the error.
     static ntsa::Error getTimestampIncomingData(bool*        timestampFlag,
                                                 ntsa::Handle socket);
+
+    /// Load into the specified 'zeroCopyFlag' the option for the specified
+    /// 'socket' that indicates if Linux MSG_ZEROCOPY mechanism can be used.
+    ///  Return the error.
+    static ntsa::Error getZeroCopy(bool*        zeroCopyFlag,
+                                   ntsa::Handle socket);
 
     /// Load into the specified 'size' the option for the specified 'socket'
     /// that indicates the amount of space left in the send buffer. Return

--- a/groups/nts/ntsu/ntsu_socketutil.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.cpp
@@ -2213,8 +2213,16 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
         }
     }
 
+    int sendFlags = NTSU_SOCKETUTIL_SENDMSG_FLAGS;
+
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if (options.zeroCopy()) {
+        sendFlags |= ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
+    }
+#endif
+
     ssize_t sendmsgResult =
-        ::sendmsg(socket, &msg, NTSU_SOCKETUTIL_SENDMSG_FLAGS);
+        ::sendmsg(socket, &msg, sendFlags);
 
     NTSU_SOCKETUTIL_DEBUG_SENDMSG_UPDATE(msg.msg_iov,
                                          msg.msg_iovlen,

--- a/groups/nts/ntsu/ntsu_timestamputil.cpp
+++ b/groups/nts/ntsu/ntsu_timestamputil.cpp
@@ -13,23 +13,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ntsu_timestamputil.h"
+#include <ntsu_timestamputil.h>
 
 #include <bslmf_assert.h>
 #include <bsls_platform.h>
 
+// clang-format off
 #if defined(BSLS_PLATFORM_OS_LINUX)
-//keep this include separate from below includes
-//as it must precede errqueue.h inclusion
-#include <linux/time.h>
-#endif
-
-#if defined(BSLS_PLATFORM_OS_LINUX)
-#include <asm-generic/socket.h>
+#include <sys/time.h>
+#include <sys/socket.h>
 #include <linux/errqueue.h>
 #include <linux/net_tstamp.h>
 #include <linux/version.h>
 #endif
+// clang-format on
 
 namespace BloombergLP {
 namespace ntsu {

--- a/groups/nts/ntsu/ntsu_zerocopyutil.cpp
+++ b/groups/nts/ntsu/ntsu_zerocopyutil.cpp
@@ -1,0 +1,51 @@
+// Copyright 2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ntsu_zerocopyutil.h>
+
+#include <bslmf_assert.h>
+#include <bsls_platform.h>
+
+// clang-format off
+#if defined(BSLS_PLATFORM_OS_LINUX)
+#include <sys/time.h>
+#include <linux/errqueue.h>
+#include <linux/version.h>
+#include <sys/socket.h>
+#endif
+// clang-format on
+
+namespace BloombergLP {
+namespace ntsu {
+
+#if defined(BSLS_PLATFORM_OS_LINUX)
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0)
+
+BSLMF_ASSERT(ZeroCopyUtil::e_SO_ZEROCOPY == static_cast<int>(SO_ZEROCOPY));
+
+BSLMF_ASSERT(ZeroCopyUtil::e_MSG_ZEROCOPY ==
+             static_cast<int>(MSG_ZEROCOPY));
+
+BSLMF_ASSERT(ZeroCopyUtil::e_SO_EE_ORIGIN_ZEROCOPY ==
+             static_cast<int>(SO_EE_ORIGIN_ZEROCOPY));
+BSLMF_ASSERT(ZeroCopyUtil::e_SO_EE_CODE_ZEROCOPY_COPIED ==
+             static_cast<int>(SO_EE_CODE_ZEROCOPY_COPIED));
+
+#endif
+#endif
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/groups/nts/ntsu/ntsu_zerocopyutil.h
+++ b/groups/nts/ntsu/ntsu_zerocopyutil.h
@@ -1,0 +1,45 @@
+// Copyright 2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_NTSU_ZEROCOPYUTIL
+#define INCLUDED_NTSU_ZEROCOPYUTIL
+
+#include <bsls_ident.h>
+BSLS_IDENT("$Id: $")
+
+namespace BloombergLP {
+namespace ntsu {
+
+/// This struct is used to define/redefine types and constants used for Linux
+/// msg zerocopy feature.
+struct ZeroCopyUtil {
+    enum {  //copied from include/asm-generic/socket.h
+        e_SO_ZEROCOPY = 60
+    };
+
+    enum {  // copied from include/linux/socket.h
+        e_MSG_ZEROCOPY = 0x4000000
+    };
+
+    enum {  // copied from include/linux/errqueue.h
+        e_SO_EE_ORIGIN_ZEROCOPY      = 5,
+        e_SO_EE_CODE_ZEROCOPY_COPIED = 1
+    };
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/groups/nts/ntsu/package/ntsu.mem
+++ b/groups/nts/ntsu/package/ntsu.mem
@@ -1,5 +1,6 @@
 ntsu_adapterutil
 ntsu_bufferutil
+ntsu_msgzerocopyutil
 ntsu_resolverutil
 ntsu_socketutil
 ntsu_socketoptionutil

--- a/groups/nts/ntsu/package/ntsu.mem
+++ b/groups/nts/ntsu/package/ntsu.mem
@@ -1,6 +1,6 @@
 ntsu_adapterutil
 ntsu_bufferutil
-ntsu_msgzerocopyutil
+ntsu_zerocopyutil
 ntsu_resolverutil
 ntsu_socketutil
 ntsu_socketoptionutil

--- a/targets.cmake
+++ b/targets.cmake
@@ -158,6 +158,7 @@ if (${NTF_BUILD_WITH_NTS})
     ntf_component(NAME ntsa_timestamp)
     ntf_component(NAME ntsa_timestamptype)
     ntf_component(NAME ntsa_uri)
+    ntf_component(NAME ntsa_zerocopy)
 
     ntf_package_end(NAME ntsa)
 
@@ -213,10 +214,12 @@ if (${NTF_BUILD_WITH_NTS})
 
     ntf_component(NAME ntsu_adapterutil)
     ntf_component(NAME ntsu_bufferutil)
+    ntf_component(NAME ntsu_zerocopyutil)
     ntf_component(NAME ntsu_resolverutil)
     ntf_component(NAME ntsu_socketutil)
     ntf_component(NAME ntsu_socketoptionutil)
     ntf_component(NAME ntsu_timestamputil)
+
 
     ntf_package_end(NAME ntsu)
 


### PR DESCRIPTION
This PR brings support of Linux MSG_ZEROCOPY (copy avoidance mechanism) to NTS.
1. `ntsa::SocketOption` is extended with a new `allowMsgZeroCopy` option.
2. `ntsa::SendOption` is extended with a new `zeroCopy` option.
3. `ntsu::SocketUtil` send methods are enhanced to work with new option.
4. `ntsu::SocketUtil::receiveNotifications()` can now retreive results of MSG_ZEROCOPY from socket error queue.
5. There is a new class named `ntsa::ZeroCopy` which carries OS feedback regarding MSG_ZEROCOPY usage.
6. New test drivers and new test cases.
7. IPV6 TX timestamp notifications are correctly parsed now - there was a bug previously.
8. `ntsu_socketutil.t` is refactored: TX timesmaping related scenarios are extracted into separate testcases. Interaction of TX timestamps and zero copy notifications is tested.
9. `ntsi::DatagramSocket`, `ntsi::ListenerSocket` and `ntsi::StreamSocket` now have `virtual ntsa::Error receiveNotifications( ntsa::NotificationQueue* notifications);` methods so that anybody can directly read from the socket error queue (as ntsu::SocketUtil is private  part of the library)
10. `ntsu::Msgzerocopyutil` is added to support building on kernels which do not support the feature

Differnet Linux kernel versions behavior (mostly from source code analysis):

- kernel < 4.14:
     - MSG_ZEROCOPY is not supported at all.
- kernel >= 4.14 && kernel < 5.0:
    - MSG_ZEROCOPY is supported only for STREAM IPV4 & IPV6 sockets
- kernel >= 5.0:
    - MSG_ZEROCOPY is supported for STREAM & DATAGRAM IPV4 & IPV6 sockets

Observation for future implementation:
internal kernel per send `uint32_t` counter is incremented only when `SO_ZEROCOPY` socket option is set and `send()` is done with `MSG_ZEROCOPY` flag. If `MSG_ZEROCOPY` flag is not used then `send()` does not increment the counter. Also, if during socket lifetime `SO_ZEROCOPY` socket option is disabled (set to `false`) then the counter is not reset to 0, so when `SO_ZEROCOPY` option is set back to `true` the counter continues to grow from its previous value.
