### PR TITLE
Ensure upgrade callbacks are correctly reset when shutting down sending while a TLS upgrade is in-progress

### DIFF
--- a/groups/ntc/ntcp/ntcp_streamsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.cpp
@@ -1964,13 +1964,20 @@ void StreamSocket::privateShutdownSequencePart2(
 
         if (d_upgradeInProgress) {
             ntca::UpgradeContext upgradeContext;
-            upgradeContext.setError(ntsa::Error(ntsa::Error::e_CANCELLED));
+
+            if (context.shutdownOrigin() == ntsa::ShutdownOrigin::e_SOURCE) {
+                upgradeContext.setError(ntsa::Error(ntsa::Error::e_CANCELLED));
+            }
+            else {
+                upgradeContext.setError(
+                    ntsa::Error(ntsa::Error::e_CONNECTION_DEAD));
+            }
 
             d_upgradeInProgress = false;
             d_encryption_sp.reset();
 
             ntci::UpgradeCallback upgradeCallback = d_upgradeCallback;
-            d_connectCallback.reset();
+            d_upgradeCallback.reset();
 
             ntca::UpgradeEvent upgradeEvent;
             upgradeEvent.setType(ntca::UpgradeEventType::e_ERROR);

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -2037,13 +2037,20 @@ void StreamSocket::privateShutdownSequenceComplete(
 
         if (d_upgradeInProgress) {
             ntca::UpgradeContext upgradeContext;
-            upgradeContext.setError(ntsa::Error(ntsa::Error::e_CANCELLED));
+
+            if (context.shutdownOrigin() == ntsa::ShutdownOrigin::e_SOURCE) {
+                upgradeContext.setError(ntsa::Error(ntsa::Error::e_CANCELLED));
+            }
+            else {
+                upgradeContext.setError(
+                    ntsa::Error(ntsa::Error::e_CONNECTION_DEAD));
+            }
 
             d_upgradeInProgress = false;
             d_encryption_sp.reset();
 
             ntci::UpgradeCallback upgradeCallback = d_upgradeCallback;
-            d_connectCallback.reset();
+            d_upgradeCallback.reset();
 
             ntca::UpgradeEvent upgradeEvent;
             upgradeEvent.setType(ntca::UpgradeEventType::e_ERROR);


### PR DESCRIPTION
When a peer closes the TCP connection when an upgrade is in-progress, we announce the upgrade as failed because of `e_CANCELED`, then proceed through the standard shutdown sequence, releasing all reference counts as needed. There is a bug in handling the in-progress upgrade however: instead of explicitly resetting `d_upgradeCallback` we erroneously reset `d_connectCallback`, so the upgrade callback is not destroyed by time we announce the socket is closed. If the user places something into the binding of this callback, such as a reference to the socket itself, we have a circular reference outstanding and a leak.

This PR fixes `ntcr_streamsocket` and `ntcp_streamsocket` replacing `d_connectCallback.reset()` with `d_upgradeCallback.reset()` in the affective code paths and announces e_CANCELED only when we initiate the shutdown sequence; when the peer initiates the shutdown sequence during an upgrade in-progress we now announce 'e_CONNECTION_DEAD'.