### PR TITLE
Introduce slimmer wrapper around 'recv' for simple use-cases

### DIFF
--- a/groups/nts/ntsf/ntsf_system.cpp
+++ b/groups/nts/ntsf/ntsf_system.cpp
@@ -690,6 +690,14 @@ ntsa::Error System::send(ntsa::SendContext*       context,
     return ntsu::SocketUtil::send(context, data, options, socket);
 }
 
+ntsa::Error System::receive(bsl::size_t* numBytesReceived,
+                            void*        data,
+                            bsl::size_t  capacity,
+                            ntsa::Handle socket)
+{
+    return ntsu::SocketUtil::receive(numBytesReceived, data, capacity, socket);
+}
+
 ntsa::Error System::receive(ntsa::ReceiveContext*       context,
                             void*                       data,
                             bsl::size_t                 capacity,

--- a/groups/nts/ntsf/ntsf_system.h
+++ b/groups/nts/ntsf/ntsf_system.h
@@ -1072,6 +1072,15 @@ struct System {
                             ntsa::Handle             socket);
 
     /// Dequeue from the receive buffer of the specified 'socket' into the
+    /// specified 'data' having the specified 'capacity'. Load into the
+    /// specified 'numBytesReceived' the result of the operation. Return the
+    /// error.
+    static ntsa::Error receive(bsl::size_t* numBytesReceived,
+                               void*        data,
+                               bsl::size_t  capacity,
+                               ntsa::Handle socket);
+
+    /// Dequeue from the receive buffer of the specified 'socket' into the
     /// specified 'data' having the specified 'capacity' according to the
     /// specified 'options'. Load into the specified 'context' the result of
     /// the operation. Return the error.

--- a/groups/nts/ntsu/ntsu_socketutil.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.cpp
@@ -2690,10 +2690,6 @@ ntsa::Error SocketUtil::receive(bsl::size_t* numBytesReceived,
         return ntsa::Error::invalid();
     }
 
-    struct iovec iovec;
-    iovec.iov_base = data;
-    iovec.iov_len  = capacity;
-
     ssize_t recvResult =
         ::recv(socket, data, capacity, NTSU_SOCKETUTIL_RECV_FLAGS);
 

--- a/groups/nts/ntsu/ntsu_socketutil.h
+++ b/groups/nts/ntsu/ntsu_socketutil.h
@@ -540,6 +540,15 @@ struct SocketUtil {
                                       ntsa::Handle              socket);
 
     /// Dequeue from the receive buffer of the specified 'socket' into the
+    /// specified 'data' having the specified 'capacity'. Load into the
+    /// specified 'numBytesReceived' the result of the operation. Return the
+    /// error.
+    static ntsa::Error receive(bsl::size_t* numBytesReceived,
+                               void*        data,
+                               bsl::size_t  capacity,
+                               ntsa::Handle socket);
+
+    /// Dequeue from the receive buffer of the specified 'socket' into the
     /// specified 'data' having the specified 'capacity' according to the
     /// specified 'options'. Load into the specified 'context' the result of
     /// the operation. Return the error.

--- a/groups/nts/ntsu/ntsu_socketutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.t.cpp
@@ -7028,18 +7028,16 @@ NTSCFG_TEST_CASE(17)
         // Dequeue incoming data received by the client socket.
 
         {
-            char                 buffer;
-            ntsa::ReceiveContext context;
-            ntsa::ReceiveOptions options;
+            char        buffer;
+            bsl::size_t numBytesReceived;
 
-            ntsa::Data data(ntsa::MutableBuffer(&buffer, 1));
-
-            error =
-                ntsu::SocketUtil::receive(&context, &data, options, client);
+            error = ntsu::SocketUtil::receive(&numBytesReceived,
+                                              &buffer,
+                                              1,
+                                              client);
             NTSCFG_TEST_ASSERT(!error);
 
-            NTSCFG_TEST_ASSERT(context.bytesReceivable() == 1);
-            NTSCFG_TEST_ASSERT(context.bytesReceived() == 1);
+            NTSCFG_TEST_ASSERT(numBytesReceived == 1);
             NTSCFG_TEST_ASSERT(buffer == 'S');
         }
 


### PR DESCRIPTION
A small internal analysis shows that `ntsf::System::receive` is quite a bit more expensive than a plain call to `recv` for simple use cases.

A sample benchmark comparison (including `context.hideEndpoint()`):

```
--------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations
--------------------------------------------------------------------
BenchmarkRawSocketRecv           214 ns          213 ns      3279958
BenchmarkNtfSocketRecv           342 ns          341 ns      2053873
```

Most of this extra overhead is a result of `recvmsg` needing to copy its complex arguments from user to kernel space. For simple use cases, `recv` is sufficient and more efficient. Using the new `ntsf::System::receive` overload introduced in this PR:

```
--------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations
--------------------------------------------------------------------
BenchmarkRawSocketRecv           220 ns          219 ns      3184668
BenchmarkNtfSocketRecv           222 ns          222 ns      3153241
```

My rationale for introducing a new overload instead of branching on the supplied `options` (as suggested was once the case by the vestigial `NTSU_SOCKETUTIL_RECVMSG_ALWAYS`) is that the divergence in requirements and implementation is wide enough to warrant a dedicated method for what I consider such a common use case. In particular, eschewing the `ntsa::ReceiveContext` reduces memory pressure as it's quite a large object that would be reset on every call (though normally stack-allocated, this is still ~4 ns extra overhead even without cache misses).
