### PR TITLE
Add overload for send taking 'const ntsa::ConstBuffer*' and 'size_t'

### DIFF
--- a/groups/nts/ntsb/ntsb_datagramsocket.cpp
+++ b/groups/nts/ntsb/ntsb_datagramsocket.cpp
@@ -108,6 +108,14 @@ ntsa::Error DatagramSocket::send(ntsa::SendContext*       context,
     return ntsu::SocketUtil::send(context, data, options, d_handle);
 }
 
+ntsa::Error DatagramSocket::send(ntsa::SendContext*       context,
+                                 const ntsa::ConstBuffer *data,
+                                 bsl::size_t              size,
+                                 const ntsa::SendOptions& options)
+{
+    return ntsu::SocketUtil::send(context, data, size, options, d_handle);
+}
+
 ntsa::Error DatagramSocket::receive(ntsa::ReceiveContext*       context,
                                     bdlbb::Blob*                data,
                                     const ntsa::ReceiveOptions& options)

--- a/groups/nts/ntsb/ntsb_datagramsocket.h
+++ b/groups/nts/ntsb/ntsb_datagramsocket.h
@@ -107,6 +107,15 @@ class DatagramSocket : public ntsi::DatagramSocket
                      const ntsa::Data&        data,
                      const ntsa::SendOptions& options) BSLS_KEYWORD_OVERRIDE;
 
+    /// Enqueue the specified 'data' having the specified 'size' to the
+    /// socket send buffer according to the specified 'options'. Load into
+    /// the specified 'context' the result of the operation. Return the
+    /// error.
+    ntsa::Error send(ntsa::SendContext*       context,
+                     const ntsa::ConstBuffer *data,
+                     bsl::size_t              size,
+                     const ntsa::SendOptions& options) BSLS_KEYWORD_OVERRIDE;
+
     /// Dequeue from the socket receive buffer into the specified 'data'
     /// according to the specified 'options'. Load into the specified
     /// 'context' the result of the operation. Return the error.

--- a/groups/nts/ntsb/ntsb_streamsocket.cpp
+++ b/groups/nts/ntsb/ntsb_streamsocket.cpp
@@ -108,6 +108,14 @@ ntsa::Error StreamSocket::send(ntsa::SendContext*       context,
     return ntsu::SocketUtil::send(context, data, options, d_handle);
 }
 
+ntsa::Error StreamSocket::send(ntsa::SendContext*       context,
+                               const ntsa::ConstBuffer *data,
+                               bsl::size_t              size,
+                               const ntsa::SendOptions& options)
+{
+    return ntsu::SocketUtil::send(context, data, size, options, d_handle);
+}
+
 ntsa::Error StreamSocket::receive(ntsa::ReceiveContext*       context,
                                   bdlbb::Blob*                data,
                                   const ntsa::ReceiveOptions& options)

--- a/groups/nts/ntsb/ntsb_streamsocket.h
+++ b/groups/nts/ntsb/ntsb_streamsocket.h
@@ -101,6 +101,15 @@ class StreamSocket : public ntsi::StreamSocket
                      const ntsa::Data&        data,
                      const ntsa::SendOptions& options) BSLS_KEYWORD_OVERRIDE;
 
+    /// Enqueue the specified 'data' having the specified 'size' to the
+    /// socket send buffer according to the specified 'options'. Load into
+    /// the specified 'context' the result of the operation. Return the
+    /// error.
+    ntsa::Error send(ntsa::SendContext*       context,
+                     const ntsa::ConstBuffer *data,
+                     bsl::size_t              size,
+                     const ntsa::SendOptions& options) BSLS_KEYWORD_OVERRIDE;
+
     /// Dequeue from the socket receive buffer into the specified 'data'
     /// according to the specified 'options'. Load into the specified
     /// 'context' the result of the operation. Return the error.

--- a/groups/nts/ntsi/ntsi_datagramsocket.cpp
+++ b/groups/nts/ntsi/ntsi_datagramsocket.cpp
@@ -72,6 +72,17 @@ ntsa::Error DatagramSocket::send(ntsa::SendContext*       context,
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 
+ntsa::Error DatagramSocket::send(ntsa::SendContext*       context,
+                                 const ntsa::ConstBuffer *data,
+                                 bsl::size_t              size,
+                                 const ntsa::SendOptions& options)
+{
+    ntsa::ConstBufferArray array;
+    array.append(data, size);
+
+    return this->send(context, ntsa::Data(array), options);
+}
+
 ntsa::Error DatagramSocket::receive(ntsa::ReceiveContext*       context,
                                     bdlbb::Blob*                data,
                                     const ntsa::ReceiveOptions& options)

--- a/groups/nts/ntsi/ntsi_datagramsocket.h
+++ b/groups/nts/ntsi/ntsi_datagramsocket.h
@@ -473,6 +473,15 @@ class DatagramSocket : public ntsi::Channel
     /// socket send buffer according to the specified 'options'. Load into
     /// the specified 'context' the result of the operation. Return the
     /// error.
+    virtual ntsa::Error send(ntsa::SendContext*       context,
+                             const ntsa::ConstBuffer *data,
+                             bsl::size_t              size,
+                             const ntsa::SendOptions& options);
+
+    /// Enqueue the specified 'data' having the specified 'size' to the
+    /// socket send buffer according to the specified 'options'. Load into
+    /// the specified 'context' the result of the operation. Return the
+    /// error.
     ntsa::Error send(ntsa::SendContext*       context,
                      const void*              data,
                      bsl::size_t              size,

--- a/groups/nts/ntsi/ntsi_streamsocket.cpp
+++ b/groups/nts/ntsi/ntsi_streamsocket.cpp
@@ -72,6 +72,17 @@ ntsa::Error StreamSocket::send(ntsa::SendContext*       context,
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 
+ntsa::Error StreamSocket::send(ntsa::SendContext*       context,
+                               const ntsa::ConstBuffer *data,
+                               bsl::size_t              size,
+                               const ntsa::SendOptions& options)
+{
+    ntsa::ConstBufferArray array;
+    array.append(data, size);
+
+    return this->send(context, ntsa::Data(array), options);
+}
+
 ntsa::Error StreamSocket::receive(ntsa::ReceiveContext*       context,
                                   bdlbb::Blob*                data,
                                   const ntsa::ReceiveOptions& options)

--- a/groups/nts/ntsi/ntsi_streamsocket.h
+++ b/groups/nts/ntsi/ntsi_streamsocket.h
@@ -268,6 +268,15 @@ class StreamSocket : public ntsi::Channel
     /// socket send buffer according to the specified 'options'. Load into
     /// the specified 'context' the result of the operation. Return the
     /// error.
+    virtual ntsa::Error send(ntsa::SendContext*       context,
+                             const ntsa::ConstBuffer *data,
+                             bsl::size_t              size,
+                             const ntsa::SendOptions& options);
+
+    /// Enqueue the specified 'data' having the specified 'size' to the
+    /// socket send buffer according to the specified 'options'. Load into
+    /// the specified 'context' the result of the operation. Return the
+    /// error.
     ntsa::Error send(ntsa::SendContext*       context,
                      const void*              data,
                      bsl::size_t              size,


### PR DESCRIPTION
Add overloads to send method of 'ntsi::StreamSocket' and 'ntsi::DatagramSocket' taking in 'const ntsa::ConstBuffer*' and 'size_t'
