### PR TITLE
Ensure that reading from error queue does not hang if the socket is in a blocking mode or ::recvmsg returns 0

### DIFF
--- a/groups/nts/ntsu/ntsu_socketutil.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.cpp
@@ -3492,16 +3492,14 @@ ntsa::Error SocketUtil::receiveNotifications(
         const ssize_t recvMsgResult =
             ::recvmsg(socket, &msg, MSG_ERRQUEUE | MSG_DONTWAIT);
 
-        if (recvMsgResult == 0) {
+        // Check that if ::recvmsg returned 0 that there is really some data
+        // inside the control message
+        if (0 == recvMsgResult && 0 == CMSG_FIRSTHDR(&msg)) {
             return ntsa::Error();
         }
 
         if (recvMsgResult < 0) {
-#if EWOULDBLOCK != EAGAIN
-            if (errno == EWOULDBLOCK || errno == EAGAIN) {
-#else
-            if (errno == EWOULDBLOCK) {
-#endif
+            if (errno == EAGAIN) {
                 return ntsa::Error();
             }
             else {

--- a/groups/nts/ntsu/ntsu_socketutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.t.cpp
@@ -2493,16 +2493,126 @@ void testStreamSocketTxTimestampsAndZeroCopy(ntsa::Transport::Value transport,
     }
 }
 
-/// Comparator with is used to help sorting Timestamps according to their time
-/// value.
-struct TimestampTimeComparator {
-    /// Return true if the specified 'a' occurred earlier than the specified
-    /// 'b'. Otherwise return false.
-    bool operator()(const ntsa::Timestamp& a, const ntsa::Timestamp& b)
+void testStreamSocketReceiveNotifications(ntsa::Transport::Value transport,
+                                          ntsa::Handle           server,
+                                          ntsa::Handle           client,
+                                          bslma::Allocator*      allocator)
+{
+    NTSCFG_TEST_LOG_DEBUG << "Testing " << transport << NTSCFG_TEST_LOG_END;
+
+    ntsa::Error error;
+
+    error = ntsu::SocketOptionUtil::setBlocking(client, true);
+    NTSCFG_TEST_OK(error);
+    error = ntsu::SocketOptionUtil::setBlocking(server, true);
+    NTSCFG_TEST_OK(error);
+
     {
-        return a.time() < b.time();
+        ntsa::NotificationQueue notifications;
+        ntsu::SocketUtil::receiveNotifications(&notifications, client);
+        ntsu::SocketUtil::receiveNotifications(&notifications, server);
     }
-};
+
+    const int msgSize = 200;
+    bsl::vector<char> message(msgSize, allocator);
+    for (int i = 0; i < msgSize; ++i) {
+        message[i] = bsl::rand() % 100;
+    }
+    const ntsa::Data sendData(
+        ntsa::ConstBuffer(message.data(), message.size()));
+    int totalSend = 0;
+    {
+
+        ntsa::SendContext context;
+        ntsa::SendOptions options;
+
+        error = ntsu::SocketUtil::send(&context, sendData, options, client);
+        NTSCFG_TEST_OK(error);
+        totalSend = context.bytesSent();
+    }
+
+    bsl::vector<char> rBuffer(msgSize, allocator);
+
+    while(totalSend != 0)
+    {
+        ntsa::ReceiveContext context;
+        ntsa::ReceiveOptions options;
+
+        ntsa::Data data(ntsa::MutableBuffer(rBuffer.data(), rBuffer.size()));
+
+        error = ntsu::SocketUtil::receive(&context, &data, options, server);
+        if (!error) {
+            totalSend -= context.bytesReceived();
+        }
+    }
+    {
+        ntsa::NotificationQueue notifications;
+        ntsu::SocketUtil::receiveNotifications(&notifications, client);
+        ntsu::SocketUtil::receiveNotifications(&notifications, server);
+    }
+}
+
+void testDatagramSocketReceiveNotifications(ntsa::Transport::Value transport,
+                                            ntsa::Handle           server,
+                                            const ntsa::Endpoint&  serverEndpoint,
+                                            ntsa::Handle           client,
+                                            const ntsa::Endpoint&  clientEndpoint,
+                                            bslma::Allocator*      allocator)
+{
+    NTSCFG_TEST_LOG_DEBUG << "Testing " << transport << NTSCFG_TEST_LOG_END;
+
+    ntsa::Error error;
+
+    error = ntsu::SocketOptionUtil::setBlocking(client, true);
+    NTSCFG_TEST_OK(error);
+    error = ntsu::SocketOptionUtil::setBlocking(server, true);
+    NTSCFG_TEST_OK(error);
+
+    {
+        ntsa::NotificationQueue notifications;
+        ntsu::SocketUtil::receiveNotifications(&notifications, client);
+        ntsu::SocketUtil::receiveNotifications(&notifications, server);
+    }
+
+    const int msgSize = 200;
+    bsl::vector<char> message(msgSize, allocator);
+    for (int i = 0; i < msgSize; ++i) {
+        message[i] = bsl::rand() % 100;
+    }
+    const ntsa::Data sendData(
+        ntsa::ConstBuffer(message.data(), message.size()));
+    int totalSend = 0;
+    {
+
+        ntsa::SendContext context;
+        ntsa::SendOptions options;
+        options.setEndpoint(serverEndpoint);
+
+        error = ntsu::SocketUtil::send(&context, sendData, options, client);
+        NTSCFG_TEST_OK(error);
+        totalSend = context.bytesSent();
+    }
+
+    bsl::vector<char> rBuffer(msgSize, allocator);
+
+    while(totalSend != 0)
+    {
+        ntsa::ReceiveContext context;
+        ntsa::ReceiveOptions options;
+
+        ntsa::Data data(ntsa::MutableBuffer(rBuffer.data(), rBuffer.size()));
+
+        error = ntsu::SocketUtil::receive(&context, &data, options, server);
+        if (!error) {
+            totalSend -= context.bytesReceived();
+        }
+    }
+    {
+        ntsa::NotificationQueue notifications;
+        ntsu::SocketUtil::receiveNotifications(&notifications, client);
+        ntsu::SocketUtil::receiveNotifications(&notifications, server);
+    }
+}
 
 }  // close namespace 'test'
 
@@ -7983,6 +8093,39 @@ NTSCFG_TEST_CASE(32)
 #endif
 }
 
+
+NTSCFG_TEST_CASE(33)
+{
+    // Concern: test that for stream sockets configured in a blocking mode
+    // attempt to read data from the socket error queue does not lead to a
+    // blocking ::recvmsg call. Also check that even if socket has some data
+    // in its receive buffer and call to ::recvmsg can return 0,
+    // receiveNotifications does not hang in an endless loop.
+
+    ntscfg::TestAllocator ta;
+    {
+        test::executeStreamSocketTest(
+            &test::testStreamSocketReceiveNotifications);
+    }
+    NTSCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTSCFG_TEST_CASE(34)
+{
+    // Concern: test that for datagram sockets configured in a blocking mode
+    // attempt to read data from the socket error queue does not lead to a
+    // blocking ::recvmsg call. Also check that even if socket has some data
+    // in its receive buffer and call to ::recvmsg can return 0,
+    // receiveNotifications does not hang in an endless loop.
+
+    ntscfg::TestAllocator ta;
+    {
+        test::executeDatagramSocketTest(
+            &test::testDatagramSocketReceiveNotifications);
+    }
+    NTSCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
 NTSCFG_TEST_DRIVER
 {
     NTSCFG_TEST_REGISTER(1);
@@ -8017,5 +8160,7 @@ NTSCFG_TEST_DRIVER
     NTSCFG_TEST_REGISTER(30);
     NTSCFG_TEST_REGISTER(31);
     NTSCFG_TEST_REGISTER(32);
+    NTSCFG_TEST_REGISTER(33);
+    NTSCFG_TEST_REGISTER(34);
 }
 NTSCFG_TEST_DRIVER_END;


### PR DESCRIPTION
It appears that Linux kernel v3.10 behaves differently from newer kernel versions:
1) Call to ```::recvmsg(socket, &msg, MSG_ERRQUEUE);``` can be blocking
2) Call to ```::recvmsg(socket, &msg, MSG_ERRQUEUE);``` can also return 0.

This PR fixes such behavior and adds some test cases for that.