### PR TITLE
Merge backwards-incompatible ntci::Proactor::detachSocketAsync with detachSocket

### DIFF
--- a/groups/ntc/ntcd/ntcd_proactor.cpp
+++ b/groups/ntc/ntcd/ntcd_proactor.cpp
@@ -74,14 +74,6 @@ BSLS_IDENT_RCSID(ntcd_proactor_cpp, "$Id$ $CSID$")
 namespace BloombergLP {
 namespace ntcd {
 
-namespace {
-
-// The flag that defines whether all waiters are interrupted when the polling
-// device gains or loses interest in socket events.
-const bool k_INTERRUPT_ALL = false;
-
-}  // close unnamed namespace
-
 /// This struct describes the context of a waiter.
 struct Proactor::Result {
   public:
@@ -1477,44 +1469,6 @@ ntsa::Error Proactor::cancel(
 }
 
 ntsa::Error Proactor::detachSocket(
-    const bsl::shared_ptr<ntci::ProactorSocket>& socket)
-{
-    ntsa::Error error;
-
-    ntsa::Handle handle = socket->handle();
-
-    {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_workMapMutex);
-
-        WorkMap::iterator it = d_workMap.find(handle);
-        if (it == d_workMap.end()) {
-            return ntsa::Error(ntsa::Error::e_INVALID);
-        }
-
-        d_workMap.erase(it);
-    }
-
-    socket->setProactorContext(bsl::shared_ptr<void>());
-
-    bsl::shared_ptr<ntcs::RegistryEntry> entry =
-        d_registry_sp->remove(socket->handle());
-
-    if (NTCCFG_LIKELY(entry)) {
-        error = d_monitor_sp->remove(entry->handle());
-        if (error) {
-            return error;
-        }
-        if (k_INTERRUPT_ALL) {
-            this->interruptAll();
-        }
-        return ntsa::Error();
-    }
-    else {
-        return ntsa::Error();
-    }
-}
-
-ntsa::Error Proactor::detachSocketAsync(
     const bsl::shared_ptr<ntci::ProactorSocket>& socket)
 {
     ntsa::Error error;

--- a/groups/ntc/ntcd/ntcd_proactor.h
+++ b/groups/ntc/ntcd/ntcd_proactor.h
@@ -299,11 +299,6 @@ class Proactor : public ntci::Proactor,
     ntsa::Error detachSocket(const bsl::shared_ptr<ntci::ProactorSocket>&
                                  socket) BSLS_KEYWORD_OVERRIDE;
 
-    /// Detach the specified 'socket' from the proactor. The specified 'socket'
-    /// will be notified when it's detached. Return the error.
-    ntsa::Error detachSocketAsync(const bsl::shared_ptr<ntci::ProactorSocket>&
-                                 socket) BSLS_KEYWORD_OVERRIDE;
-
     /// Close all monitored sockets and timers.
     ntsa::Error closeAll() BSLS_KEYWORD_OVERRIDE;
 

--- a/groups/ntc/ntcd/ntcd_proactor.t.cpp
+++ b/groups/ntc/ntcd/ntcd_proactor.t.cpp
@@ -1660,17 +1660,17 @@ NTCCFG_TEST_CASE(1)
 
         // Detach the server from the proactor.
 
-        error = proactor->detachSocketAsync(server);
+        error = proactor->detachSocket(server);
         NTCCFG_TEST_OK(error);
 
         // Detach the client from the proactor.
 
-        error = proactor->detachSocketAsync(client);
+        error = proactor->detachSocket(client);
         NTCCFG_TEST_OK(error);
 
         // Detach the listener from the proactor.
 
-        proactor->detachSocketAsync(listener);
+        proactor->detachSocket(listener);
         NTCCFG_TEST_OK(error);
 
         while (!server->pollForDetachment() || !client->pollForDetachment() ||

--- a/groups/ntc/ntci/ntci_proactor.h
+++ b/groups/ntc/ntci/ntci_proactor.h
@@ -125,15 +125,7 @@ class Proactor : public ntci::Driver, public ntci::ProactorPool
         const bsl::shared_ptr<ntci::ProactorSocket>& socket) = 0;
 
     /// Detach the specified 'socket' from the proactor. Return the error.
-    BSLS_DEPRECATE_FEATURE("ntci",
-                           "socket-detachment",
-                           "use detachSocketAsync instead")
     virtual ntsa::Error detachSocket(
-        const bsl::shared_ptr<ntci::ProactorSocket>& socket) = 0;
-
-    /// Detach the specified 'socket' from the proactor. The specified 'socket'
-    /// will be notified when it's detached. Return the error.
-    virtual ntsa::Error detachSocketAsync(
         const bsl::shared_ptr<ntci::ProactorSocket>& socket) = 0;
 
     /// Close all monitored sockets and timers.

--- a/groups/ntc/ntci/ntci_proactorsocket.h
+++ b/groups/ntc/ntci/ntci_proactorsocket.h
@@ -98,7 +98,8 @@ class ProactorSocket : public ntci::ProactorSocketBase, public ntsi::Descriptor
     /// Process the specified 'error' that has occurred on the socket.
     virtual void processSocketError(const ntsa::Error& error);
 
-    /// Process the completion of socket detachment
+    /// Process the completion of the detachment of this socket from its 
+    /// proactor.
     virtual void processSocketDetached();
 
     /// Close the stream socket.

--- a/groups/ntc/ntco/ntco_iocp.cpp
+++ b/groups/ntc/ntco/ntco_iocp.cpp
@@ -422,10 +422,6 @@ class Iocp : public ntci::Proactor,
                                  socket) BSLS_KEYWORD_OVERRIDE;
     // Detach the specified 'socket' from the proactor. Return the error.
 
-    ntsa::Error detachSocketAsync(const bsl::shared_ptr<ntci::ProactorSocket>&
-                                      socket) BSLS_KEYWORD_OVERRIDE;
-    // Detach the specified 'socket' from the proactor. Return the error.
-
     ntsa::Error closeAll() BSLS_KEYWORD_OVERRIDE;
     // Close all monitored sockets and timers.
 
@@ -2431,12 +2427,6 @@ ntsa::Error Iocp::cancel(const bsl::shared_ptr<ntci::ProactorSocket>& socket)
 }
 
 ntsa::Error Iocp::detachSocket(
-    const bsl::shared_ptr<ntci::ProactorSocket>& socket)
-{
-    return detachSocketAsync(socket);
-}
-
-ntsa::Error Iocp::detachSocketAsync(
     const bsl::shared_ptr<ntci::ProactorSocket>& socket)
 {
     ntsa::Error error;

--- a/groups/ntc/ntco/ntco_iocp.t.cpp
+++ b/groups/ntc/ntco/ntco_iocp.t.cpp
@@ -1708,7 +1708,7 @@ NTCCFG_TEST_CASE(1)
 
         // Detach the server from the proactor.
 
-        error = proactor->detachSocketAsync(server);
+        error = proactor->detachSocket(server);
         NTCCFG_TEST_OK(error);
 
         // Wait for the server to become detached from the proactor.
@@ -1719,7 +1719,7 @@ NTCCFG_TEST_CASE(1)
 
         // Detach the client from the proactor.
 
-        error = proactor->detachSocketAsync(client);
+        error = proactor->detachSocket(client);
         NTCCFG_TEST_OK(error);
 
         // Wait for the client to become detached from the proactor.
@@ -1730,7 +1730,7 @@ NTCCFG_TEST_CASE(1)
 
         // Detach the listener from the proactor.
 
-        proactor->detachSocketAsync(listener);
+        proactor->detachSocket(listener);
         NTCCFG_TEST_OK(error);
 
         // Wait for the listener to become detached from the proactor.

--- a/groups/ntc/ntco/ntco_ioring.cpp
+++ b/groups/ntc/ntco/ntco_ioring.cpp
@@ -4643,11 +4643,6 @@ class IoRing : public ntci::Proactor,
     ntsa::Error detachSocket(const bsl::shared_ptr<ntci::ProactorSocket>&
                                  socket) BSLS_KEYWORD_OVERRIDE;
 
-    // Detach the specified 'socket' from the proactor. The specified 'socket'
-    // will be notified when it's detached. Return the error.
-    ntsa::Error detachSocketAsync(const bsl::shared_ptr<ntci::ProactorSocket>&
-                                      socket) BSLS_KEYWORD_OVERRIDE;
-
     // Close all monitored sockets and timers.
     ntsa::Error closeAll() BSLS_KEYWORD_OVERRIDE;
 
@@ -5905,12 +5900,6 @@ ntsa::Error IoRing::cancel(const bsl::shared_ptr<ntci::ProactorSocket>& socket)
 }
 
 ntsa::Error IoRing::detachSocket(
-    const bsl::shared_ptr<ntci::ProactorSocket>& socket)
-{
-    return detachSocketAsync(socket);
-}
-
-ntsa::Error IoRing::detachSocketAsync(
     const bsl::shared_ptr<ntci::ProactorSocket>& socket)
 {
     ntsa::Error error;

--- a/groups/ntc/ntcp/ntcp_datagramsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_datagramsocket.cpp
@@ -1509,7 +1509,7 @@ bool DatagramSocket::privateCloseFlowControl(
             BSLS_ASSERT(d_detachState.get() !=
                         ntcs::DetachState::e_DETACH_INITIATED);
             proactorRef->cancel(self);
-            const ntsa::Error error = proactorRef->detachSocketAsync(self);
+            const ntsa::Error error = proactorRef->detachSocket(self);
             if (NTCCFG_UNLIKELY(error)) {
                 return false;
             }

--- a/groups/ntc/ntcp/ntcp_listenersocket.cpp
+++ b/groups/ntc/ntcp/ntcp_listenersocket.cpp
@@ -1148,7 +1148,7 @@ bool ListenerSocket::privateCloseFlowControl(
             BSLS_ASSERT(d_detachState.get() !=
                         ntcs::DetachState::e_DETACH_INITIATED);
             proactorRef->cancel(self);
-            const ntsa::Error error = proactorRef->detachSocketAsync(self);
+            const ntsa::Error error = proactorRef->detachSocket(self);
             if (NTCCFG_UNLIKELY(error)) {
                 return false;
             }

--- a/groups/ntc/ntcp/ntcp_streamsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.cpp
@@ -919,7 +919,7 @@ void StreamSocket::privateFailConnect(
                 if (proactorRef) {
                     proactorRef->cancel(self);
                     const ntsa::Error error =
-                        proactorRef->detachSocketAsync(self);
+                        proactorRef->detachSocket(self);
                     if (NTCCFG_LIKELY(!error)) {
                         d_detachState.set(
                             ntcs::DetachState::e_DETACH_INITIATED);
@@ -952,7 +952,7 @@ void StreamSocket::privateFailConnect(
                 if (proactorRef) {
                     proactorRef->cancel(self);
                     const ntsa::Error error =
-                        proactorRef->detachSocketAsync(self);
+                        proactorRef->detachSocket(self);
                     if (NTCCFG_LIKELY(!error)) {
                         d_detachState.set(
                             ntcs::DetachState::e_DETACH_INITIATED);
@@ -2404,7 +2404,7 @@ bool StreamSocket::privateCloseFlowControl(
             BSLS_ASSERT(d_detachState.get() !=
                         ntcs::DetachState::e_DETACH_INITIATED);
             proactorRef->cancel(self);
-            const ntsa::Error error = proactorRef->detachSocketAsync(self);
+            const ntsa::Error error = proactorRef->detachSocket(self);
             if (NTCCFG_UNLIKELY(error)) {
                 return false;
             }


### PR DESCRIPTION
During the implementation of asynchronous detachment of a proactor socket from its proactor, a new function was introduced: `ntci::Proactor::detachSocketAsync`. This function was declared pure-virtual but all implementations were enhanced to simply make `ntci::Proactor::detachSocketAsync` synonymous with the existing function `ntci::Proactor::detachSocket`. This change breaks existing implementations of `ntci::Proactor` that do not upgrade in lock-step with the commit that introduced `ntci::Proactor::detachSocketAsync`.

This PR removes `ntci::Proactor::detachSocketAsync` and codifies that all calls to `ntci::Proactor::detachSocket` execute asynchronously and notify the caller when detachment is complete by calling `ntci::ProactorSocket::processSocketDetached`.