### PR TITLE
Defer StreamSocket shutdown execution if the socket is waiting for detachment to be finished

### DIFF
--- a/groups/ntc/ntcp/ntcp_streamsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.cpp
@@ -5632,6 +5632,14 @@ ntsa::Error StreamSocket::shutdown(ntsa::ShutdownType::Value direction,
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
     NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
 
+    if (d_detachState.get() == ntcs::DetachState::e_DETACH_INITIATED) {
+        d_deferredCalls.push_back(NTCCFG_BIND(&StreamSocket::shutdown,
+                                              self,
+                                              direction,
+                                              mode));
+        return ntsa::Error();;
+    }
+
     if (d_connectInProgress) {
         if (direction == ntsa::ShutdownType::e_SEND ||
             direction == ntsa::ShutdownType::e_BOTH)

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -6501,6 +6501,14 @@ ntsa::Error StreamSocket::shutdown(ntsa::ShutdownType::Value direction,
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
     NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
 
+    if (d_detachState.get() == ntcs::DetachState::e_DETACH_INITIATED) {
+        d_deferredCalls.push_back(NTCCFG_BIND(&StreamSocket::shutdown,
+                                              self,
+                                              direction,
+                                              mode));
+        return ntsa::Error();;
+    }
+
     if (d_connectInProgress) {
         if (direction == ntsa::ShutdownType::e_SEND ||
             direction == ntsa::ShutdownType::e_BOTH)


### PR DESCRIPTION
Previously it was possible to execute "shutdown" for a StreamSocket during socket detachment procedure and have it failed on an assertion. This PR fixes that behavior by deferring shutdown processing. Also a test case was added to ntcf_system.t.

This bug occurs during the following sequence of events:
1) User thread calls  `ntci::StreamSocket::connect()`
2) I/O thread makes a decision that "Connection attempt has failed"
3) Before retrying connection, the I/O thread initiates the asynchronous socket detachment process and saves an internal callback to resume the next required actions to retry connecting after asynchronous socket detachment completes
4) User thread calls `ntci::StreamSocket::shutdown()`, the shutdown logic correctly thinks that the overall connection effort is still in progress (as there are still more connection attempts planned), so it tries to abort connection process completely but fails on an assertion (available in debug build only) that socket detachment is not finished yet.

A more rigorous set of tests that verify correct execution of shutdown and/or close during asynchronous socket detachment is planned for a subsequent PR.