### PR TITLE
Correctly reschedule an initially non-recurring timer when a new definite period is specified

### DIFF
--- a/groups/ntc/ntci/ntci_timer.h
+++ b/groups/ntc/ntci/ntci_timer.h
@@ -770,17 +770,17 @@ class Timer
     /// timer will be announced as cancelled instead),
     /// 'ntsa::Error::e_INVALID' if the 'timer' has not been registered or
     /// already removed, and 'ntsa::Error::e_OK' if this timer's deadline
-    /// has already occured, is not recurring nor has been rescheduled.
+    /// has already occurred, is not recurring nor has been rescheduled.
     virtual ntsa::Error cancel() = 0;
 
-    /// Cancel this timer if its deadline has not already occured, close the
+    /// Cancel this timer if its deadline has not already occurred, close the
     /// timer for subsequent scheduling, and remove its resources. Return
     /// the error, notably 'ntca::Error::e_CANCELED' if another occurrence
     /// of this timer's deadline is scheduled but has not yet occurred (in
     /// which case the timer will be announced as cancelled instead),
     /// 'ntsa::Error::e_INVALID' if the 'timer' has not been registered or
     /// already removed, and 'ntsa::Error::e_OK' if this timer's deadline
-    /// has already occured, is not recurring nor has been rescheduled.
+    /// has already occurred, is not recurring nor has been rescheduled.
     virtual ntsa::Error close() = 0;
 
     /// Announce the arrival of the last specified 'deadline' of this timer,

--- a/groups/ntc/ntcs/ntcs_chronology.cpp
+++ b/groups/ntc/ntcs/ntcs_chronology.cpp
@@ -302,7 +302,7 @@ ntsa::Error Chronology::Timer::schedule(const bsls::TimeInterval& deadline,
             return ntsa::Error(ntsa::Error::e_INVALID);
         }
 
-        d_period = period;
+        d_period = effectivePeriod;
         d_state  = e_STATE_SCHEDULED;
     }
 
@@ -321,17 +321,13 @@ ntsa::Error Chronology::Timer::schedule(const bsls::TimeInterval& deadline,
             if (deadlineInMicroseconds == 0) {
                 d_deadlineMapHandle = d_chronology_p->d_deadlineMap.addL(
                     deadlineInMicroseconds,
-                    DeadlineMapEntry(d_node_p,
-                                     effectivePeriod,
-                                     d_options.oneShot()),
+                    DeadlineMapEntry(d_node_p),
                     &newFrontFlag);
             }
             else {
                 d_deadlineMapHandle = d_chronology_p->d_deadlineMap.addR(
                     deadlineInMicroseconds,
-                    DeadlineMapEntry(d_node_p,
-                                     effectivePeriod,
-                                     d_options.oneShot()),
+                    DeadlineMapEntry(d_node_p),
                     &newFrontFlag);
             }
 
@@ -1089,7 +1085,7 @@ void Chronology::announce()
                     timerDeadlineInMicroseconds);
 
                 const bool isRecurring =
-                    entry.d_period != bsls::TimeInterval();
+                    timer->d_period != bsls::TimeInterval();
 
                 NTCS_CHRONOLOGY_LOG_POP(nowInMicroseconds,
                                         timer,
@@ -1098,21 +1094,21 @@ void Chronology::announce()
 #if NTCCFG_PLATFORM_COMPILER_SUPPORTS_LAMDAS
                 timersDue.emplace_back(entry.d_node_p,
                                        timerDeadline,
-                                       entry.d_period,
-                                       entry.d_oneShot,
+                                       timer->d_period,
+                                       timer->d_options.oneShot(),
                                        isRecurring);
 #else
                 timersDue.push_back(DueEntry(entry.d_node_p,
                                              timerDeadline,
-                                             entry.d_period,
-                                             entry.d_oneShot,
+                                             timer->d_period,
+                                             timer->d_options.oneShot(),
                                              isRecurring));
 #endif
 
                 if (NTCCFG_UNLIKELY(isRecurring)) {
                     Microseconds nextDeadlineInMicroseconds =
                         timerDeadlineInMicroseconds +
-                        entry.d_period.totalMicroseconds();
+                        timer->d_period.totalMicroseconds();
 
                     if (nextDeadlineInMicroseconds < nowInMicroseconds) {
                         nextDeadlineInMicroseconds = nowInMicroseconds;

--- a/groups/ntc/ntcs/ntcs_chronology.h
+++ b/groups/ntc/ntcs/ntcs_chronology.h
@@ -78,23 +78,15 @@ class Chronology
     struct DeadlineMapEntry {
         DeadlineMapEntry()
         : d_node_p(0)
-        , d_period()
-        , d_oneShot(false)
         {
         }
 
-        DeadlineMapEntry(TimerNode*                node,
-                         const bsls::TimeInterval& period,
-                         bool                      oneShot)
+        explicit DeadlineMapEntry(TimerNode* node)
         : d_node_p(node)
-        , d_period(period)
-        , d_oneShot(oneShot)
         {
         }
 
-        TimerNode*         d_node_p;
-        bsls::TimeInterval d_period;
-        const bool         d_oneShot;
+        TimerNode* d_node_p;
 
         NTCCFG_DECLARE_NESTED_BITWISE_MOVABLE_TRAITS(DeadlineMapEntry);
     };


### PR DESCRIPTION
There is a bug  when a timer is rescheduled and transitions from non-recurring to recurring. The bug occurs in the following sequence of operations:

1) A non-oneshot timer is created and scheduled to some deadline far in the future
2) The timer is quickly rescheduled to some near deadline and assigned a period by which it recurrs
3) The timer fires at the initial deadline but does not subsequently fire (i.e. the period is not honored)

It's possible that this bug was introduced `ntcs::Chronology` was revised to become implemented by `ntcs::SkipList`: when we update the `ntcs::Chronology::DeadlineMapEntry` in the skip list (rather than adding a new entry) we do not update the initial period to the new period. It's also possible this bug pre-dated that revision, however.

In any case, the current `ntcs::SkipList`-based implementation does not need `ntcs::Chronology::DeadlineMapEntry::d_period` nor `d_oneShot`, we can always safely access those fields from the associated `ntci::Timer` object itself, which are always written to a read from the same `ntcs::Chronology::d_mutex`.

This PR removes those fields from `ntcs::Chronology::DeadlineMapEntry` and uses the necessary fields directly from `ntci::Timer`.