### PR TITLE
Remove -fcoroutines-ts flag when clang (>= 16.0) is used

### DIFF
--- a/repository.cmake
+++ b/repository.cmake
@@ -577,12 +577,15 @@ function (ntf_target_options_common_prolog target)
             ntf_target_build_option(
                 TARGET ${target} COMPILE LINK VALUE -fexceptions)
 
-            if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-                ntf_target_build_option(
-                    TARGET ${target} COMPILE LINK VALUE -fcoroutines-ts)
-            elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-                ntf_target_build_option(
-                    TARGET ${target} COMPILE LINK VALUE -fcoroutines)
+            if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+                if(DEFINED CMAKE_CXX_COMPILER_VERSION
+                    AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16.0)
+                    ntf_target_build_option(TARGET ${target} COMPILE LINK VALUE
+                        -fcoroutines-ts)
+                endif()
+            else() #GCC
+                ntf_target_build_option(TARGET ${target} COMPILE LINK VALUE
+                        -fcoroutines)
             endif()
 
             ntf_target_build_option(


### PR DESCRIPTION
- `-fcoroutines-ts` was deprecated in `clang 16.0`
- `-fcoroutines-ts` was removed in `clang 17.0`
- `clang 16`, `clang 17` and `clang 18` do not like `-fcoroutines` flag either


Some examples of errorsI encountered when trying to use either `-fcoroutines-ts` or `-fcoroutines` flag with modern clang:

- CLANG-16, CPP20 DBG
> clang-16: error: the '-fcoroutines-ts' flag is deprecated and it will be removed in Clang 17; use '-std=c++20' or higher to use standard C++ coroutines instead [-Werror,-Wdeprecated-experimental-coroutine]

- CLANG-18, CPP03 DBG
> clang++clang++: : warning: argument unused during compilation: '-fcoroutines' [-Wunused-command-line-argument]

- CLANG-18, CPP20 DBG
> clang++clang++: : error: error: argument unused during compilation: '-fcoroutines' [-Werror,-Wunused-command-line-argument]

- CLANG-18, CPP20 OPT
> clang++: error: argument unused during compilation: '-fcoroutines' [-Werror,-Wunused-command-line-argument]
