### PR TITLE
Selectively disable -Wmaybe-uninitialized

### DIFF
--- a/groups/ntc/ntcdns/ntcdns_client.cpp
+++ b/groups/ntc/ntcdns/ntcdns_client.cpp
@@ -176,6 +176,14 @@
             << NTCI_LOG_STREAM_END;                                           \
     } while (false)
 
+
+// Some versions of GCC erroneously warn when 'timeToLive.value()' is
+// called even when protected by a check of '!timeToLive.isNull()'.
+#if defined(BSLS_PLATFORM_CMP_GNU)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 namespace BloombergLP {
 namespace ntcdns {
 
@@ -372,13 +380,6 @@ void ClientGetIpAddressOperation::processResponse(
     bsl::size_t               serverIndex,
     const bsls::TimeInterval& now)
 {
-    // Some versions of GCC erroneously warn when 'timeToLive.value()' is
-    // called even when protected by a check of '!timeToLive.isNull()'.
-#if defined(BSLS_PLATFORM_CMP_GNU)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-
     NTCI_LOG_CONTEXT();
 
     ntsa::Error error;
@@ -545,10 +546,6 @@ void ClientGetIpAddressOperation::processResponse(
 
     d_resolver_sp.reset();
     d_serverList.clear();
-
-#if defined(BSLS_PLATFORM_CMP_GNU)
-#pragma GCC diagnostic pop
-#endif
 }
 
 void ClientGetIpAddressOperation::processError(const ntsa::Error& error)

--- a/groups/ntc/ntcp/ntcp_datagramsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_datagramsocket.cpp
@@ -155,6 +155,13 @@ BSLS_IDENT_RCSID(ntcp_datagramsocket_cpp, "$Id$ $CSID$")
     NTCI_LOG_TRACE("Datagram socket "                                         \
                    "is shutting down transmission")
 
+// Some versions of GCC erroneously warn ntcs::ObserverRef::d_shared may be
+// uninitialized.
+#if defined(BSLS_PLATFORM_CMP_GNU)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 namespace BloombergLP {
 namespace ntcp {
 

--- a/groups/ntc/ntcp/ntcp_listenersocket.cpp
+++ b/groups/ntc/ntcp/ntcp_listenersocket.cpp
@@ -131,6 +131,13 @@ BSLS_IDENT_RCSID(ntcp_listenersocket_cpp, "$Id$ $CSID$")
     NTCI_LOG_TRACE("Listener socket "                                         \
                    "is shutting down acceptance")
 
+// Some versions of GCC erroneously warn ntcs::ObserverRef::d_shared may be
+// uninitialized.
+#if defined(BSLS_PLATFORM_CMP_GNU)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 namespace BloombergLP {
 namespace ntcp {
 

--- a/groups/ntc/ntcp/ntcp_streamsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.cpp
@@ -197,6 +197,13 @@ BSLS_IDENT_RCSID(ntcp_streamsocket_cpp, "$Id$ $CSID$")
     NTCI_LOG_TRACE("Stream socket "                                           \
                    "is shutting down transmission")
 
+// Some versions of GCC erroneously warn ntcs::ObserverRef::d_shared may be
+// uninitialized.
+#if defined(BSLS_PLATFORM_CMP_GNU)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 namespace BloombergLP {
 namespace ntcp {
 

--- a/groups/ntc/ntcr/ntcr_datagramsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.cpp
@@ -206,6 +206,13 @@ BSLS_IDENT_RCSID(ntcr_datagramsocket_cpp, "$Id$ $CSID$")
 #define NTCR_DATAGRAMSOCKET_LOG_RX_DELAY(delay, type)
 #endif
 
+// Some versions of GCC erroneously warn ntcs::ObserverRef::d_shared may be
+// uninitialized.
+#if defined(BSLS_PLATFORM_CMP_GNU)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 namespace BloombergLP {
 namespace ntcr {
 

--- a/groups/ntc/ntcr/ntcr_listenersocket.cpp
+++ b/groups/ntc/ntcr/ntcr_listenersocket.cpp
@@ -137,6 +137,13 @@ BSLS_IDENT_RCSID(ntcr_listenersocket_cpp, "$Id$ $CSID$")
     NTCI_LOG_TRACE("Listener socket "                                         \
                    "is shutting down acceptance")
 
+// Some versions of GCC erroneously warn ntcs::ObserverRef::d_shared may be
+// uninitialized.
+#if defined(BSLS_PLATFORM_CMP_GNU)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 namespace BloombergLP {
 namespace ntcr {
 

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -261,6 +261,13 @@ BSLS_IDENT_RCSID(ntcr_streamsocket_cpp, "$Id$ $CSID$")
 #define NTCR_STREAMSOCKET_LOG_RX_DELAY(delay, type)
 #endif
 
+// Some versions of GCC erroneously warn ntcs::ObserverRef::d_shared may be
+// uninitialized.
+#if defined(BSLS_PLATFORM_CMP_GNU)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 namespace BloombergLP {
 namespace ntcr {
 

--- a/groups/ntc/ntcs/ntcs_strand.cpp
+++ b/groups/ntc/ntcs/ntcs_strand.cpp
@@ -87,6 +87,13 @@ BSLS_IDENT_RCSID(ntcs_strand_cpp, "$Id$ $CSID$")
 // Define the strand implementation algorithm.
 #define NTCS_STRAND_IMP NTCS_STRAND_IMP_GREEDY
 
+// Some versions of GCC erroneously warn ntcs::ObserverRef::d_shared may be
+// uninitialized.
+#if defined(BSLS_PLATFORM_CMP_GNU)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 // IMPLEMENTATION NOTES: Testing indicates that, with 10 threads driving the
 // reactor utilized by a strand, fair algorithm achieves 250,000 functors per
 // second, evenly distributed across all threads, while the greedy algorithm


### PR DESCRIPTION
GCC 11 and 12 errorneously issue -Wmaybe-uninitialized compiling certain parts of the implementation of BDE and NTF. Selectively disable that warning in the affected translation units.