### PR TITLE
Implement simple mocking framework and test ntcr::StreamSocket shutdown sequence during connection phase using whitebox testing approach

### DIFF
--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -896,7 +896,7 @@ struct SetterHolder : ProcessInterface<ARG> {
     {
     }
 
-    void process(const ARG& arg) override
+    void process(const ARG& arg) BSLS_KEYWORD_OVERRIDE
     {
         d_setter.process(arg);
     }
@@ -950,7 +950,7 @@ struct ExtractorHolder : ProcessInterface<ARG> {
     {
     }
 
-    void process(const ARG& arg) override
+    void process(const ARG& arg) BSLS_KEYWORD_OVERRIDE
     {
         d_extractor.process(arg);
     }
@@ -1020,7 +1020,7 @@ struct MatcherHolder : ProcessInterface<ARG> {
     {
     }
 
-    void process(const ARG& arg) override
+    void process(const ARG& arg) BSLS_KEYWORD_OVERRIDE
     {
         d_matcher.process(arg);
     }
@@ -1194,8 +1194,6 @@ struct InvocationData;
 
 template <class RESULT>
 struct InvocationData<RESULT> : public InvocationDataBase<RESULT> {
-    InvocationData()                            = default;
-    InvocationData(const InvocationData& other) = default;
 };
 
 template <class RESULT, class ARG1>

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -845,7 +845,7 @@ namespace ntf_mock {
 template <class ARG>
 struct ProcessInterface {
     virtual void process(const ARG& arg) = 0;
-    virtual ~ProcessInterface()
+    virtual ~    ProcessInterface()
     {
     }
 };
@@ -1034,9 +1034,8 @@ struct InvocationResult {
     : d_expResult()
     {
     }
-    BloombergLP::bdlb::NullableValue<RESULT>
-           d_expResult;  //TODO: wont work with ref
-    RESULT get()
+    BloombergLP::bdlb::NullableValue<RESULT> d_expResult;
+    RESULT                                   get()
     {
         NTCCFG_TEST_TRUE(d_expResult.has_value());
         return d_expResult.value();
@@ -1052,7 +1051,6 @@ struct InvocationResult<RESULT&> {
     RESULT* d_expResult;
     RESULT& get()
     {
-        printf("InvocationResult<RESULT&>::get d_expResult=%p\n", (void*)d_expResult);
         NTCCFG_TEST_TRUE(d_expResult != 0);
         return *d_expResult;
     }
@@ -1067,7 +1065,6 @@ struct InvocationResult<RESULT const&> {
     RESULT const* d_expResult;
     const RESULT& get()
     {
-        printf("InvocationResult<RESULT const&>::get d_expResult=%p\n", (void*)d_expResult);
         NTCCFG_TEST_TRUE(d_expResult != 0);
         return *d_expResult;
     }
@@ -1089,7 +1086,6 @@ struct InvocationBaseWillReturn {
 
     SELF& willReturn(const RESULT& result)
     {
-        printf("InvocationBaseWillReturn<INVOCATION_DATA, SELF, RESULT>::willReturn &result=%p\n", (void*)(&result));
         INVOCATION_DATA& invocation     = getInvocationDataBack();
         invocation.d_result.d_expResult = result;
         return *(static_cast<SELF*>(this));
@@ -1105,9 +1101,8 @@ template <class INVOCATION_DATA, class SELF, class RESULT>
 struct InvocationBaseWillReturn<INVOCATION_DATA, SELF, RESULT&> {
     virtual INVOCATION_DATA& getInvocationDataBack() = 0;
 
-    SELF& willReturn(RESULT* result)
+    SELF& willReturnRef(RESULT* result)
     {
-        printf("InvocationBaseWillReturn<INVOCATION_DATA, SELF, RESULT&>::willReturn &result=%p\n", (void*)(&result));
         INVOCATION_DATA& invocation     = getInvocationDataBack();
         invocation.d_result.d_expResult = result;
         return *(static_cast<SELF*>(this));
@@ -1123,10 +1118,8 @@ template <class INVOCATION_DATA, class SELF, class RESULT>
 struct InvocationBaseWillReturn<INVOCATION_DATA, SELF, RESULT const&> {
     virtual INVOCATION_DATA& getInvocationDataBack() = 0;
 
-    SELF& willReturn(RESULT const* result)
+    SELF& willReturnRef(RESULT const* result)
     {
-        printf("InvocationBaseWillReturn<INVOCATION_DATA, SELF, RESULT const&>::willReturn &result=%p\n", std::addressof(result));
-
         INVOCATION_DATA& invocation     = getInvocationDataBack();
         invocation.d_result.d_expResult = result;
         return *(static_cast<SELF*>(this));
@@ -1201,7 +1194,7 @@ struct InvocationData;
 
 template <class RESULT>
 struct InvocationData<RESULT> : public InvocationDataBase<RESULT> {
-    InvocationData() = default;
+    InvocationData()                            = default;
     InvocationData(const InvocationData& other) = default;
 };
 
@@ -1307,7 +1300,7 @@ template <class INVOCATION_DATA,
           class ARG5 = NO_ARG>
 struct InvocationBaseSaveSetArg {
   private:
-    InvocationBaseSaveSetArg();
+     InvocationBaseSaveSetArg();
     ~InvocationBaseSaveSetArg();
 };
 
@@ -1447,9 +1440,11 @@ struct Invocation0
 
     Invocation0& expect()
     {
-        InvocationDataT invocation;
-        //        d_invocations.emplace_back();
-        d_invocations.push_back(invocation);
+        if (!d_invocations.empty()) {
+            NTCCFG_TEST_NE(d_invocations.back().d_expectedCalls,
+                           InvocationDataT::k_INFINITE_CALLS);
+        }
+        d_invocations.emplace_back();
         return *this;
     }
 
@@ -1507,6 +1502,10 @@ struct Invocation1
     template <class ARG1_MATCHER>
     Invocation1& expect(const ARG1_MATCHER& arg1Matcher)
     {
+        if (!d_invocations.empty()) {
+            NTCCFG_TEST_NE(d_invocations.back().d_expectedCalls,
+                           InvocationDataT::k_INFINITE_CALLS);
+        }
         d_invocations.emplace_back();
 
         if (!arg1Matcher.ignore()) {
@@ -1569,6 +1568,10 @@ struct Invocation2
     Invocation2& expect(const ARG1_MATCHER& arg1Matcher,
                         const ARG2_MATCHER& arg2Matcher)
     {
+        if (!d_invocations.empty()) {
+            NTCCFG_TEST_NE(d_invocations.back().d_expectedCalls,
+                           InvocationDataT::k_INFINITE_CALLS);
+        }
         d_invocations.emplace_back();
         InvocationDataT& data = d_invocations.back();
         if (!arg1Matcher.ignore()) {
@@ -1640,6 +1643,10 @@ struct Invocation3
                         const ARG2_MATCHER& arg2Matcher,
                         const ARG3_MATCHER& arg3Matcher)
     {
+        if (!d_invocations.empty()) {
+            NTCCFG_TEST_NE(d_invocations.back().d_expectedCalls,
+                           InvocationDataT::k_INFINITE_CALLS);
+        }
         d_invocations.emplace_back();
         InvocationDataT& data = d_invocations.back();
         if (!arg1Matcher.ignore()) {
@@ -1862,6 +1869,7 @@ struct Invocation3
 #define ALWAYS() willAlways()
 #define TIMES(x) willTimes(x)
 #define RETURN(VAL) willReturn(VAL)
+#define RETURNREF(VAL) willReturnRef(&VAL)
 
 #define TO(ARG) ntf_mock::createExtractor<ntf_mock::NoDerefPolicy>(ARG)
 #define TO_DEREF(ARG) ntf_mock::createExtractor<ntf_mock::DerefPolicy>(ARG)

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -1108,11 +1108,7 @@ template <class RESULT,
           class ARG3 = NO_ARG,
           class ARG4 = NO_ARG,
           class ARG5 = NO_ARG>
-struct InvocationData {
-  private:
-     InvocationData();
-    ~InvocationData();
-};
+struct InvocationData;
 
 template <class RESULT>
 struct InvocationData<RESULT> : public InvocationDataBase<RESULT> {
@@ -1372,37 +1368,6 @@ struct Invocation0
 
     bsl::list<InvocationDataT> d_invocations;
 };
-
-template <class T>
-bool operator==(const T&, const IgnoreArg&)
-{
-    NTCCFG_TEST_ASSERT(false);
-    return false;
-}
-template <class T>
-bool operator!=(const T&, const IgnoreArg&)
-{
-    NTCCFG_TEST_ASSERT(false);
-    return false;
-}
-template <class T>
-bool operator==(const IgnoreArg&, const T&)
-{
-    NTCCFG_TEST_ASSERT(false);
-    return false;
-}
-template <class T>
-bool operator!=(const IgnoreArg&, const T&)
-{
-    NTCCFG_TEST_ASSERT(false);
-    return false;
-}
-
-inline bsl::ostream& operator<<(bsl::ostream& stream, const IgnoreArg&)
-{
-    NTCCFG_TEST_ASSERT(false);
-    return stream;
-}
 
 template <class T>
 struct TypeToType {

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -1715,7 +1715,7 @@ struct Invocation2 {
     }                                                                         \
     NTF_MOCK_METHOD_0_IMP_NEW(RESULT, METHOD_NAME)
 
-#define NTF_MOCK_METHOD_CONST_NEW_1(RESULT, METHOD_NAME)                      \
+#define NTF_MOCK_METHOD_CONST_NEW_0(RESULT, METHOD_NAME)                      \
   public:                                                                     \
     RESULT METHOD_NAME() const override                                       \
     {                                                                         \

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -751,15 +751,13 @@ struct DefaultSetter {
 template <class IN, template <class, class> class SET_POLICY>
 struct Setter {
     template <class ARG>
-    void process(ARG& arg)
+    struct SetterImpl
     {
-        SET_POLICY<ARG&, IN>::set(arg, d_in);
-    }
-    template <class ARG>
-    void process(ARG* arg)
-    {
-        SET_POLICY<ARG*, IN>::set(arg, d_in);
-    }
+        static void process(ARG arg, const IN& in)
+        {
+            SET_POLICY<ARG, IN>::set(arg, in);
+        }
+    };
 
     explicit Setter(const IN& in)
     : d_in(in)
@@ -785,7 +783,7 @@ struct SetterHolder : SetterInterface<ARG> {
 
     void process(ARG arg) BSLS_KEYWORD_OVERRIDE
     {
-        d_setter.process(arg);
+        SETTER::SetterImpl<ARG>::process(arg, d_setter.d_in);
     }
 
     SETTER d_setter;

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -823,8 +823,20 @@ class TestAllocator : public bslma::Allocator
 #error Not implemented
 #endif
 
-//#define NTF_MOCK_METHOD_INVOKE_COMMON_IMP(unused)                             \
-
+#define NTF_MOCK_METHOD_INVOKE_COMMON_IMP()                                   \
+    NTCCFG_TEST_FALSE(d_invocations.empty());                                 \
+    InvocationData& invocation = d_invocations.front();                       \
+    if (invocation.d_expectedCalls != -1) {                                   \
+        NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);                        \
+    }                                                                         \
+    NTCCFG_TEST_TRUE(invocation.d_result.has_value());                        \
+    const auto result = invocation.d_result.value();                          \
+    if (invocation.d_expectedCalls != -1) {                                   \
+        --invocation.d_expectedCalls;                                         \
+        if (invocation.d_expectedCalls == 0) {                                \
+            d_invocations.pop_front();                                        \
+        }                                                                     \
+    }
 
 #define NTF_MOCK_METHOD_COMMON_IMP(RESULT, METHOD_NAME)                       \
   public:                                                                     \
@@ -887,21 +899,7 @@ class TestAllocator : public bslma::Allocator
       public:                                                                 \
         RESULT invoke()                                                       \
         {                                                                     \
-            NTCCFG_TEST_FALSE(d_invocations.empty());                         \
-            InvocationData& invocation = d_invocations.front();               \
-                                                                              \
-            if (invocation.d_expectedCalls != -1) {                           \
-                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);                \
-            }                                                                 \
-                                                                              \
-            NTCCFG_TEST_TRUE(invocation.d_result.has_value());                \
-            const auto result = invocation.d_result.value();                  \
-            if (invocation.d_expectedCalls != -1) {                           \
-                --invocation.d_expectedCalls;                                 \
-                if (invocation.d_expectedCalls == 0) {                        \
-                    d_invocations.pop_front();                                \
-                }                                                             \
-            }                                                                 \
+            NTF_MOCK_METHOD_INVOKE_COMMON_IMP()                               \
             return result;                                                    \
         }                                                                     \
     };                                                                        \
@@ -922,7 +920,7 @@ class TestAllocator : public bslma::Allocator
     }                                                                         \
     NTF_MOCK_METHOD_0_IMP(RESULT, METHOD_NAME)
 
-#define NTF_MOCK_METHOD_0_CONST(RESULT, METHOD_NAME)                          \
+#define NTF_MOCK_METHOD_CONST_0(RESULT, METHOD_NAME)                          \
   public:                                                                     \
     RESULT METHOD_NAME() const override                                       \
     {                                                                         \
@@ -930,8 +928,83 @@ class TestAllocator : public bslma::Allocator
     }                                                                         \
     NTF_MOCK_METHOD_0_IMP(RESULT, METHOD_NAME)
 
-#define NTF_MOCK_METHOD(RESULT, METHOD_NAME)                                  \
-    NTF_MOCK_METHOD_0(RESULT, METHOD_NAME)
 
-#define NTF_MOCK_METHOD_CONST(RESULT, METHOD_NAME)                            \
-    NTF_MOCK_METHOD_0_CONST(RESULT, METHOD_NAME)
+
+#define NTF_MOCK_METHOD_1_IMP(RESULT, METHOD_NAME, ARG1)                      \
+  public:                                                                     \
+    class Invocation_##METHOD_NAME                                            \
+    {                                                                         \
+      private:                                                                \
+        struct InvocationData {                                               \
+            int                         d_expectedCalls;                      \
+            bdlb::NullableValue<RESULT> d_result;                             \
+            bdlb::NullableValue<ARG1>   d_arg1;                               \
+            ARG1*                       d_arg1_out;                           \
+            InvocationData()                                                  \
+            : d_expectedCalls(0)                                              \
+            , d_result()                                                      \
+            , d_arg1                                                          \
+            {                                                                 \
+            }                                                                 \
+        };                                                                    \
+                                                                              \
+        NTF_MOCK_METHOD_COMMON_IMP(RESULT, METHOD_NAME)                       \
+                                                                              \
+        Invocation_##METHOD_NAME& saveArg1To(ARG1& arg1)                      \
+        {                                                                     \
+            NTCCFG_TEST_FALSE(d_invocations.empty());                         \
+            InvocationData& invocation = d_invocations.back();                \
+            invocation.d_arg1_out      = &arg1;                               \
+            return *this;                                                     \
+        }                                                                     \
+                                                                              \
+      public:                                                                 \
+        RESULT invoke(const ARG1& arg1)                                       \
+        {                                                                     \
+            NTF_MOCK_METHOD_INVOKE_COMMON_IMP()                               \
+            if (invocation.d_arg1.has_value()) {                              \
+                NTCCFG_TEST_EQ(arg1, invocation.d_arg1.value());              \
+            }                                                                 \
+            if (invocation.d_arg1_out) {                                      \
+                *invocation.d_arg1_out = arg1;                                \
+            }                                                                 \
+            return result;                                                    \
+        }                                                                     \
+    };                                                                        \
+                                                                              \
+    Invocation_##METHOD_NAME& expect_##METHOD_NAME()                          \
+    {                                                                         \
+        return d_invocation_##METHOD_NAME.expect();                           \
+    }                                                                         \
+                                                                              \
+  private:                                                                    \
+    mutable Invocation_##METHOD_NAME d_invocation_##METHOD_NAME;
+
+#define NTF_MOCK_METHOD_1(RESULT, METHOD_NAME, ARG1)                          \
+  public:                                                                     \
+    /*TODO: invoke and correctly pass the argument, saving all CVs*/          \
+    RESULT METHOD_NAME(ARG1 arg1) override                                    \
+    {                                                                         \
+        return d_invocation_##METHOD_NAME.invoke(arg1);                       \
+    }                                                                         \
+    NTF_MOCK_METHOD_1_IMP(RESULT, METHOD_NAME, ARG1)
+
+#define NTF_MOCK_METHOD_1_CONST(RESULT, METHOD_NAME, ARG1)                    \
+  public:                                                                     \
+    RESULT METHOD_NAME(ARG1 arg1) const override                              \
+    {                                                                         \
+        return d_invocation_##METHOD_NAME.invoke(arg1);                       \
+    }                                                                         \
+    NTF_MOCK_METHOD_1_IMP(RESULT, METHOD_NAME, ARG1
+
+#define NTF_EXPAND( X ) X
+#define NTF_CAT( A, B ) A ## B
+#define NTF_SELECT( NAME, NUM ) NTF_CAT( NAME ## _, NUM )
+
+#define NTF_GET_COUNT( _1, _2, _3, _4, _5, _6, COUNT, ... ) COUNT
+#define NTF_VA_SIZE( ... ) NTF_EXPAND( NTF_GET_COUNT( __VA_ARGS__, 4, 3, 2, 1, 0, -1 ) )
+
+#define NTF_VA_SELECT( NAME, ... ) NTF_SELECT( NAME, NTF_VA_SIZE(__VA_ARGS__) )(__VA_ARGS__)
+
+#define NTF_MOCK_METHOD( ... ) NTF_VA_SELECT( NTF_MOCK_METHOD, __VA_ARGS__ )
+#define NTF_MOCK_METHOD_CONST( ... ) NTF_VA_SELECT( NTF_MOCK_METHOD_CONST, __VA_ARGS__ )

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -1308,109 +1308,39 @@ template <class RESULT>
 struct InvocationData<RESULT, NO_ARG> : public InvocationDataBase<RESULT> {
 };
 
-
-template <class INVOCATION_DATA,
-          class SELF,
-          class ARG1 = NO_ARG,
-          class ARG2 = NO_ARG,
-          class ARG3 = NO_ARG,
-          class ARG4 = NO_ARG,
-          class ARG5 = NO_ARG>
-struct InvocationBaseSaveSetArg;
-
-template <class INVOCATION_DATA, class SELF, class ARG1>
-struct InvocationBaseSaveSetArg<INVOCATION_DATA, SELF, ARG1> {
+template <class INVOCATION_DATA, class SELF, class ARG_LIST>
+struct InvocationBaseSaveSetArg {
     virtual INVOCATION_DATA& getInvocationDataBack() = 0;
 
-    template <class ARG_EXTRACTOR>
-    SELF& saveArg1(const ARG_EXTRACTOR& extractor)
+    template <int ARG_INDEX, class ARG_EXTRACTOR>
+    SELF& saveArg(const ARG_EXTRACTOR& extractor)
     {
+        typedef typename BloombergLP::bslmf::TypeListTypeAt<ARG_INDEX,
+                                                            ARG_LIST>::Type
+                         ArgType;
         INVOCATION_DATA& data = this->getInvocationDataBack();
 
-        bsl::shared_ptr<ExtractorHolder<ARG1, ARG_EXTRACTOR> >
+        bsl::shared_ptr<ExtractorHolder<ArgType, ARG_EXTRACTOR> >
             extractorInterface(
-                new ExtractorHolder<ARG1, ARG_EXTRACTOR>(extractor));
+                new ExtractorHolder<ArgType, ARG_EXTRACTOR>(extractor));
 
-        getInvocationArgs<0>(data).d_extractor = extractorInterface;
-
-        return *(static_cast<SELF*>(this));
-    }
-
-    template <class ARG_SETTER>
-    SELF& setArg1(const ARG_SETTER& setter)
-    {
-        INVOCATION_DATA& data = this->getInvocationDataBack();
-
-        bsl::shared_ptr<SetterHolder<ARG1, ARG_SETTER> > setterInterface(
-            new SetterHolder<ARG1, ARG_SETTER>(setter));
-
-        getInvocationArgs<0>(data).d_setter = setterInterface;
-
-        return *(static_cast<SELF*>(this));
-    }
-};
-
-template <class INVOCATION_DATA, class SELF, class ARG1, class ARG2>
-struct InvocationBaseSaveSetArg<INVOCATION_DATA, SELF, ARG1, ARG2>
-: public InvocationBaseSaveSetArg<INVOCATION_DATA, SELF, ARG1> {
-    template <class ARG_EXTRACTOR>
-    SELF& saveArg2(const ARG_EXTRACTOR& extractor)
-    {
-        INVOCATION_DATA& data = this->getInvocationDataBack();
-
-        bsl::shared_ptr<ExtractorHolder<ARG2, ARG_EXTRACTOR> >
-            extractorInterface(
-                new ExtractorHolder<ARG2, ARG_EXTRACTOR>(extractor));
-
-        getInvocationArgs<1>(data).d_extractor = extractorInterface;
+        getInvocationArgs<ARG_INDEX>(data).d_extractor = extractorInterface;
 
         return *(static_cast<SELF*>(this));
     }
 
-    template <class ARG_SETTER>
-    SELF& setArg2(const ARG_SETTER& setter)
+    template <int ARG_INDEX, class ARG_SETTER>
+    SELF& setArg(const ARG_SETTER& setter)
     {
+        typedef typename BloombergLP::bslmf::TypeListTypeAt<ARG_INDEX,
+                                                            ARG_LIST>::Type
+                         ArgType;
         INVOCATION_DATA& data = this->getInvocationDataBack();
 
-        bsl::shared_ptr<SetterHolder<ARG2, ARG_SETTER> > setterInterface(
-            new SetterHolder<ARG2, ARG_SETTER>(setter));
+        bsl::shared_ptr<SetterHolder<ArgType, ARG_SETTER> > setterInterface(
+            new SetterHolder<ArgType, ARG_SETTER>(setter));
 
-        data.arg2Setter = setterInterface;
-
-        return *(static_cast<SELF*>(this));
-    }
-};
-
-template <class INVOCATION_DATA,
-          class SELF,
-          class ARG1,
-          class ARG2,
-          class ARG3>
-struct InvocationBaseSaveSetArg<INVOCATION_DATA, SELF, ARG1, ARG2, ARG3>
-: public InvocationBaseSaveSetArg<INVOCATION_DATA, SELF, ARG1, ARG2> {
-    template <class ARG_EXTRACTOR>
-    SELF& saveArg3(const ARG_EXTRACTOR& extractor)
-    {
-        INVOCATION_DATA& data = this->getInvocationDataBack();
-
-        bsl::shared_ptr<ExtractorHolder<ARG3, ARG_EXTRACTOR> >
-            extractorInterface(
-                new ExtractorHolder<ARG3, ARG_EXTRACTOR>(extractor));
-
-        data.arg3Extractor = extractorInterface;
-
-        return *(static_cast<SELF*>(this));
-    }
-
-    template <class ARG_SETTER>
-    SELF& setArg3(const ARG_SETTER& setter)
-    {
-        INVOCATION_DATA& data = this->getInvocationDataBack();
-
-        bsl::shared_ptr<SetterHolder<ARG3, ARG_SETTER> > setterInterface(
-            new SetterHolder<ARG3, ARG_SETTER>(setter));
-
-        data.arg3Setter = setterInterface;
+        getInvocationArgs<ARG_INDEX>(data).d_setter = setterInterface;
 
         return *(static_cast<SELF*>(this));
     }
@@ -1503,10 +1433,9 @@ struct Invocation1
                                   RESULT>,
   public InvocationBaseTimes<InvocationData<RESULT, ARG_LIST>,
                              Invocation1<METHOD_INFO, RESULT, ARG_LIST> >,
-  public InvocationBaseSaveSetArg<
-      InvocationData<RESULT, ARG_LIST>,
-      Invocation1<METHOD_INFO, RESULT, ARG_LIST>,
-      typename BloombergLP::bslmf::TypeListTypeAt<0, ARG_LIST>::Type>
+  public InvocationBaseSaveSetArg<InvocationData<RESULT, ARG_LIST>,
+                                  Invocation1<METHOD_INFO, RESULT, ARG_LIST>,
+                                  ARG_LIST>
 
 {
     typedef InvocationData<RESULT, ARG_LIST> InvocationDataT;
@@ -1575,11 +1504,9 @@ struct Invocation2
                                   RESULT>,
   public InvocationBaseTimes<InvocationData<RESULT, ARG_LIST>,
                              Invocation2<METHOD_INFO, RESULT, ARG_LIST> >,
-  public InvocationBaseSaveSetArg<
-      InvocationData<RESULT, ARG_LIST>,
-      Invocation2<METHOD_INFO, RESULT, ARG_LIST>,
-      typename BloombergLP::bslmf::TypeListTypeAt<0, ARG_LIST>::Type,
-      typename BloombergLP::bslmf::TypeListTypeAt<1, ARG_LIST>::Type>
+  public InvocationBaseSaveSetArg<InvocationData<RESULT, ARG_LIST>,
+                                  Invocation2<METHOD_INFO, RESULT, ARG_LIST>,
+                                  ARG_LIST>
 
 {
     typedef InvocationData<RESULT, ARG_LIST> InvocationDataT;
@@ -1658,12 +1585,9 @@ struct Invocation3
                                   RESULT>,
   public InvocationBaseTimes<InvocationData<RESULT, ARG_LIST>,
                              Invocation3<METHOD_INFO, RESULT, ARG_LIST> >,
-  public InvocationBaseSaveSetArg<
-      InvocationData<RESULT, ARG_LIST>,
-      Invocation3<METHOD_INFO, RESULT, ARG_LIST>,
-      typename BloombergLP::bslmf::TypeListTypeAt<0, ARG_LIST>::Type,
-      typename BloombergLP::bslmf::TypeListTypeAt<1, ARG_LIST>::Type,
-      typename BloombergLP::bslmf::TypeListTypeAt<2, ARG_LIST>::Type>
+  public InvocationBaseSaveSetArg<InvocationData<RESULT, ARG_LIST>,
+                                  Invocation3<METHOD_INFO, RESULT, ARG_LIST>,
+                                  ARG_LIST>
 
 {
     typedef InvocationData<RESULT, ARG_LIST> InvocationDataT;
@@ -1984,16 +1908,16 @@ struct Invocation3
 #define TO(ARG) ntf_mock::createExtractor<ntf_mock::NoDerefPolicy>(ARG)
 #define TO_DEREF(ARG) ntf_mock::createExtractor<ntf_mock::DerefPolicy>(ARG)
 
-#define SAVE_ARG_1(...) saveArg1(__VA_ARGS__)
-#define SAVE_ARG_2(...) saveArg2(__VA_ARGS__)
-#define SAVE_ARG_3(...) saveArg1(__VA_ARGS__)
-#define SAVE_ARG_4(...) saveArg2(__VA_ARGS__)
+#define SAVE_ARG_1(...) saveArg<0>(__VA_ARGS__)
+#define SAVE_ARG_2(...) saveArg<1>(__VA_ARGS__)
+#define SAVE_ARG_3(...) saveArg<2>(__VA_ARGS__)
+#define SAVE_ARG_4(...) saveArg<3>(__VA_ARGS__)
 
 #define FROM(ARG) ntf_mock::createSetter<ntf_mock::DefaultSetter>(ARG)
 
 #define FROM_DEREF(ARG) ntf_mock::createSetter<ntf_mock::DerefSetter>(ARG)
 
-#define SET_ARG_1(...) setArg1(__VA_ARGS__)
-#define SET_ARG_2(...) setArg2(__VA_ARGS__)
-#define SET_ARG_3(...) setArg3(__VA_ARGS__)
-#define SET_ARG_4(...) setArg4(__VA_ARGS__)
+#define SET_ARG_1(...) setArg<0>(__VA_ARGS__)
+#define SET_ARG_2(...) setArg<1>(__VA_ARGS__)
+#define SET_ARG_3(...) setArg<2>(__VA_ARGS__)
+#define SET_ARG_4(...) setArg<3>(__VA_ARGS__)

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -1415,8 +1415,9 @@ struct InvocationDataStorage {
         {
             if (it->d_expectedCalls != INVOCATION_DATA::k_INFINITE_CALLS) {
                 BSLS_LOG_FATAL(
-                    "Invocation \"%s\" did not fire but was expected "
+                    "%s: invocation \"%s\" did not fire but was expected "
                     "to fire %d times",
+                    METHOD_INFO().mockName,
                     METHOD_INFO().name,
                     it->d_expectedCalls);
                 bsl::abort();
@@ -1704,7 +1705,8 @@ struct Invocation3
 }
 
 #define NTF_METHOD_INFO(METHOD_NAME)                                          \
-    struct NTF_CAT2(MethodInfo, __LINE__) {                                   \
+    struct NTF_CAT2(MethodInfo, __LINE__)                                     \
+    : public MockInfo {                                                       \
         const char* name;                                                     \
         NTF_CAT2(MethodInfo, __LINE__)                                        \
         ()                                                                    \
@@ -1811,6 +1813,20 @@ struct Invocation3
     mutable ntf_mock::                                                        \
         Invocation3<NTF_CAT2(MethodInfo, __LINE__), RESULT, ARG1, ARG2, ARG3> \
             NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__);
+
+#define NTF_MOCK_CLASS(MOCK_NAME, CLASS_TO_MOCK)                              \
+    class MOCK_NAME : public CLASS_TO_MOCK                                    \
+    {                                                                         \
+      public:                                                                 \
+        struct MockInfo {                                                     \
+            const char* mockName;                                             \
+                        MockInfo()                                            \
+            : mockName(#MOCK_NAME)                                            \
+            {                                                                 \
+            }                                                                 \
+        };
+
+#define NTF_MOCK_CLASS_END }
 
 #define NTF_MOCK_METHOD_0(RESULT, METHOD_NAME)                                \
   public:                                                                     \

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -1224,8 +1224,12 @@ class Invocation1
 }
 }
 
+#define NTF_CAT2_(A, B) A##B
+#define NTF_CAT2(A, B) NTF_CAT2_(A, B)
+
 #define NTF_EXPAND(X) X
 #define NTF_CAT(A, B) A##B
+// #define NTF_CAT(A, B) NTF_CAT_(A, B)
 #define NTF_SELECT(NAME, NUM) NTF_CAT(NAME##_, NUM)
 
 #define NTF_GET_COUNT(_1, _2, _3, _4, _5, _6, COUNT, ...) COUNT
@@ -1593,7 +1597,8 @@ struct Invocation0
     bsl::list<InvocationData<RESULT, NO_ARG, NO_ARG, NO_ARG> > d_invocations;
 };
 
-struct IgnoreArg{};
+struct IgnoreArg {
+};
 
 template <class RESULT, class ARG1>
 struct Invocation1
@@ -1713,11 +1718,13 @@ struct Invocation2 {
     NewMock::Invocation1<RESULT, ARG1>& expect_##METHOD_NAME(                 \
         const MATCHER& arg1)                                                  \
     {                                                                         \
-        return d_invocation_##METHOD_NAME.expect(arg1);                       \
+        return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__).expect(arg1);    \
     }                                                                         \
                                                                               \
   private:                                                                    \
-    mutable NewMock::Invocation1<RESULT, ARG1> d_invocation_##METHOD_NAME;
+    mutable NewMock::Invocation1<RESULT, ARG1> NTF_CAT2(                       \
+        d_invocation_##METHOD_NAME,                                           \
+        __LINE__);
 
 #define NTF_MOCK_METHOD_NEW_0(RESULT, METHOD_NAME)                            \
   public:                                                                     \
@@ -1739,7 +1746,7 @@ struct Invocation2 {
   public:                                                                     \
     RESULT METHOD_NAME(ARG1 arg1) override                                    \
     {                                                                         \
-        return d_invocation_##METHOD_NAME.invoke(arg1);                       \
+        return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__).invoke(arg1);    \
     }                                                                         \
     NTF_MOCK_METHOD_1_IMP_NEW(RESULT, METHOD_NAME, ARG1)
 
@@ -1747,7 +1754,7 @@ struct Invocation2 {
   public:                                                                     \
     RESULT METHOD_NAME(ARG1 arg1) const override                              \
     {                                                                         \
-        return d_invocation_##METHOD_NAME.invoke(arg1);                       \
+        return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__).invoke(arg1);    \
     }                                                                         \
     NTF_MOCK_METHOD_1_IMP_NEW(RESULT, METHOD_NAME, ARG1)
 

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -826,7 +826,6 @@ class TestAllocator : public bslma::Allocator
 #include <bdlb_nullablevalue.h>
 #include <bsl_list.h>
 
-
 #define NTF_CAT2_(A, B) A##B
 #define NTF_CAT2(A, B) NTF_CAT2_(A, B)
 
@@ -841,8 +840,7 @@ class TestAllocator : public bslma::Allocator
 #define NTF_VA_SELECT(NAME, ...)                                              \
     NTF_SELECT(NAME, NTF_VA_SIZE(__VA_ARGS__))(__VA_ARGS__)
 
-
-namespace NewMock {
+namespace ntf_mock {
 
 template <class ARG>
 struct ProcessInterface {
@@ -1587,35 +1585,35 @@ struct Invocation3
 
 }
 
-#define NTF_MOCK_METHOD_0_IMP_NEW(RESULT, METHOD_NAME)                        \
+#define NTF_MOCK_METHOD_0_IMP(RESULT, METHOD_NAME)                            \
   public:                                                                     \
-    NewMock::Invocation0<RESULT>& expect_##METHOD_NAME()                      \
+    ntf_mock::Invocation0<RESULT>& expect_##METHOD_NAME()                         \
     {                                                                         \
         return d_invocation_##METHOD_NAME.expect();                           \
     }                                                                         \
                                                                               \
   private:                                                                    \
-    mutable NewMock::Invocation0<RESULT> d_invocation_##METHOD_NAME;
+    mutable ntf_mock::Invocation0<RESULT> d_invocation_##METHOD_NAME;
 
-#define NTF_MOCK_METHOD_1_IMP_NEW(RESULT, METHOD_NAME, ARG1)                  \
+#define NTF_MOCK_METHOD_1_IMP(RESULT, METHOD_NAME, ARG1)                      \
   public:                                                                     \
     template <class MATCHER>                                                  \
-    NewMock::Invocation1<RESULT, ARG1>& expect_##METHOD_NAME(                 \
+    ntf_mock::Invocation1<RESULT, ARG1>& expect_##METHOD_NAME(                    \
         const MATCHER& arg1,                                                  \
-        NewMock::TypeToType<ARG1> = NewMock::TypeToType<ARG1>())              \
+        ntf_mock::TypeToType<ARG1> = ntf_mock::TypeToType<ARG1>())                    \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__).expect(arg1);   \
     }                                                                         \
                                                                               \
   private:                                                                    \
-    mutable NewMock::Invocation1<RESULT, ARG1> NTF_CAT2(                      \
+    mutable ntf_mock::Invocation1<RESULT, ARG1> NTF_CAT2(                         \
         d_invocation_##METHOD_NAME,                                           \
         __LINE__);
 
-#define NTF_MOCK_METHOD_2_IMP_NEW(RESULT, METHOD_NAME, ARG1, ARG2)            \
+#define NTF_MOCK_METHOD_2_IMP(RESULT, METHOD_NAME, ARG1, ARG2)                \
   public:                                                                     \
     template <class MATCHER1, class MATCHER2>                                 \
-    NewMock::Invocation2<RESULT, ARG1, ARG2>& expect_##METHOD_NAME(           \
+    ntf_mock::Invocation2<RESULT, ARG1, ARG2>& expect_##METHOD_NAME(              \
         const MATCHER1& arg1,                                                 \
         const MATCHER2& arg2)                                                 \
     {                                                                         \
@@ -1624,25 +1622,25 @@ struct Invocation3
     }                                                                         \
                                                                               \
     template <class MATCHER1, class MATCHER2>                                 \
-    NewMock::Invocation2<RESULT, ARG1, ARG2>& expect_##METHOD_NAME(           \
+    ntf_mock::Invocation2<RESULT, ARG1, ARG2>& expect_##METHOD_NAME(              \
         const MATCHER1& arg1,                                                 \
-        NewMock::TypeToType<ARG1>,                                            \
+        ntf_mock::TypeToType<ARG1>,                                               \
         const MATCHER2& arg2,                                                 \
-        NewMock::TypeToType<ARG2> = NewMock::TypeToType<ARG2>())              \
+        ntf_mock::TypeToType<ARG2> = ntf_mock::TypeToType<ARG2>())                    \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__)                 \
             .expect(arg1, arg2);                                              \
     }                                                                         \
                                                                               \
   private:                                                                    \
-    mutable NewMock::Invocation2<RESULT, ARG1, ARG2> NTF_CAT2(                \
+    mutable ntf_mock::Invocation2<RESULT, ARG1, ARG2> NTF_CAT2(                   \
         d_invocation_##METHOD_NAME,                                           \
         __LINE__);
 
-#define NTF_MOCK_METHOD_3_IMP_NEW(RESULT, METHOD_NAME, ARG1, ARG2, ARG3)      \
+#define NTF_MOCK_METHOD_3_IMP(RESULT, METHOD_NAME, ARG1, ARG2, ARG3)          \
   public:                                                                     \
     template <class MATCHER1, class MATCHER2, class MATCHER3>                 \
-    NewMock::Invocation3<RESULT, ARG1, ARG2, ARG3>& expect_##METHOD_NAME(     \
+    ntf_mock::Invocation3<RESULT, ARG1, ARG2, ARG3>& expect_##METHOD_NAME(        \
         const MATCHER1& arg1,                                                 \
         const MATCHER2& arg2,                                                 \
         const MATCHER3& arg3)                                                 \
@@ -1652,109 +1650,106 @@ struct Invocation3
     }                                                                         \
                                                                               \
     template <class MATCHER1, class MATCHER2, class MATCHER3>                 \
-    NewMock::Invocation3<RESULT, ARG1, ARG2, ARG3>& expect_##METHOD_NAME(     \
+    ntf_mock::Invocation3<RESULT, ARG1, ARG2, ARG3>& expect_##METHOD_NAME(        \
         const MATCHER1& arg1,                                                 \
-        NewMock::TypeToType<ARG1>,                                            \
+        ntf_mock::TypeToType<ARG1>,                                               \
         const MATCHER2& arg2,                                                 \
-        NewMock::TypeToType<ARG2>,                                            \
+        ntf_mock::TypeToType<ARG2>,                                               \
         const MATCHER3& arg3,                                                 \
-        NewMock::TypeToType<ARG3>)                                            \
+        ntf_mock::TypeToType<ARG3>)                                               \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__)                 \
             .expect(arg1, arg2, arg3);                                        \
     }                                                                         \
                                                                               \
   private:                                                                    \
-    mutable NewMock::Invocation3<RESULT, ARG1, ARG2, ARG3> NTF_CAT2(          \
+    mutable ntf_mock::Invocation3<RESULT, ARG1, ARG2, ARG3> NTF_CAT2(             \
         d_invocation_##METHOD_NAME,                                           \
         __LINE__);
 
-#define NTF_MOCK_METHOD_NEW_0(RESULT, METHOD_NAME)                            \
+#define NTF_MOCK_METHOD_0(RESULT, METHOD_NAME)                                \
   public:                                                                     \
     RESULT METHOD_NAME() override                                             \
     {                                                                         \
         return d_invocation_##METHOD_NAME.invoke();                           \
     }                                                                         \
-    NTF_MOCK_METHOD_0_IMP_NEW(RESULT, METHOD_NAME)
+    NTF_MOCK_METHOD_0_IMP(RESULT, METHOD_NAME)
 
-#define NTF_MOCK_METHOD_CONST_NEW_0(RESULT, METHOD_NAME)                      \
+#define NTF_MOCK_METHOD_CONST_0(RESULT, METHOD_NAME)                          \
   public:                                                                     \
     RESULT METHOD_NAME() const override                                       \
     {                                                                         \
         return d_invocation_##METHOD_NAME.invoke();                           \
     }                                                                         \
-    NTF_MOCK_METHOD_0_IMP_NEW(RESULT, METHOD_NAME)
+    NTF_MOCK_METHOD_0_IMP(RESULT, METHOD_NAME)
 
-#define NTF_MOCK_METHOD_NEW_1(RESULT, METHOD_NAME, ARG1)                      \
+#define NTF_MOCK_METHOD_1(RESULT, METHOD_NAME, ARG1)                          \
   public:                                                                     \
     RESULT METHOD_NAME(ARG1 arg1) override                                    \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__).invoke(arg1);   \
     }                                                                         \
-    NTF_MOCK_METHOD_1_IMP_NEW(RESULT, METHOD_NAME, ARG1)
+    NTF_MOCK_METHOD_1_IMP(RESULT, METHOD_NAME, ARG1)
 
-#define NTF_MOCK_METHOD_CONST_NEW_1(RESULT, METHOD_NAME, ARG1)                \
+#define NTF_MOCK_METHOD_CONST_1(RESULT, METHOD_NAME, ARG1)                    \
   public:                                                                     \
     RESULT METHOD_NAME(ARG1 arg1) const override                              \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__).invoke(arg1);   \
     }                                                                         \
-    NTF_MOCK_METHOD_1_IMP_NEW(RESULT, METHOD_NAME, ARG1)
+    NTF_MOCK_METHOD_1_IMP(RESULT, METHOD_NAME, ARG1)
 
-#define NTF_MOCK_METHOD_NEW_2(RESULT, METHOD_NAME, ARG1, ARG2)                \
+#define NTF_MOCK_METHOD_2(RESULT, METHOD_NAME, ARG1, ARG2)                    \
   public:                                                                     \
     RESULT METHOD_NAME(ARG1 arg1, ARG2 arg2) override                         \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__)                 \
             .invoke(arg1, arg2);                                              \
     }                                                                         \
-    NTF_MOCK_METHOD_2_IMP_NEW(RESULT, METHOD_NAME, ARG1, ARG2)
+    NTF_MOCK_METHOD_2_IMP(RESULT, METHOD_NAME, ARG1, ARG2)
 
-#define NTF_MOCK_METHOD_CONST_NEW_2(RESULT, METHOD_NAME, ARG1, ARG2)          \
+#define NTF_MOCK_METHOD_CONST_2(RESULT, METHOD_NAME, ARG1, ARG2)              \
   public:                                                                     \
     RESULT METHOD_NAME(ARG1 arg1, ARG2 arg2) const override                   \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__)                 \
             .invoke(arg1, arg2);                                              \
     }                                                                         \
-    NTF_MOCK_METHOD_2_IMP_NEW(RESULT, METHOD_NAME, ARG1, ARG2)
+    NTF_MOCK_METHOD_2_IMP(RESULT, METHOD_NAME, ARG1, ARG2)
 
-#define NTF_MOCK_METHOD_NEW_3(RESULT, METHOD_NAME, ARG1, ARG2, ARG3)          \
+#define NTF_MOCK_METHOD_3(RESULT, METHOD_NAME, ARG1, ARG2, ARG3)              \
   public:                                                                     \
     RESULT METHOD_NAME(ARG1 arg1, ARG2 arg2, ARG3 arg3) override              \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__)                 \
             .invoke(arg1, arg2, arg3);                                        \
     }                                                                         \
-    NTF_MOCK_METHOD_3_IMP_NEW(RESULT, METHOD_NAME, ARG1, ARG2, ARG3)
+    NTF_MOCK_METHOD_3_IMP(RESULT, METHOD_NAME, ARG1, ARG2, ARG3)
 
-#define NTF_MOCK_METHOD_CONST_NEW_3(RESULT, METHOD_NAME, ARG1, ARG2, ARG3)    \
+#define NTF_MOCK_METHOD_CONST_3(RESULT, METHOD_NAME, ARG1, ARG2, ARG3)        \
   public:                                                                     \
     RESULT METHOD_NAME(ARG1 arg1, ARG2 arg2, ARG3 arg3) const override        \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__)                 \
             .invoke(arg1, arg2, arg3);                                        \
     }                                                                         \
-    NTF_MOCK_METHOD_3_IMP_NEW(RESULT, METHOD_NAME, ARG1, ARG2, ARG3)
+    NTF_MOCK_METHOD_3_IMP(RESULT, METHOD_NAME, ARG1, ARG2, ARG3)
 
-#define NTF_MOCK_METHOD_NEW(...)                                              \
-    NTF_VA_SELECT(NTF_MOCK_METHOD_NEW, __VA_ARGS__)
+#define NTF_MOCK_METHOD(...) NTF_VA_SELECT(NTF_MOCK_METHOD, __VA_ARGS__)
 
-#define NTF_MOCK_METHOD_CONST_NEW(...)                                        \
-    NTF_VA_SELECT(NTF_MOCK_METHOD_CONST_NEW, __VA_ARGS__)
+#define NTF_MOCK_METHOD_CONST(...)                                            \
+    NTF_VA_SELECT(NTF_MOCK_METHOD_CONST, __VA_ARGS__)
 
-#define NTF_EQ(ARG) NewMock::createEqMatcher<NewMock::DirectComparator>(ARG)
+#define NTF_EQ(ARG) ntf_mock::createEqMatcher<ntf_mock::DirectComparator>(ARG)
 #define NTF_EQ_SPEC(ARG, SPEC)                                                \
-    NewMock::createEqMatcher<NewMock::DirectComparator>(ARG),                 \
-        NewMock::TypeToType<SPEC>()
-#define IGNORE_ARG NewMock::IgnoreArg()
-#define IGNORE_ARG_S(SPEC) NewMock::IgnoreArg(), NewMock::TypeToType<SPEC>()
+    ntf_mock::createEqMatcher<ntf_mock::DirectComparator>(ARG),                       \
+        ntf_mock::TypeToType<SPEC>()
+#define IGNORE_ARG ntf_mock::IgnoreArg()
+#define IGNORE_ARG_S(SPEC) ntf_mock::IgnoreArg(), ntf_mock::TypeToType<SPEC>()
 
-#define NTF_EQ_DEREF(ARG)                                                     \
-    NewMock::createEqMatcher<NewMock::DerefComparator>(ARG)
+#define NTF_EQ_DEREF(ARG) ntf_mock::createEqMatcher<ntf_mock::DerefComparator>(ARG)
 #define NTF_EQ_DEREF_SPEC(ARG, SPEC)                                          \
-    NewMock::createEqMatcher<NewMock::DerefComparator>(ARG),                  \
-        NewMock::TypeToType<SPEC>()
+    ntf_mock::createEqMatcher<ntf_mock::DerefComparator>(ARG), ntf_mock::TypeToType<SPEC>()
 
 #define NTF_EXPECT_0(MOCK_OBJECT, METHOD) (MOCK_OBJECT).expect_##METHOD()
 #define NTF_EXPECT_1(MOCK_OBJECT, METHOD, ...)                                \
@@ -1771,17 +1766,17 @@ struct Invocation3
 #define TIMES(x) willTimes(x)
 #define RETURN(VAL) willReturn((VAL))
 
-#define TO(ARG) NewMock::createExtractor<NewMock::NoDerefPolicy>(ARG)
-#define TO_DEREF(ARG) NewMock::createExtractor<NewMock::DerefPolicy>(ARG)
+#define TO(ARG) ntf_mock::createExtractor<ntf_mock::NoDerefPolicy>(ARG)
+#define TO_DEREF(ARG) ntf_mock::createExtractor<ntf_mock::DerefPolicy>(ARG)
 
 #define SAVE_ARG_1(...) saveArg1(__VA_ARGS__)
 #define SAVE_ARG_2(...) saveArg2(__VA_ARGS__)
 #define SAVE_ARG_3(...) saveArg1(__VA_ARGS__)
 #define SAVE_ARG_4(...) saveArg2(__VA_ARGS__)
 
-#define FROM(ARG) NewMock::createSetter<NewMock::DefaultSetter>(ARG)
+#define FROM(ARG) ntf_mock::createSetter<ntf_mock::DefaultSetter>(ARG)
 
-#define FROM_DEREF(ARG) NewMock::createSetter<NewMock::DerefSetter>(ARG)
+#define FROM_DEREF(ARG) ntf_mock::createSetter<ntf_mock::DerefSetter>(ARG)
 
 #define SET_ARG_1(...) setArg1(__VA_ARGS__)
 #define SET_ARG_2(...) setArg2(__VA_ARGS__)

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -1983,7 +1983,7 @@ struct Invocation3
 {
     typedef InvocationData<RESULT, ARG1, ARG2, ARG3> InvocationDataT;
 
-    RESULT invoke(ARG1 arg1, ARG2 arg2)
+    RESULT invoke(ARG1 arg1, ARG2 arg2, ARG3 arg3)
     {
         NTCCFG_TEST_FALSE(d_invocations.empty());
         InvocationDataT& invocation = d_invocations.front();
@@ -1991,7 +1991,7 @@ struct Invocation3
             NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
         }
 
-        invocation.processArgs(arg1, arg2);
+        invocation.processArgs(arg1, arg2, arg3);
 
         InvocationResult<RESULT> result = invocation.d_result;  //copy by value
         if (invocation.d_expectedCalls != InvocationDataT::k_INFINITE_CALLS) {
@@ -2112,7 +2112,7 @@ struct Invocation3
             .expect(arg1, arg2, arg3);                                        \
     }                                                                         \
                                                                               \
-    template <class MATCHER1, class MATCHER2, class MATCHER 3>                \
+    template <class MATCHER1, class MATCHER2, class MATCHER3>                 \
     NewMock::Invocation3<RESULT, ARG1, ARG2, ARG3>& expect_##METHOD_NAME(     \
         const MATCHER1& arg1,                                                 \
         NewMock::TypeToType<ARG1>,                                            \

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -1437,7 +1437,12 @@ struct Invocation0
 
     RESULT invoke()
     {
-        NTCCFG_TEST_FALSE(d_storage.d_invocations.empty());
+        if (d_storage.d_invocations.empty()) {
+            BSLS_LOG_FATAL("%s: unexpected call to \"%s\"",
+                           METHOD_INFO().mockName,
+                           METHOD_INFO().name);
+            bsl::abort();
+        }
         InvocationDataT& invocation = d_storage.d_invocations.front();
         if (invocation.d_expectedCalls != InvocationDataT::k_INFINITE_CALLS) {
             NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
@@ -1495,7 +1500,12 @@ struct Invocation1
 
     RESULT invoke(ARG1 arg)
     {
-        NTCCFG_TEST_FALSE(d_storage.d_invocations.empty());
+        if (d_storage.d_invocations.empty()) {
+            BSLS_LOG_FATAL("%s: unexpected call to \"%s\"",
+                           METHOD_INFO().mockName,
+                           METHOD_INFO().name);
+            bsl::abort();
+        }
         InvocationDataT& invocation = d_storage.d_invocations.front();
         if (invocation.d_expectedCalls != InvocationDataT::k_INFINITE_CALLS) {
             NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
@@ -1560,7 +1570,12 @@ struct Invocation2
 
     RESULT invoke(ARG1 arg1, ARG2 arg2)
     {
-        NTCCFG_TEST_FALSE(d_storage.d_invocations.empty());
+        if (d_storage.d_invocations.empty()) {
+            BSLS_LOG_FATAL("%s: unexpected call to \"%s\"",
+                           METHOD_INFO().mockName,
+                           METHOD_INFO().name);
+            bsl::abort();
+        }
         InvocationDataT& invocation = d_storage.d_invocations.front();
         if (invocation.d_expectedCalls != InvocationDataT::k_INFINITE_CALLS) {
             NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
@@ -1637,7 +1652,12 @@ struct Invocation3
 
     RESULT invoke(ARG1 arg1, ARG2 arg2, ARG3 arg3)
     {
-        NTCCFG_TEST_FALSE(d_storage.d_invocations.empty());
+        if (d_storage.d_invocations.empty()) {
+            BSLS_LOG_FATAL("%s: unexpected call to \"%s\"",
+                           METHOD_INFO().mockName,
+                           METHOD_INFO().name);
+            bsl::abort();
+        }
         InvocationDataT& invocation = d_storage.d_invocations.front();
         if (invocation.d_expectedCalls != InvocationDataT::k_INFINITE_CALLS) {
             NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -1850,7 +1850,7 @@ struct Invocation3
 
 #define NTF_MOCK_METHOD_0(RESULT, METHOD_NAME)                                \
   public:                                                                     \
-    RESULT METHOD_NAME() override                                             \
+    RESULT METHOD_NAME() BSLS_KEYWORD_OVERRIDE                                \
     {                                                                         \
         return d_invocation_##METHOD_NAME.invoke();                           \
     }                                                                         \
@@ -1858,7 +1858,7 @@ struct Invocation3
 
 #define NTF_MOCK_METHOD_CONST_0(RESULT, METHOD_NAME)                          \
   public:                                                                     \
-    RESULT METHOD_NAME() const override                                       \
+    RESULT METHOD_NAME() const BSLS_KEYWORD_OVERRIDE                          \
     {                                                                         \
         return d_invocation_##METHOD_NAME.invoke();                           \
     }                                                                         \
@@ -1866,7 +1866,7 @@ struct Invocation3
 
 #define NTF_MOCK_METHOD_1(RESULT, METHOD_NAME, ARG1)                          \
   public:                                                                     \
-    RESULT METHOD_NAME(ARG1 arg1) override                                    \
+    RESULT METHOD_NAME(ARG1 arg1) BSLS_KEYWORD_OVERRIDE                       \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__).invoke(arg1);   \
     }                                                                         \
@@ -1874,7 +1874,7 @@ struct Invocation3
 
 #define NTF_MOCK_METHOD_CONST_1(RESULT, METHOD_NAME, ARG1)                    \
   public:                                                                     \
-    RESULT METHOD_NAME(ARG1 arg1) const override                              \
+    RESULT METHOD_NAME(ARG1 arg1) const BSLS_KEYWORD_OVERRIDE                 \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__).invoke(arg1);   \
     }                                                                         \
@@ -1882,7 +1882,7 @@ struct Invocation3
 
 #define NTF_MOCK_METHOD_2(RESULT, METHOD_NAME, ARG1, ARG2)                    \
   public:                                                                     \
-    RESULT METHOD_NAME(ARG1 arg1, ARG2 arg2) override                         \
+    RESULT METHOD_NAME(ARG1 arg1, ARG2 arg2) BSLS_KEYWORD_OVERRIDE            \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__)                 \
             .invoke(arg1, arg2);                                              \
@@ -1891,7 +1891,7 @@ struct Invocation3
 
 #define NTF_MOCK_METHOD_CONST_2(RESULT, METHOD_NAME, ARG1, ARG2)              \
   public:                                                                     \
-    RESULT METHOD_NAME(ARG1 arg1, ARG2 arg2) const override                   \
+    RESULT METHOD_NAME(ARG1 arg1, ARG2 arg2) const BSLS_KEYWORD_OVERRIDE      \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__)                 \
             .invoke(arg1, arg2);                                              \
@@ -1900,7 +1900,7 @@ struct Invocation3
 
 #define NTF_MOCK_METHOD_3(RESULT, METHOD_NAME, ARG1, ARG2, ARG3)              \
   public:                                                                     \
-    RESULT METHOD_NAME(ARG1 arg1, ARG2 arg2, ARG3 arg3) override              \
+    RESULT METHOD_NAME(ARG1 arg1, ARG2 arg2, ARG3 arg3) BSLS_KEYWORD_OVERRIDE \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__)                 \
             .invoke(arg1, arg2, arg3);                                        \
@@ -1909,7 +1909,8 @@ struct Invocation3
 
 #define NTF_MOCK_METHOD_CONST_3(RESULT, METHOD_NAME, ARG1, ARG2, ARG3)        \
   public:                                                                     \
-    RESULT METHOD_NAME(ARG1 arg1, ARG2 arg2, ARG3 arg3) const override        \
+    RESULT METHOD_NAME(ARG1 arg1, ARG2 arg2, ARG3 arg3)                       \
+        const BSLS_KEYWORD_OVERRIDE                                           \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__)                 \
             .invoke(arg1, arg2, arg3);                                        \

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -981,7 +981,7 @@ class Invocation1 : public InvocationBase<InvocationDataArg1<RESULT, ARG1>,
     {
         this->d_invocations.emplace_back();
         InvocationDataImpl& invocation = this->d_invocations.back();
-        //        TODO: save arg1
+        invocation.d_arg1              = arg1;
         return *this;
     }
 
@@ -992,7 +992,12 @@ class Invocation1 : public InvocationBase<InvocationDataArg1<RESULT, ARG1>,
         if (invocation.d_expectedCalls != -1) {
             NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
         }
-        //TODO: match arg1
+        if (invocation.d_arg1.has_value()) {
+            NTCCFG_TEST_EQ(arg1, invocation.d_arg1.value());
+        }
+        if (invocation.d_arg1_out) {
+            *invocation.d_arg1_out = arg1;
+        }
         NTCCFG_TEST_TRUE(invocation.d_result.has_value());
         const auto result = invocation.d_result.value();
         if (invocation.d_expectedCalls != -1) {

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -1688,11 +1688,6 @@ struct Invocation<METHOD_INFO, RESULT, NoArgs>
     }
 };
 
-template <class T>
-struct TypeToType {
-    typedef T Type;
-};
-
 }
 
 #define NTF_METHOD_INFO(METHOD_NAME)                                          \
@@ -1730,8 +1725,8 @@ struct TypeToType {
                          RESULT,                                              \
                          BloombergLP::bslmf::TypeList<ARG1> >&                \
         expect_##METHOD_NAME(const MATCHER& arg1,                             \
-                             ntf_mock::TypeToType<ARG1> =                     \
-                                 ntf_mock::TypeToType<ARG1>())                \
+                             bsl::type_identity<ARG1> =                       \
+                                 bsl::type_identity<ARG1>())                  \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__)                 \
             .get()                                                            \
@@ -1763,10 +1758,10 @@ struct TypeToType {
                          RESULT,                                              \
                          BloombergLP::bslmf::TypeList<ARG1, ARG2> >&          \
         expect_##METHOD_NAME(const MATCHER1& arg1,                            \
-                             ntf_mock::TypeToType<ARG1>,                      \
+                             bsl::type_identity<ARG1>,                        \
                              const MATCHER2& arg2,                            \
-                             ntf_mock::TypeToType<ARG2> =                     \
-                                 ntf_mock::TypeToType<ARG2>())                \
+                             bsl::type_identity<ARG2> =                       \
+                                 bsl::type_identity<ARG2>())                  \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__)                 \
             .get()                                                            \
@@ -1800,11 +1795,11 @@ struct TypeToType {
                          RESULT,                                              \
                          BloombergLP::bslmf::TypeList<ARG1, ARG2, ARG3> >&    \
         expect_##METHOD_NAME(const MATCHER1& arg1,                            \
-                             ntf_mock::TypeToType<ARG1>,                      \
+                             bsl::type_identity<ARG1>,                        \
                              const MATCHER2& arg2,                            \
-                             ntf_mock::TypeToType<ARG2>,                      \
+                             bsl::type_identity<ARG2>,                        \
                              const MATCHER3& arg3,                            \
-                             ntf_mock::TypeToType<ARG3>)                      \
+                             bsl::type_identity<ARG3>)                        \
     {                                                                         \
         return NTF_CAT2(d_invocation_##METHOD_NAME, __LINE__)                 \
             .get()                                                            \
@@ -1917,15 +1912,15 @@ struct TypeToType {
 #define NTF_EQ(ARG) ntf_mock::createEqMatcher<ntf_mock::DirectComparator>(ARG)
 #define NTF_EQ_SPEC(ARG, SPEC)                                                \
     ntf_mock::createEqMatcher<ntf_mock::DirectComparator>(ARG),               \
-        ntf_mock::TypeToType<SPEC>()
+        bsl::type_identity<SPEC>()
 #define IGNORE_ARG ntf_mock::IgnoreArg()
-#define IGNORE_ARG_S(SPEC) ntf_mock::IgnoreArg(), ntf_mock::TypeToType<SPEC>()
+#define IGNORE_ARG_S(SPEC) ntf_mock::IgnoreArg(), bsl::type_identity<SPEC>()
 
 #define NTF_EQ_DEREF(ARG)                                                     \
     ntf_mock::createEqMatcher<ntf_mock::DerefComparator>(ARG)
 #define NTF_EQ_DEREF_SPEC(ARG, SPEC)                                          \
     ntf_mock::createEqMatcher<ntf_mock::DerefComparator>(ARG),                \
-        ntf_mock::TypeToType<SPEC>()
+        bsl::type_identity<SPEC>()
 
 #define NTF_EXPECT_0(MOCK_OBJECT, METHOD) (MOCK_OBJECT).expect_##METHOD()
 #define NTF_EXPECT_1(MOCK_OBJECT, METHOD, ...)                                \

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -824,6 +824,7 @@ class TestAllocator : public bslma::Allocator
 #endif
 
 #include <bdlb_nullablevalue.h>
+#include <bslmf_removecvref.h>
 #include <bsl_list.h>
 
 namespace framework {
@@ -848,8 +849,9 @@ struct InvocationResult<void> {
 
 template <typename ARG1>
 struct InvocationArg1 {
-    BloombergLP::bdlb::NullableValue<ARG1> d_arg1;
-    ARG1*                                  d_arg1_out;
+    typedef typename bsl::remove_cvref<ARG1>::type ARG1_type;
+    BloombergLP::bdlb::NullableValue<ARG1_type> d_arg1;
+    ARG1_type*                                  d_arg1_out;
 
     InvocationArg1()
     : d_arg1()
@@ -915,6 +917,7 @@ class InvocationBaseInvoke
         }
         return result;
     }
+
   private:
     virtual INVOCATION_DATA& getInvocationDataFront()    = 0;
     virtual void             removeInvocationDataFront() = 0;
@@ -939,8 +942,6 @@ class InvocationBaseInvoke<INVOCATION_DATA, void>
     virtual INVOCATION_DATA& getInvocationDataFront()    = 0;
     virtual void             removeInvocationDataFront() = 0;
 };
-
-
 
 template <typename SELF, typename INVOCATION_DATA>
 class InvocationBaseOnceAlways
@@ -1029,8 +1030,9 @@ class Invocation1 : public InvocationBase<InvocationDataArg1<RESULT, ARG1>,
     typedef InvocationDataArg1<RESULT, ARG1> InvocationDataImpl;
 
   public:
-    Invocation1& expect(
-        const BloombergLP::bdlb::NullableValue<ARG1>& arg1)
+    typedef typename bsl::remove_cvref<ARG1>::type ARG1_type;
+
+    Invocation1& expect(const BloombergLP::bdlb::NullableValue<ARG1_type>& arg1)
     {
         this->d_invocations.emplace_back();
         InvocationDataImpl& invocation = this->d_invocations.back();
@@ -1038,7 +1040,7 @@ class Invocation1 : public InvocationBase<InvocationDataArg1<RESULT, ARG1>,
         return *this;
     }
 
-    RESULT invoke(const ARG1& arg1)
+    RESULT invoke(const ARG1_type& arg1)
     {
         NTCCFG_TEST_FALSE(this->d_invocations.empty());
         InvocationDataImpl& invocation = this->d_invocations.front();
@@ -1083,7 +1085,7 @@ class Invocation1 : public InvocationBase<InvocationDataArg1<RESULT, ARG1>,
 #define NTF_MOCK_METHOD_1_IMP(RESULT, METHOD_NAME, ARG1)                      \
   public:                                                                     \
     framework::internal::Invocation1<RESULT, ARG1>& expect_##METHOD_NAME(     \
-        const bdlb::NullableValue<ARG1>& arg1)                                \
+        const bdlb::NullableValue<bsl::remove_cvref<ARG1>::type>& arg1)       \
     {                                                                         \
         return d_invocation_##METHOD_NAME.expect(arg1);                       \
     }                                                                         \

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -22,6 +22,7 @@ BSLS_IDENT("$Id: $")
 #include <ntccfg_config.h>
 #include <ntccfg_platform.h>
 #include <ntcscm_version.h>
+#include <bdlb_nullablevalue.h>
 #include <bdlt_currenttime.h>
 #include <bdlt_datetime.h>
 #include <bdlt_epochutil.h>
@@ -36,6 +37,7 @@ BSLS_IDENT("$Id: $")
 #include <bsl_cstdio.h>
 #include <bsl_cstdlib.h>
 #include <bsl_cstring.h>
+#include <bsl_list.h>
 #include <bsl_ostream.h>
 #include <bsl_sstream.h>
 #include <bsl_stdexcept.h>
@@ -697,135 +699,6 @@ class TestAllocator : public bslma::Allocator
         bsl::printf("Running test case %d\n", number);                        \
         runTestCase##number();                                                \
         return 0;
-
-#endif
-
-/// @internal @brief
-/// Log at the fatal severity level.
-///
-/// @ingroup module_ntccfg
-#define NTCCFG_TEST_LOG_FATAL                                                 \
-    if (BloombergLP::bsls::LogSeverity::e_FATAL <=                            \
-        BloombergLP::bsls::Log::severityThreshold())                          \
-    {                                                                         \
-        BloombergLP::bsls::LogSeverity::Enum ntclSeverity =                   \
-            BloombergLP::bsls::LogSeverity::e_FATAL;                          \
-        bsl::stringstream ntclStream;                                         \
-        ntclStream
-
-/// @internal @brief
-/// Log at the error severity level.
-///
-/// @ingroup module_ntccfg
-#define NTCCFG_TEST_LOG_ERROR                                                 \
-    if (BloombergLP::bsls::LogSeverity::e_ERROR <=                            \
-        BloombergLP::bsls::Log::severityThreshold())                          \
-    {                                                                         \
-        BloombergLP::bsls::LogSeverity::Enum ntclSeverity =                   \
-            BloombergLP::bsls::LogSeverity::e_ERROR;                          \
-        bsl::stringstream ntclStream;                                         \
-        ntclStream
-
-/// @internal @brief
-/// Log at the warn severity level.
-///
-/// @ingroup module_ntccfg
-#define NTCCFG_TEST_LOG_WARN                                                  \
-    if (BloombergLP::bsls::LogSeverity::e_WARN <=                             \
-        BloombergLP::bsls::Log::severityThreshold())                          \
-    {                                                                         \
-        BloombergLP::bsls::LogSeverity::Enum ntclSeverity =                   \
-            BloombergLP::bsls::LogSeverity::e_WARN;                           \
-        bsl::stringstream ntclStream;                                         \
-        ntclStream
-
-/// @internal @brief
-/// Log at the info severity level.
-///
-/// @ingroup module_ntccfg
-#define NTCCFG_TEST_LOG_INFO                                                  \
-    if (BloombergLP::bsls::LogSeverity::e_INFO <=                             \
-        BloombergLP::bsls::Log::severityThreshold())                          \
-    {                                                                         \
-        BloombergLP::bsls::LogSeverity::Enum ntclSeverity =                   \
-            BloombergLP::bsls::LogSeverity::e_INFO;                           \
-        bsl::stringstream ntclStream;                                         \
-        ntclStream
-
-/// @internal @brief
-/// Log at the debug severity level.
-///
-/// @ingroup module_ntccfg
-#define NTCCFG_TEST_LOG_DEBUG                                                 \
-    if (BloombergLP::bsls::LogSeverity::e_DEBUG <=                            \
-        BloombergLP::bsls::Log::severityThreshold())                          \
-    {                                                                         \
-        BloombergLP::bsls::LogSeverity::Enum ntclSeverity =                   \
-            BloombergLP::bsls::LogSeverity::e_DEBUG;                          \
-        bsl::stringstream ntclStream;                                         \
-        ntclStream
-
-/// @internal @brief
-/// Log at the trace severity level.
-///
-/// @ingroup module_ntccfg
-#define NTCCFG_TEST_LOG_TRACE                                                 \
-    if (BloombergLP::bsls::LogSeverity::e_TRACE <=                            \
-        BloombergLP::bsls::Log::severityThreshold())                          \
-    {                                                                         \
-        BloombergLP::bsls::LogSeverity::Enum ntclSeverity =                   \
-            BloombergLP::bsls::LogSeverity::e_TRACE;                          \
-        bsl::stringstream ntclStream;                                         \
-        ntclStream
-
-/// @internal @brief
-/// End logging.
-///
-/// @ingroup module_ntccfg
-#define NTCCFG_TEST_LOG_END                                                   \
-    bsl::flush;                                                               \
-    BloombergLP::bsls::Log::logFormattedMessage(ntclSeverity,                 \
-                                                __FILE__,                     \
-                                                __LINE__,                     \
-                                                "%s",                         \
-                                                ntclStream.str().c_str());    \
-    }
-
-#if defined(BSLS_PLATFORM_CMP_GNU)
-
-#pragma GCC diagnostic ignored "-Wpedantic"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wconversion"
-#pragma GCC diagnostic ignored "-Wsign-compare"
-
-#elif defined(BSLS_PLATFORM_CMP_CLANG)
-
-#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#pragma clang diagnostic ignored "-Wunused-variable"
-#pragma clang diagnostic ignored "-Wshorten-64-to-32"
-#pragma clang diagnostic ignored "-Wconversion"
-#pragma clang diagnostic ignored "-Wsign-compare"
-
-#elif defined(BSLS_PLATFORM_CMP_SUN)
-
-// ...
-
-#elif defined(BSLS_PLATFORM_CMP_IBM)
-
-// ...
-
-#elif defined(BSLS_PLATFORM_CMP_MSVC)
-
-#pragma warning(push, 0)
-
-#else
-#error Not implemented
-#endif
-
-#include <bdlb_nullablevalue.h>
-#include <bsl_list.h>
 
 #define NTF_CAT2_(A, B) A##B
 #define NTF_CAT2(A, B) NTF_CAT2_(A, B)
@@ -1954,3 +1827,129 @@ struct Invocation<METHOD_INFO, RESULT, NoArgs>
 #define SET_ARG_2(...) setArg<1>(__VA_ARGS__)
 #define SET_ARG_3(...) setArg<2>(__VA_ARGS__)
 #define SET_ARG_4(...) setArg<3>(__VA_ARGS__)
+
+#endif
+
+/// @internal @brief
+/// Log at the fatal severity level.
+///
+/// @ingroup module_ntccfg
+#define NTCCFG_TEST_LOG_FATAL                                                 \
+    if (BloombergLP::bsls::LogSeverity::e_FATAL <=                            \
+        BloombergLP::bsls::Log::severityThreshold())                          \
+    {                                                                         \
+        BloombergLP::bsls::LogSeverity::Enum ntclSeverity =                   \
+            BloombergLP::bsls::LogSeverity::e_FATAL;                          \
+        bsl::stringstream ntclStream;                                         \
+        ntclStream
+
+/// @internal @brief
+/// Log at the error severity level.
+///
+/// @ingroup module_ntccfg
+#define NTCCFG_TEST_LOG_ERROR                                                 \
+    if (BloombergLP::bsls::LogSeverity::e_ERROR <=                            \
+        BloombergLP::bsls::Log::severityThreshold())                          \
+    {                                                                         \
+        BloombergLP::bsls::LogSeverity::Enum ntclSeverity =                   \
+            BloombergLP::bsls::LogSeverity::e_ERROR;                          \
+        bsl::stringstream ntclStream;                                         \
+        ntclStream
+
+/// @internal @brief
+/// Log at the warn severity level.
+///
+/// @ingroup module_ntccfg
+#define NTCCFG_TEST_LOG_WARN                                                  \
+    if (BloombergLP::bsls::LogSeverity::e_WARN <=                             \
+        BloombergLP::bsls::Log::severityThreshold())                          \
+    {                                                                         \
+        BloombergLP::bsls::LogSeverity::Enum ntclSeverity =                   \
+            BloombergLP::bsls::LogSeverity::e_WARN;                           \
+        bsl::stringstream ntclStream;                                         \
+        ntclStream
+
+/// @internal @brief
+/// Log at the info severity level.
+///
+/// @ingroup module_ntccfg
+#define NTCCFG_TEST_LOG_INFO                                                  \
+    if (BloombergLP::bsls::LogSeverity::e_INFO <=                             \
+        BloombergLP::bsls::Log::severityThreshold())                          \
+    {                                                                         \
+        BloombergLP::bsls::LogSeverity::Enum ntclSeverity =                   \
+            BloombergLP::bsls::LogSeverity::e_INFO;                           \
+        bsl::stringstream ntclStream;                                         \
+        ntclStream
+
+/// @internal @brief
+/// Log at the debug severity level.
+///
+/// @ingroup module_ntccfg
+#define NTCCFG_TEST_LOG_DEBUG                                                 \
+    if (BloombergLP::bsls::LogSeverity::e_DEBUG <=                            \
+        BloombergLP::bsls::Log::severityThreshold())                          \
+    {                                                                         \
+        BloombergLP::bsls::LogSeverity::Enum ntclSeverity =                   \
+            BloombergLP::bsls::LogSeverity::e_DEBUG;                          \
+        bsl::stringstream ntclStream;                                         \
+        ntclStream
+
+/// @internal @brief
+/// Log at the trace severity level.
+///
+/// @ingroup module_ntccfg
+#define NTCCFG_TEST_LOG_TRACE                                                 \
+    if (BloombergLP::bsls::LogSeverity::e_TRACE <=                            \
+        BloombergLP::bsls::Log::severityThreshold())                          \
+    {                                                                         \
+        BloombergLP::bsls::LogSeverity::Enum ntclSeverity =                   \
+            BloombergLP::bsls::LogSeverity::e_TRACE;                          \
+        bsl::stringstream ntclStream;                                         \
+        ntclStream
+
+/// @internal @brief
+/// End logging.
+///
+/// @ingroup module_ntccfg
+#define NTCCFG_TEST_LOG_END                                                   \
+    bsl::flush;                                                               \
+    BloombergLP::bsls::Log::logFormattedMessage(ntclSeverity,                 \
+                                                __FILE__,                     \
+                                                __LINE__,                     \
+                                                "%s",                         \
+                                                ntclStream.str().c_str());    \
+    }
+
+#if defined(BSLS_PLATFORM_CMP_GNU)
+
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wsign-compare"
+
+#elif defined(BSLS_PLATFORM_CMP_CLANG)
+
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#pragma clang diagnostic ignored "-Wconversion"
+#pragma clang diagnostic ignored "-Wsign-compare"
+
+#elif defined(BSLS_PLATFORM_CMP_SUN)
+
+// ...
+
+#elif defined(BSLS_PLATFORM_CMP_IBM)
+
+// ...
+
+#elif defined(BSLS_PLATFORM_CMP_MSVC)
+
+#pragma warning(push, 0)
+
+#else
+#error Not implemented
+#endif

--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -719,7 +719,7 @@ namespace ntf_mock {
 template <class ARG>
 struct ProcessInterface {
     virtual void process(const ARG& arg) = 0;
-    virtual ~    ProcessInterface()
+    virtual ~ProcessInterface()
     {
     }
 };
@@ -727,7 +727,7 @@ struct ProcessInterface {
 template <class ARG>
 struct SetterInterface {
     virtual void process(ARG arg) = 0;
-    virtual ~    SetterInterface()
+    virtual ~SetterInterface()
     {
     }
 };
@@ -751,8 +751,7 @@ struct DefaultSetter {
 template <class IN, template <class, class> class SET_POLICY>
 struct Setter {
     template <class ARG>
-    struct SetterImpl
-    {
+    struct SetterImpl {
         static void process(ARG arg, const IN& in)
         {
             SET_POLICY<ARG, IN>::set(arg, in);
@@ -783,7 +782,7 @@ struct SetterHolder : SetterInterface<ARG> {
 
     void process(ARG arg) BSLS_KEYWORD_OVERRIDE
     {
-        SETTER::SetterImpl<ARG>::process(arg, d_setter.d_in);
+        SETTER::template SetterImpl<ARG>::process(arg, d_setter.d_in);
     }
 
     SETTER d_setter;
@@ -1073,7 +1072,7 @@ struct InvocationArgsImpl;
 
 template <class TL>
 struct InvocationArgsImpl<TL, bsl::integral_constant<int, 0> > {
-    typedef typename BloombergLP::bslmf::TypeListTypeAt<0, TL>::Type ArgType;
+    typedef typename BloombergLP::bslmf::TypeListTypeOf<1, TL>::Type ArgType;
 
     bsl::shared_ptr<ProcessInterface<ArgType> > d_matcher;
     bsl::shared_ptr<ProcessInterface<ArgType> > d_extractor;
@@ -1096,8 +1095,9 @@ struct InvocationArgsImpl<TL, bsl::integral_constant<int, 0> > {
 template <class TL, int ARG_INDEX>
 struct InvocationArgsImpl<TL, bsl::integral_constant<int, ARG_INDEX> >
 : public InvocationArgsImpl<TL, bsl::integral_constant<int, ARG_INDEX - 1> > {
-    typedef typename BloombergLP::bslmf::TypeListTypeAt<ARG_INDEX, TL>::Type
-        ArgType;
+    typedef
+        typename BloombergLP::bslmf::TypeListTypeOf<ARG_INDEX + 1, TL>::Type
+            ArgType;
 
     bsl::shared_ptr<ProcessInterface<ArgType> > d_matcher;
     bsl::shared_ptr<ProcessInterface<ArgType> > d_extractor;
@@ -1139,7 +1139,7 @@ struct ProcessArgs;
 template <class ARG_LIST>
 struct ProcessArgs<1, ARG_LIST> {
     typedef
-        typename BloombergLP::bslmf::TypeListTypeAt<0, ARG_LIST>::Type Arg0;
+        typename BloombergLP::bslmf::TypeListTypeOf<1, ARG_LIST>::Type Arg0;
     template <class INVOCATION_ARGS>
     static void process(INVOCATION_ARGS& args, Arg0 arg0)
     {
@@ -1150,9 +1150,9 @@ struct ProcessArgs<1, ARG_LIST> {
 template <class ARG_LIST>
 struct ProcessArgs<2, ARG_LIST> {
     typedef
-        typename BloombergLP::bslmf::TypeListTypeAt<0, ARG_LIST>::Type Arg0;
+        typename BloombergLP::bslmf::TypeListTypeOf<1, ARG_LIST>::Type Arg0;
     typedef
-        typename BloombergLP::bslmf::TypeListTypeAt<1, ARG_LIST>::Type Arg1;
+        typename BloombergLP::bslmf::TypeListTypeOf<2, ARG_LIST>::Type Arg1;
 
     template <class INVOCATION_ARGS>
     static void process(INVOCATION_ARGS& args, Arg0 arg0, Arg1 arg1)
@@ -1165,11 +1165,11 @@ struct ProcessArgs<2, ARG_LIST> {
 template <class ARG_LIST>
 struct ProcessArgs<3, ARG_LIST> {
     typedef
-        typename BloombergLP::bslmf::TypeListTypeAt<0, ARG_LIST>::Type Arg0;
+        typename BloombergLP::bslmf::TypeListTypeOf<1, ARG_LIST>::Type Arg0;
     typedef
-        typename BloombergLP::bslmf::TypeListTypeAt<1, ARG_LIST>::Type Arg1;
+        typename BloombergLP::bslmf::TypeListTypeOf<2, ARG_LIST>::Type Arg1;
     typedef
-        typename BloombergLP::bslmf::TypeListTypeAt<2, ARG_LIST>::Type Arg2;
+        typename BloombergLP::bslmf::TypeListTypeOf<3, ARG_LIST>::Type Arg2;
     template <class INVOCATION_ARGS>
     static void process(INVOCATION_ARGS& args, Arg0 arg0, Arg1 arg1, Arg2 arg2)
     {
@@ -1182,13 +1182,13 @@ struct ProcessArgs<3, ARG_LIST> {
 template <class ARG_LIST>
 struct ProcessArgs<4, ARG_LIST> {
     typedef
-        typename BloombergLP::bslmf::TypeListTypeAt<0, ARG_LIST>::Type Arg0;
+        typename BloombergLP::bslmf::TypeListTypeOf<1, ARG_LIST>::Type Arg0;
     typedef
-        typename BloombergLP::bslmf::TypeListTypeAt<1, ARG_LIST>::Type Arg1;
+        typename BloombergLP::bslmf::TypeListTypeOf<2, ARG_LIST>::Type Arg1;
     typedef
-        typename BloombergLP::bslmf::TypeListTypeAt<2, ARG_LIST>::Type Arg2;
+        typename BloombergLP::bslmf::TypeListTypeOf<3, ARG_LIST>::Type Arg2;
     typedef
-        typename BloombergLP::bslmf::TypeListTypeAt<3, ARG_LIST>::Type Arg3;
+        typename BloombergLP::bslmf::TypeListTypeOf<4, ARG_LIST>::Type Arg3;
 
     template <class INVOCATION_ARGS>
     static void process(INVOCATION_ARGS& args,
@@ -1220,7 +1220,7 @@ struct InvocationBaseSaveSetArg {
     template <int ARG_INDEX, class ARG_EXTRACTOR>
     SELF& saveArg(const ARG_EXTRACTOR& extractor)
     {
-        typedef typename BloombergLP::bslmf::TypeListTypeAt<ARG_INDEX,
+        typedef typename BloombergLP::bslmf::TypeListTypeOf<ARG_INDEX + 1,
                                                             ARG_LIST>::Type
                          ArgType;
         INVOCATION_DATA& data = this->getInvocationDataBack();
@@ -1237,7 +1237,7 @@ struct InvocationBaseSaveSetArg {
     template <int ARG_INDEX, class ARG_SETTER>
     SELF& setArg(const ARG_SETTER& setter)
     {
-        typedef typename BloombergLP::bslmf::TypeListTypeAt<ARG_INDEX,
+        typedef typename BloombergLP::bslmf::TypeListTypeOf<ARG_INDEX + 1,
                                                             ARG_LIST>::Type
                          ArgType;
         INVOCATION_DATA& data = this->getInvocationDataBack();
@@ -1294,9 +1294,15 @@ template <class METHOD_INFO, class RESULT, class ARG_LIST>
 struct InvocationImpl<1, METHOD_INFO, RESULT, ARG_LIST>
 : public InvocationImplBase<Invocation<METHOD_INFO, RESULT, ARG_LIST> > {
     typedef Invocation<METHOD_INFO, RESULT, ARG_LIST> InvocationType;
-    typedef InvocationType::InvocationDataT           InvocationDataT;
+    typedef InvocationImplBase<InvocationType>        BaseType;
+    typedef typename InvocationType::InvocationDataT  InvocationDataT;
     typedef
-        typename BloombergLP::bslmf::TypeListTypeAt<0, ARG_LIST>::Type ARG1;
+        typename BloombergLP::bslmf::TypeListTypeOf<1, ARG_LIST>::Type ARG1;
+
+    InvocationImpl(InvocationType& inv)
+    : BaseType(inv)
+    {
+    }
 
     RESULT invoke(ARG1 arg)
     {
@@ -1351,11 +1357,17 @@ template <class METHOD_INFO, class RESULT, class ARG_LIST>
 struct InvocationImpl<2, METHOD_INFO, RESULT, ARG_LIST>
 : public InvocationImplBase<Invocation<METHOD_INFO, RESULT, ARG_LIST> > {
     typedef Invocation<METHOD_INFO, RESULT, ARG_LIST> InvocationType;
-    typedef InvocationType::InvocationDataT           InvocationDataT;
+    typedef InvocationImplBase<InvocationType>        BaseType;
+    typedef typename InvocationType::InvocationDataT  InvocationDataT;
     typedef
-        typename BloombergLP::bslmf::TypeListTypeAt<0, ARG_LIST>::Type ARG1;
+        typename BloombergLP::bslmf::TypeListTypeOf<1, ARG_LIST>::Type ARG1;
     typedef
-        typename BloombergLP::bslmf::TypeListTypeAt<1, ARG_LIST>::Type ARG2;
+        typename BloombergLP::bslmf::TypeListTypeOf<2, ARG_LIST>::Type ARG2;
+
+    InvocationImpl(InvocationType& inv)
+    : BaseType(inv)
+    {
+    }
 
     RESULT invoke(ARG1 arg1, ARG2 arg2)
     {
@@ -1419,13 +1431,16 @@ template <class METHOD_INFO, class RESULT, class ARG_LIST>
 struct InvocationImpl<3, METHOD_INFO, RESULT, ARG_LIST>
 : public InvocationImplBase<Invocation<METHOD_INFO, RESULT, ARG_LIST> > {
     typedef Invocation<METHOD_INFO, RESULT, ARG_LIST> InvocationType;
-    typedef InvocationType::InvocationDataT           InvocationDataT;
+    typedef InvocationImplBase<InvocationType> BaseType;
+    typedef typename InvocationType::InvocationDataT  InvocationDataT;
     typedef
-        typename BloombergLP::bslmf::TypeListTypeAt<0, ARG_LIST>::Type ARG1;
+        typename BloombergLP::bslmf::TypeListTypeOf<1, ARG_LIST>::Type ARG1;
     typedef
-        typename BloombergLP::bslmf::TypeListTypeAt<1, ARG_LIST>::Type ARG2;
+        typename BloombergLP::bslmf::TypeListTypeOf<2, ARG_LIST>::Type ARG2;
     typedef
-        typename BloombergLP::bslmf::TypeListTypeAt<2, ARG_LIST>::Type ARG3;
+        typename BloombergLP::bslmf::TypeListTypeOf<3, ARG_LIST>::Type ARG3;
+
+    InvocationImpl(InvocationType& inv): BaseType(inv) {}
 
     RESULT invoke(ARG1 arg1, ARG2 arg2, ARG3 arg3)
     {
@@ -1703,7 +1718,7 @@ struct Invocation<METHOD_INFO, RESULT, NoArgs>
       public:                                                                 \
         struct MockInfo {                                                     \
             const char* mockName;                                             \
-                        MockInfo()                                            \
+            MockInfo()                                                        \
             : mockName(#MOCK_NAME)                                            \
             {                                                                 \
             }                                                                 \

--- a/groups/ntc/ntccfg/ntccfg_test.t.cpp
+++ b/groups/ntc/ntccfg/ntccfg_test.t.cpp
@@ -16,8 +16,6 @@
 #include <ntccfg_test.h>
 #include <bslma_testallocator.h>
 
-#include <pdh.h>
-
 using namespace BloombergLP;
 
 //=============================================================================

--- a/groups/ntc/ntccfg/ntccfg_test.t.cpp
+++ b/groups/ntc/ntccfg/ntccfg_test.t.cpp
@@ -140,10 +140,54 @@ NTCCFG_TEST_CASE(3)
     }
 }
 
+NTCCFG_TEST_CASE(4)
+{
+    using namespace mock_test;
+
+    MyMock mock;
+
+    {
+        // an argument can be saved to external variable to later used
+        int storage = 0;
+        NTF_EXPECT_1(mock, f2, IGNORE_ARG).ONCE().SAVE_ARG_1(TO(&storage));
+
+        int val = 22;
+        mock.f2(val);
+
+        NTCCFG_TEST_EQ(storage, val);
+    }
+    {
+        //the same can be done with raw pointers
+        int *ptr = 0;
+        NTF_EXPECT_1(mock, f3, IGNORE_ARG).ONCE().SAVE_ARG_1(TO(&ptr));
+
+        int val = 6;
+        mock.f3(&val);
+        NTCCFG_TEST_EQ(ptr, &val);
+
+        //pointer argument can be dereferenced before saving
+        int storage = 0;
+        NTF_EXPECT_1(mock, f3, IGNORE_ARG).ONCE().SAVE_ARG_1(TO_DEREF(&storage));
+
+        mock.f3(&val);
+        NTCCFG_TEST_EQ(storage, val);
+    }
+    {
+        //the same can be done with references
+        int storage = 0;
+        NTF_EXPECT_1(mock, f4, IGNORE_ARG).ONCE().SAVE_ARG_1(TO(&storage));
+
+        int val = 7;
+        mock.f4(val);
+        NTCCFG_TEST_EQ(storage, val);
+    }
+}
+
 NTCCFG_TEST_DRIVER
 {
     NTCCFG_TEST_REGISTER(1);
     NTCCFG_TEST_REGISTER(2);
     NTCCFG_TEST_REGISTER(3);
+    NTCCFG_TEST_REGISTER(4);
 }
 NTCCFG_TEST_DRIVER_END;

--- a/groups/ntc/ntcd/ntcd_blobbufferfactory.cpp
+++ b/groups/ntc/ntcd/ntcd_blobbufferfactory.cpp
@@ -1,0 +1,19 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ntcd_blobbufferfactory.h>
+
+#include <bsls_ident.h>
+BSLS_IDENT_RCSID(ntcd_blobbufferfactory_cpp, "$Id$ $CSID$")

--- a/groups/ntc/ntcd/ntcd_blobbufferfactory.h
+++ b/groups/ntc/ntcd/ntcd_blobbufferfactory.h
@@ -1,0 +1,34 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef INCLUDED_NTCD_BLOBBUFFERFACTORY
+#define INCLUDED_NTCD_BLOBBUFFERFACTORY
+
+#include <bsls_ident.h>
+BSLS_IDENT("$Id: $")
+
+#include <bdlbb_blob.h>
+#include <ntccfg_test.h>
+
+namespace BloombergLP {
+namespace ntcd {
+
+NTF_MOCK_CLASS(BufferFactoryMock, bdlbb::BlobBufferFactory)
+NTF_MOCK_METHOD(void, allocate, bdlbb::BlobBuffer*)
+NTF_MOCK_CLASS_END;
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/groups/ntc/ntcd/ntcd_blobbufferfactory.t.cpp
+++ b/groups/ntc/ntcd/ntcd_blobbufferfactory.t.cpp
@@ -1,0 +1,28 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ntcd_blobbufferfactory.h>
+
+#include <ntccfg_test.h>
+
+NTCCFG_TEST_CASE(1)
+{
+}
+
+NTCCFG_TEST_DRIVER
+{
+    NTCCFG_TEST_REGISTER(1);
+}
+NTCCFG_TEST_DRIVER_END;

--- a/groups/ntc/ntcd/ntcd_datapool.cpp
+++ b/groups/ntc/ntcd/ntcd_datapool.cpp
@@ -1,0 +1,19 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ntcd_datapool.h>
+
+#include <bsls_ident.h>
+BSLS_IDENT_RCSID(ntcd_datapool_cpp, "$Id$ $CSID$")

--- a/groups/ntc/ntcd/ntcd_datapool.h
+++ b/groups/ntc/ntcd/ntcd_datapool.h
@@ -1,0 +1,43 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef INCLUDED_NTCD_DATAPOOL
+#define INCLUDED_NTCD_DATAPOOL
+
+#include <bsls_ident.h>
+BSLS_IDENT("$Id: $")
+
+#include <ntci_datapool.h>
+#include <ntccfg_test.h>
+
+namespace BloombergLP {
+namespace ntcd {
+
+NTF_MOCK_CLASS(DataPoolMock, ntci::DataPool)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createIncomingData)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createOutgoingData)
+NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createIncomingBlob)
+NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createOutgoingBlob)
+NTF_MOCK_METHOD(void, createIncomingBlobBuffer, bdlbb::BlobBuffer*)
+NTF_MOCK_METHOD(void, createOutgoingBlobBuffer, bdlbb::BlobBuffer*)
+NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
+                      incomingBlobBufferFactory)
+NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
+                      outgoingBlobBufferFactory)
+NTF_MOCK_CLASS_END;
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/groups/ntc/ntcd/ntcd_datapool.t.cpp
+++ b/groups/ntc/ntcd/ntcd_datapool.t.cpp
@@ -1,0 +1,28 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ntcd_datapool.h>
+
+#include <ntccfg_test.h>
+
+NTCCFG_TEST_CASE(1)
+{
+}
+
+NTCCFG_TEST_DRIVER
+{
+    NTCCFG_TEST_REGISTER(1);
+}
+NTCCFG_TEST_DRIVER_END;

--- a/groups/ntc/ntcd/ntcd_machine.cpp
+++ b/groups/ntc/ntcd/ntcd_machine.cpp
@@ -4021,7 +4021,7 @@ bsl::size_t Monitor::process(bsl::vector<ntca::ReactorEvent>* result)
 
 // MRM
 #if 0
-                if (entry->d_oneShot_result) {
+                if (entry->d_oneShot) {
                     entry->d_wantReadable = false;
                 }
 #endif
@@ -4052,7 +4052,7 @@ bsl::size_t Monitor::process(bsl::vector<ntca::ReactorEvent>* result)
 
 // MRM
 #if 0
-                if (entry->d_oneShot_result) {
+                if (entry->d_oneShot) {
                     entry->d_wantWritable = false;
                 }
 #endif

--- a/groups/ntc/ntcd/ntcd_machine.cpp
+++ b/groups/ntc/ntcd/ntcd_machine.cpp
@@ -4021,7 +4021,7 @@ bsl::size_t Monitor::process(bsl::vector<ntca::ReactorEvent>* result)
 
 // MRM
 #if 0
-                if (entry->d_oneShot) {
+                if (entry->d_oneShot_result) {
                     entry->d_wantReadable = false;
                 }
 #endif
@@ -4052,7 +4052,7 @@ bsl::size_t Monitor::process(bsl::vector<ntca::ReactorEvent>* result)
 
 // MRM
 #if 0
-                if (entry->d_oneShot) {
+                if (entry->d_oneShot_result) {
                     entry->d_wantWritable = false;
                 }
 #endif

--- a/groups/ntc/ntcd/ntcd_reactor.h
+++ b/groups/ntc/ntcd/ntcd_reactor.h
@@ -21,6 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #include <ntca_reactorconfig.h>
 #include <ntccfg_platform.h>
+#include <ntccfg_test.h>
 #include <ntcd_datagramsocket.h>
 #include <ntcd_listenersocket.h>
 #include <ntcd_streamsocket.h>
@@ -100,7 +101,7 @@ class Reactor : public ntci::Reactor,
     bslma::Allocator*                           d_allocator_p;
 
   private:
-    Reactor(const Reactor&) BSLS_KEYWORD_DELETED;
+             Reactor(const Reactor&) BSLS_KEYWORD_DELETED;
     Reactor& operator=(const Reactor&) BSLS_KEYWORD_DELETED;
 
   private:
@@ -598,7 +599,7 @@ class ReactorFactory : public ntci::ReactorFactory
     bslma::Allocator* d_allocator_p;
 
   private:
-    ReactorFactory(const ReactorFactory&) BSLS_KEYWORD_DELETED;
+                    ReactorFactory(const ReactorFactory&) BSLS_KEYWORD_DELETED;
     ReactorFactory& operator=(const ReactorFactory&) BSLS_KEYWORD_DELETED;
 
   public:
@@ -620,6 +621,162 @@ class ReactorFactory : public ntci::ReactorFactory
         const bsl::shared_ptr<ntci::User>& user,
         bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
 };
+
+NTF_MOCK_CLASS(ReactorMock, ntci::Reactor)
+
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::DatagramSocket>,
+                createDatagramSocket,
+                const ntca::DatagramSocketOptions&,
+                bslma::Allocator*)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createIncomingData)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createOutgoingData)
+NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createIncomingBlob)
+NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createOutgoingBlob)
+NTF_MOCK_METHOD(void, createIncomingBlobBuffer, bdlbb::BlobBuffer*)
+NTF_MOCK_METHOD(void, createOutgoingBlobBuffer, bdlbb::BlobBuffer*)
+
+NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
+                      incomingBlobBufferFactory)
+NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
+                      outgoingBlobBufferFactory)
+
+NTF_MOCK_METHOD(ntci::Waiter, registerWaiter, const ntca::WaiterOptions&)
+NTF_MOCK_METHOD(void, deregisterWaiter, ntci::Waiter)
+NTF_MOCK_METHOD(void, run, ntci::Waiter)
+NTF_MOCK_METHOD(void, poll, ntci::Waiter)
+NTF_MOCK_METHOD(void, interruptOne)
+NTF_MOCK_METHOD(void, interruptAll)
+NTF_MOCK_METHOD(void, stop)
+NTF_MOCK_METHOD(void, restart)
+NTF_MOCK_METHOD(void, execute, const Functor&)
+NTF_MOCK_METHOD(void, moveAndExecute, FunctorSequence*, const Functor&)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::ListenerSocket>,
+                createListenerSocket,
+                const ntca::ListenerSocketOptions&,
+                bslma::Allocator*)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                attachSocket,
+                const bsl::shared_ptr<ntci::ReactorSocket>&)
+NTF_MOCK_METHOD(ntsa::Error, attachSocket, ntsa::Handle)
+NTF_MOCK_METHOD(ntsa::Error,
+                showReadable,
+                const bsl::shared_ptr<ntci::ReactorSocket>&,
+                const ntca::ReactorEventOptions&)
+NTF_MOCK_METHOD(ntsa::Error,
+                showReadable,
+                ntsa::Handle,
+                const ntca::ReactorEventOptions&,
+                const ntci::ReactorEventCallback&)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                showWritable,
+                const bsl::shared_ptr<ntci::ReactorSocket>&,
+                const ntca::ReactorEventOptions&)
+NTF_MOCK_METHOD(ntsa::Error,
+                showWritable,
+                ntsa::Handle,
+                const ntca::ReactorEventOptions&,
+                const ntci::ReactorEventCallback&)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                showError,
+                const bsl::shared_ptr<ntci::ReactorSocket>&,
+                const ntca::ReactorEventOptions&)
+NTF_MOCK_METHOD(ntsa::Error,
+                showError,
+                ntsa::Handle,
+                const ntca::ReactorEventOptions&,
+                const ntci::ReactorEventCallback&)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                hideReadable,
+                const bsl::shared_ptr<ntci::ReactorSocket>&)
+NTF_MOCK_METHOD(ntsa::Error, hideReadable, ntsa::Handle)
+NTF_MOCK_METHOD(ntsa::Error,
+                hideWritable,
+                const bsl::shared_ptr<ntci::ReactorSocket>&)
+NTF_MOCK_METHOD(ntsa::Error, hideWritable, ntsa::Handle)
+NTF_MOCK_METHOD(ntsa::Error,
+                hideError,
+                const bsl::shared_ptr<ntci::ReactorSocket>&)
+NTF_MOCK_METHOD(ntsa::Error, hideError, ntsa::Handle)
+NTF_MOCK_METHOD(ntsa::Error,
+                detachSocket,
+                const bsl::shared_ptr<ntci::ReactorSocket>&)
+NTF_MOCK_METHOD(ntsa::Error, detachSocket, ntsa::Handle)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                detachSocket,
+                const bsl::shared_ptr<ntci::ReactorSocket>&,
+                const ntci::SocketDetachedCallback&)
+NTF_MOCK_METHOD(ntsa::Error,
+                detachSocket,
+                ntsa::Handle,
+                const ntci::SocketDetachedCallback&)
+
+NTF_MOCK_METHOD(ntsa::Error, closeAll)
+NTF_MOCK_METHOD(void, incrementLoad, const ntca::LoadBalancingOptions&)
+NTF_MOCK_METHOD(void, decrementLoad, const ntca::LoadBalancingOptions&)
+
+NTF_MOCK_METHOD(void, drainFunctions)
+NTF_MOCK_METHOD(void, clearFunctions)
+NTF_MOCK_METHOD(void, clearTimers)
+NTF_MOCK_METHOD(void, clearSockets)
+NTF_MOCK_METHOD(void, clear)
+NTF_MOCK_METHOD_CONST(size_t, numSockets)
+NTF_MOCK_METHOD_CONST(size_t, maxSockets)
+NTF_MOCK_METHOD_CONST(size_t, numTimers)
+NTF_MOCK_METHOD_CONST(size_t, maxTimers)
+NTF_MOCK_METHOD_CONST(bool, autoAttach)
+NTF_MOCK_METHOD_CONST(bool, autoDetach)
+NTF_MOCK_METHOD_CONST(bool, oneShot)
+NTF_MOCK_METHOD_CONST(ntca::ReactorEventTrigger::Value, trigger)
+NTF_MOCK_METHOD_CONST(size_t, load)
+NTF_MOCK_METHOD_CONST(bslmt::ThreadUtil::Handle, threadHandle)
+NTF_MOCK_METHOD_CONST(size_t, threadIndex)
+NTF_MOCK_METHOD_CONST(bool, empty)
+NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<ntci::DataPool>&, dataPool)
+
+NTF_MOCK_METHOD_CONST(bool, supportsOneShot, bool)
+NTF_MOCK_METHOD_CONST(bool, supportsTrigger, ntca::ReactorEventTrigger::Value)
+
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Reactor>,
+                acquireReactor,
+                const ntca::LoadBalancingOptions&)
+NTF_MOCK_METHOD(void,
+                releaseReactor,
+                const bsl::shared_ptr<ntci::Reactor>&,
+                const ntca::LoadBalancingOptions&)
+NTF_MOCK_METHOD(bool, acquireHandleReservation)
+NTF_MOCK_METHOD(void, releaseHandleReservation)
+
+NTF_MOCK_METHOD_CONST(size_t, numReactors)
+NTF_MOCK_METHOD_CONST(size_t, numThreads)
+NTF_MOCK_METHOD_CONST(size_t, minThreads)
+NTF_MOCK_METHOD_CONST(size_t, maxThreads)
+
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Strand>, createStrand, bslma::Allocator*)
+
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::StreamSocket>,
+                createStreamSocket,
+                const ntca::StreamSocketOptions&,
+                bslma::Allocator*)
+
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
+                createTimer,
+                const ntca::TimerOptions&,
+                const bsl::shared_ptr<ntci::TimerSession>&,
+                bslma::Allocator*)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
+                createTimer,
+                const ntca::TimerOptions&,
+                const ntci::TimerCallback&,
+                bslma::Allocator*)
+NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<ntci::Strand>&, strand)
+NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
+
+NTF_MOCK_CLASS_END;
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/groups/ntc/ntcd/ntcd_resolver.cpp
+++ b/groups/ntc/ntcd/ntcd_resolver.cpp
@@ -1,0 +1,19 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ntcd_resolver.h>
+
+#include <bsls_ident.h>
+BSLS_IDENT_RCSID(ntcd_resolver_cpp, "$Id$ $CSID$")

--- a/groups/ntc/ntcd/ntcd_resolver.h
+++ b/groups/ntc/ntcd/ntcd_resolver.h
@@ -1,0 +1,130 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef INCLUDED_NTCD_RESOLVER
+#define INCLUDED_NTCD_RESOLVER
+
+#include <bsls_ident.h>
+BSLS_IDENT("$Id: $")
+
+#include <ntci_resolver.h>
+#include <ntccfg_test.h>
+
+namespace BloombergLP {
+namespace ntcd {
+
+NTF_MOCK_CLASS(ResolverMock, ntci::Resolver)
+
+NTF_MOCK_METHOD(void, execute, const Functor&)
+NTF_MOCK_METHOD(void, moveAndExecute, FunctorSequence*, const Functor&)
+NTF_MOCK_METHOD_CONST(bsl::shared_ptr<ntci::Strand>&, strand)
+
+NTF_MOCK_METHOD(ntsa::Error, start)
+NTF_MOCK_METHOD(void, shutdown)
+NTF_MOCK_METHOD(void, linger)
+NTF_MOCK_METHOD(ntsa::Error,
+                setIpAddress,
+                const bslstl::StringRef&,
+                const bsl::vector<ntsa::IpAddress>&)
+NTF_MOCK_METHOD(ntsa::Error,
+                addIpAddress,
+                const bslstl::StringRef&,
+                const bsl::vector<ntsa::IpAddress>&)
+NTF_MOCK_METHOD(ntsa::Error,
+                addIpAddress,
+                const bslstl::StringRef&,
+                const ntsa::IpAddress&)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                setPort,
+                const bslstl::StringRef&,
+                const bsl::vector<ntsa::Port>&,
+                ntsa::Transport::Value)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                addPort,
+                const bslstl::StringRef&,
+                const bsl::vector<ntsa::Port>&,
+                ntsa::Transport::Value)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                addPort,
+                const bslstl::StringRef&,
+                ntsa::Port,
+                ntsa::Transport::Value)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                setLocalIpAddress,
+                const bsl::vector<ntsa::IpAddress>&)
+NTF_MOCK_METHOD(ntsa::Error, setHostname, const bsl::string&)
+NTF_MOCK_METHOD(ntsa::Error, setHostnameFullyQualified, const bsl::string&)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                getIpAddress,
+                const bslstl::StringRef&,
+                const ntca::GetIpAddressOptions&,
+                const ntci::GetIpAddressCallback&)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                getDomainName,
+                const ntsa::IpAddress&,
+                const ntca::GetDomainNameOptions&,
+                const ntci::GetDomainNameCallback&)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                getPort,
+                const bslstl::StringRef&,
+                const ntca::GetPortOptions&,
+                const ntci::GetPortCallback&)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                getServiceName,
+                ntsa::Port,
+                const ntca::GetServiceNameOptions&,
+                const ntci::GetServiceNameCallback&)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                getEndpoint,
+                const bslstl::StringRef&,
+                const ntca::GetEndpointOptions&,
+                const ntci::GetEndpointCallback&)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                getLocalIpAddress,
+                bsl::vector<ntsa::IpAddress>*,
+                const ntsa::IpAddressOptions&)
+NTF_MOCK_METHOD(ntsa::Error, getHostname, bsl::string*)
+NTF_MOCK_METHOD(ntsa::Error, getHostnameFullyQualified, bsl::string*)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Strand>, createStrand, bslma::Allocator*)
+
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
+                createTimer,
+                const ntca::TimerOptions&,
+                const bsl::shared_ptr<ntci::TimerSession>&,
+                bslma::Allocator*)
+
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
+                createTimer,
+                const ntca::TimerOptions&,
+                const ntci::TimerCallback&,
+                bslma::Allocator*)
+NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
+
+NTF_MOCK_CLASS_END;
+
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/groups/ntc/ntcd/ntcd_resolver.t.cpp
+++ b/groups/ntc/ntcd/ntcd_resolver.t.cpp
@@ -1,0 +1,28 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ntcd_reactor.h>
+
+#include <ntccfg_test.h>
+
+NTCCFG_TEST_CASE(1)
+{
+}
+
+NTCCFG_TEST_DRIVER
+{
+    NTCCFG_TEST_REGISTER(1);
+}
+NTCCFG_TEST_DRIVER_END;

--- a/groups/ntc/ntcd/ntcd_streamsocket.h
+++ b/groups/ntc/ntcd/ntcd_streamsocket.h
@@ -28,6 +28,8 @@ BSLS_IDENT("$Id: $")
 #include <bsl_string.h>
 #include <bsl_vector.h>
 
+#include <ntccfg_test.h>
+
 namespace BloombergLP {
 namespace ntcd {
 
@@ -50,7 +52,7 @@ class StreamSocket : public ntsi::StreamSocket
     bslma::Allocator*              d_allocator_p;
 
   private:
-    StreamSocket(const StreamSocket&) BSLS_KEYWORD_DELETED;
+                  StreamSocket(const StreamSocket&) BSLS_KEYWORD_DELETED;
     StreamSocket& operator=(const StreamSocket&) BSLS_KEYWORD_DELETED;
 
   public:
@@ -246,6 +248,57 @@ class StreamSocketFactory : public ntci::StreamSocketFactory
         const ntca::StreamSocketOptions& options,
         bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
 };
+
+NTF_MOCK_CLASS(StreamSocketMock, ntsi::StreamSocket)
+
+NTF_MOCK_METHOD_CONST(ntsa::Handle, handle)
+NTF_MOCK_METHOD(ntsa::Error, open, ntsa::Transport::Value)
+NTF_MOCK_METHOD(ntsa::Error, acquire, ntsa::Handle)
+NTF_MOCK_METHOD(ntsa::Handle, release)
+
+NTF_MOCK_METHOD(ntsa::Error, bind, const ntsa::Endpoint&, bool)
+NTF_MOCK_METHOD(ntsa::Error, bindAny, ntsa::Transport::Value, bool)
+NTF_MOCK_METHOD(ntsa::Error, connect, const ntsa::Endpoint&)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                send,
+                ntsa::SendContext*,
+                const bdlbb::Blob&,
+                const ntsa::SendOptions&)
+NTF_MOCK_METHOD(ntsa::Error,
+                send,
+                ntsa::SendContext*,
+                const ntsa::Data&,
+                const ntsa::SendOptions&)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                receive,
+                ntsa::ReceiveContext*,
+                bdlbb::Blob*,
+                const ntsa::ReceiveOptions&)
+NTF_MOCK_METHOD(ntsa::Error,
+                receive,
+                ntsa::ReceiveContext*,
+                ntsa::Data*,
+                const ntsa::ReceiveOptions&)
+
+NTF_MOCK_METHOD(ntsa::Error, receiveNotifications, ntsa::NotificationQueue*)
+NTF_MOCK_METHOD(ntsa::Error, shutdown, ntsa::ShutdownType::Value)
+NTF_MOCK_METHOD(ntsa::Error, unlink)
+NTF_MOCK_METHOD(ntsa::Error, close)
+NTF_MOCK_METHOD_CONST(ntsa::Error, sourceEndpoint, ntsa::Endpoint*)
+NTF_MOCK_METHOD_CONST(ntsa::Error, remoteEndpoint, ntsa::Endpoint*)
+NTF_MOCK_METHOD(ntsa::Error, setBlocking, bool)
+NTF_MOCK_METHOD(ntsa::Error, setOption, const ntsa::SocketOption&)
+
+NTF_MOCK_METHOD(ntsa::Error,
+                getOption,
+                ntsa::SocketOption*,
+                ntsa::SocketOptionType::Value)
+NTF_MOCK_METHOD(ntsa::Error, getLastError, ntsa::Error*)
+NTF_MOCK_METHOD_CONST(bsl::size_t, maxBuffersPerSend)
+NTF_MOCK_METHOD_CONST(bsl::size_t, maxBuffersPerReceive)
+NTF_MOCK_CLASS_END;
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/groups/ntc/ntcd/ntcd_timer.cpp
+++ b/groups/ntc/ntcd/ntcd_timer.cpp
@@ -1,0 +1,19 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ntcd_timer.h>
+
+#include <bsls_ident.h>
+BSLS_IDENT_RCSID(ntcd_timer_cpp, "$Id$ $CSID$")

--- a/groups/ntc/ntcd/ntcd_timer.h
+++ b/groups/ntc/ntcd/ntcd_timer.h
@@ -1,0 +1,51 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef INCLUDED_NTCD_TIMER
+#define INCLUDED_NTCD_TIMER
+
+#include <bsls_ident.h>
+BSLS_IDENT("$Id: $")
+
+#include <ntci_timer.h>
+#include <ntccfg_test.h>
+
+namespace BloombergLP {
+namespace ntcd {
+
+NTF_MOCK_CLASS(TimerMock, ntci::Timer)
+NTF_MOCK_METHOD(ntsa::Error,
+                schedule,
+                const bsls::TimeInterval&,
+                const bsls::TimeInterval&)
+NTF_MOCK_METHOD(ntsa::Error, cancel)
+NTF_MOCK_METHOD(ntsa::Error, close)
+NTF_MOCK_METHOD(void,
+                arrive,
+                const bsl::shared_ptr<ntci::Timer>&,
+                const bsls::TimeInterval&,
+                const bsls::TimeInterval&)
+NTF_MOCK_METHOD_CONST(void*, handle)
+NTF_MOCK_METHOD_CONST(int, id)
+NTF_MOCK_METHOD_CONST(bool, oneShot)
+NTF_MOCK_METHOD_CONST(bslmt::ThreadUtil::Handle, threadHandle)
+NTF_MOCK_METHOD_CONST(size_t, threadIndex)
+NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<ntci::Strand>&, strand)
+NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
+NTF_MOCK_CLASS_END;
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/groups/ntc/ntcd/ntcd_timer.t.cpp
+++ b/groups/ntc/ntcd/ntcd_timer.t.cpp
@@ -1,0 +1,28 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ntcd_timer.h>
+
+#include <ntccfg_test.h>
+
+NTCCFG_TEST_CASE(1)
+{
+}
+
+NTCCFG_TEST_DRIVER
+{
+    NTCCFG_TEST_REGISTER(1);
+}
+NTCCFG_TEST_DRIVER_END;

--- a/groups/ntc/ntcd/package/ntcd.mem
+++ b/groups/ntc/ntcd/package/ntcd.mem
@@ -1,5 +1,6 @@
 ntcd_blobbufferfactory
 ntcd_datagramsocket
+ntcd_datapool
 ntcd_datautil
 ntcd_encryption
 ntcd_listenersocket

--- a/groups/ntc/ntcd/package/ntcd.mem
+++ b/groups/ntc/ntcd/package/ntcd.mem
@@ -9,3 +9,4 @@ ntcd_reactor
 ntcd_resolver
 ntcd_streamsocket
 ntcd_simulation
+ntcd_timer

--- a/groups/ntc/ntcd/package/ntcd.mem
+++ b/groups/ntc/ntcd/package/ntcd.mem
@@ -5,5 +5,6 @@ ntcd_listenersocket
 ntcd_machine
 ntcd_proactor
 ntcd_reactor
+ntcd_resolver
 ntcd_streamsocket
 ntcd_simulation

--- a/groups/ntc/ntcd/package/ntcd.mem
+++ b/groups/ntc/ntcd/package/ntcd.mem
@@ -1,3 +1,4 @@
+ntcd_blobbufferfactory
 ntcd_datagramsocket
 ntcd_datautil
 ntcd_encryption

--- a/groups/ntc/ntco/ntco_epoll.cpp
+++ b/groups/ntc/ntco/ntco_epoll.cpp
@@ -101,7 +101,7 @@ BSLS_IDENT_RCSID(ntco_epoll_cpp, "$Id$ $CSID$")
 
 #define NTCO_EPOLL_LOG_WAIT_RESULT_OR_TIMEOUT(numEvents, results)             \
     do {                                                                      \
-        if (numEvents == 1 && results[0].data.fd == d_timer) {                \
+        if (numEvents == 1 && results[0].data.fd == d_timer_result) {                \
             NTCO_EPOLL_LOG_WAIT_TIMEOUT();                                    \
         }                                                                     \
         else {                                                                \
@@ -218,7 +218,7 @@ class Epoll : public ntci::Reactor,
 
     ntccfg::Object                           d_object;
     int                                      d_epoll;
-    int                                      d_timer;
+    int                                      d_timer_result;
     bsls::AtomicBool                         d_timerPending;
     ntcs::RegistryEntryCatalog::EntryFunctor d_detachFunctor;
     ntcs::RegistryEntryCatalog               d_registry;
@@ -973,7 +973,7 @@ ntsa::Error Epoll::setTimer(const bsls::TimeInterval& absoluteTimeout)
     its.it_interval.tv_sec  = 0;
     its.it_interval.tv_nsec = 0;
 
-    int rc = ::timerfd_settime(d_timer, TFD_TIMER_ABSTIME, &its, 0);
+    int rc = ::timerfd_settime(d_timer_result, TFD_TIMER_ABSTIME, &its, 0);
     if (rc != 0) {
         ntsa::Error error(errno);
         return error;
@@ -988,7 +988,7 @@ ntsa::Error Epoll::ackTimer(bsl::size_t* numTimers)
 {
     bsl::uint64_t numExpirations = 0;
     ssize_t       timerReadResult =
-        ::read(d_timer, &numExpirations, sizeof numExpirations);
+        ::read(d_timer_result, &numExpirations, sizeof numExpirations);
 
     if (NTCCFG_UNLIKELY(timerReadResult < 0)) {
 #if (EAGAIN == EWOULDBLOCK)
@@ -1070,7 +1070,7 @@ Epoll::Epoll(const ntca::ReactorConfig&         configuration,
              bslma::Allocator*                  basicAllocator)
 : d_object("ntco::Epoll")
 , d_epoll(-1)
-, d_timer(-1)
+, d_timer_result(-1)
 , d_timerPending(false)
 #if NTCCFG_PLATFORM_COMPILER_SUPPORTS_LAMDAS
 , d_detachFunctor([this](const auto& entry) {
@@ -1235,18 +1235,18 @@ Epoll::Epoll(const ntca::ReactorConfig&         configuration,
 #if NTCO_EPOLL_USE_TIMERFD
 
     if (d_config.maxThreads().value() == 1) {
-        d_timer = timerfd_create(CLOCK_REALTIME, TFD_NONBLOCK | TFD_CLOEXEC);
-        if (d_timer < 0) {
+        d_timer_result = timerfd_create(CLOCK_REALTIME, TFD_NONBLOCK | TFD_CLOEXEC);
+        if (d_timer_result < 0) {
             NTCCFG_ABORT();
         }
 
         {
             ::epoll_event e;
 
-            e.data.fd = d_timer;
+            e.data.fd = d_timer_result;
             e.events  = EPOLLIN;
 
-            int rc = ::epoll_ctl(d_epoll, EPOLL_CTL_ADD, d_timer, &e);
+            int rc = ::epoll_ctl(d_epoll, EPOLL_CTL_ADD, d_timer_result, &e);
             if (rc != 0) {
                 NTCCFG_ABORT();
             }
@@ -1274,18 +1274,18 @@ Epoll::~Epoll()
         {
             ::epoll_event e;
 
-            e.data.fd = d_timer;
+            e.data.fd = d_timer_result;
             e.events  = 0;
 
-            int rc = ::epoll_ctl(d_epoll, EPOLL_CTL_DEL, d_timer, &e);
+            int rc = ::epoll_ctl(d_epoll, EPOLL_CTL_DEL, d_timer_result, &e);
             if (rc != 0) {
                 NTCCFG_ABORT();
             }
         }
 
-        if (d_timer >= 0) {
-            ::close(d_timer);
-            d_timer = -1;
+        if (d_timer_result >= 0) {
+            ::close(d_timer_result);
+            d_timer_result = -1;
         }
     }
 
@@ -2253,7 +2253,7 @@ void Epoll::run(ntci::Waiter waiter)
 
 #if NTCO_EPOLL_USE_TIMERFD
 
-                if (NTCCFG_UNLIKELY(e.data.fd == d_timer)) {
+                if (NTCCFG_UNLIKELY(e.data.fd == d_timer_result)) {
                     ntsa::Error error = this->ackTimer(&numTimers);
                     if (error) {
                         NTCO_EPOLL_LOG_TIMER_ACK_FAILURE(error);
@@ -2552,7 +2552,7 @@ void Epoll::poll(ntci::Waiter waiter)
 
 #if NTCO_EPOLL_USE_TIMERFD
 
-            if (NTCCFG_UNLIKELY(e.data.fd == d_timer)) {
+            if (NTCCFG_UNLIKELY(e.data.fd == d_timer_result)) {
                 ntsa::Error error = this->ackTimer(&numTimers);
                 if (error) {
                     NTCO_EPOLL_LOG_TIMER_ACK_FAILURE(error);

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -1649,7 +1649,9 @@ void StreamSocket::privateFailConnectPart2(
         this->privateRetryConnect(self);
     }
 
-    this->moveAndExecute(&d_deferredCalls, ntci::Executor::Functor());
+    if (!d_deferredCalls.empty()) {
+        this->moveAndExecute(&d_deferredCalls, ntci::Executor::Functor());
+    }
     d_deferredCalls.clear();
 
     if (lock) {

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -20,6 +20,7 @@
 #include <ntcd_datautil.h>
 #include <ntcd_encryption.h>
 #include <ntcd_reactor.h>
+#include <ntcd_resolver.h>
 #include <ntcd_simulation.h>
 #include <ntci_log.h>
 #include <ntcm_monitorableutil.h>
@@ -1374,103 +1375,6 @@ void variation(const test::Parameters& parameters)
 
 namespace mock {
 
-NTF_MOCK_CLASS(ResolverMock, ntci::Resolver)
-NTF_MOCK_METHOD(void, execute, const Functor&)
-NTF_MOCK_METHOD(void, moveAndExecute, FunctorSequence*, const Functor&)
-NTF_MOCK_METHOD_CONST(bsl::shared_ptr<ntci::Strand>&, strand)
-
-NTF_MOCK_METHOD(ntsa::Error, start)
-NTF_MOCK_METHOD(void, shutdown)
-NTF_MOCK_METHOD(void, linger)
-NTF_MOCK_METHOD(ntsa::Error,
-                setIpAddress,
-                const bslstl::StringRef&,
-                const bsl::vector<ntsa::IpAddress>&)
-NTF_MOCK_METHOD(ntsa::Error,
-                addIpAddress,
-                const bslstl::StringRef&,
-                const bsl::vector<ntsa::IpAddress>&)
-NTF_MOCK_METHOD(ntsa::Error,
-                addIpAddress,
-                const bslstl::StringRef&,
-                const ntsa::IpAddress&)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                setPort,
-                const bslstl::StringRef&,
-                const bsl::vector<ntsa::Port>&,
-                ntsa::Transport::Value)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                addPort,
-                const bslstl::StringRef&,
-                const bsl::vector<ntsa::Port>&,
-                ntsa::Transport::Value)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                addPort,
-                const bslstl::StringRef&,
-                ntsa::Port,
-                ntsa::Transport::Value)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                setLocalIpAddress,
-                const bsl::vector<ntsa::IpAddress>&)
-NTF_MOCK_METHOD(ntsa::Error, setHostname, const bsl::string&)
-NTF_MOCK_METHOD(ntsa::Error, setHostnameFullyQualified, const bsl::string&)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                getIpAddress,
-                const bslstl::StringRef&,
-                const ntca::GetIpAddressOptions&,
-                const ntci::GetIpAddressCallback&)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                getDomainName,
-                const ntsa::IpAddress&,
-                const ntca::GetDomainNameOptions&,
-                const ntci::GetDomainNameCallback&)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                getPort,
-                const bslstl::StringRef&,
-                const ntca::GetPortOptions&,
-                const ntci::GetPortCallback&)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                getServiceName,
-                ntsa::Port,
-                const ntca::GetServiceNameOptions&,
-                const ntci::GetServiceNameCallback&)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                getEndpoint,
-                const bslstl::StringRef&,
-                const ntca::GetEndpointOptions&,
-                const ntci::GetEndpointCallback&)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                getLocalIpAddress,
-                bsl::vector<ntsa::IpAddress>*,
-                const ntsa::IpAddressOptions&)
-NTF_MOCK_METHOD(ntsa::Error, getHostname, bsl::string*)
-NTF_MOCK_METHOD(ntsa::Error, getHostnameFullyQualified, bsl::string*)
-NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Strand>, createStrand, bslma::Allocator*)
-
-NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
-                createTimer,
-                const ntca::TimerOptions&,
-                const bsl::shared_ptr<ntci::TimerSession>&,
-                bslma::Allocator*)
-
-NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
-                createTimer,
-                const ntca::TimerOptions&,
-                const ntci::TimerCallback&,
-                bslma::Allocator*)
-NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
-NTF_MOCK_CLASS_END;
-
 NTF_MOCK_CLASS(BufferFactoryMock, bdlbb::BlobBufferFactory)
 NTF_MOCK_METHOD(void, allocate, bdlbb::BlobBuffer*)
 NTF_MOCK_CLASS_END;
@@ -1733,7 +1637,7 @@ struct Fixture {
     bsl::shared_ptr<mock::DataPoolMock>       d_dataPoolMock;
     bsl::shared_ptr<ntci::DataPool>           d_dataPool;
     bsl::shared_ptr<mock::ReactorMock>        d_reactorMock;
-    bsl::shared_ptr<mock::ResolverMock>       d_resolverMock;
+    bsl::shared_ptr<ntcd::ResolverMock>       d_resolverMock;
     bsl::shared_ptr<mock::StreamSocketMock>   d_streamSocketMock;
     bsl::shared_ptr<mock::TimerMock>          d_connectRetryTimerMock;
     bsl::shared_ptr<mock::TimerMock>          d_connectDeadlineTimerMock;

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1403,28 +1403,23 @@ class ResolverMock : public ntci::Resolver
                         const bslstl::StringRef&,
                         const ntsa::IpAddress&)
 
-  public:
-    ntsa::Error setPort(const bslstl::StringRef&       serviceName,
-                        const bsl::vector<ntsa::Port>& portList,
-                        ntsa::Transport::Value         transport) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error addPort(const bslstl::StringRef&       serviceName,
-                        const bsl::vector<ntsa::Port>& portList,
-                        ntsa::Transport::Value         transport) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error addPort(const bslstl::StringRef& serviceName,
-                        ntsa::Port               port,
-                        ntsa::Transport::Value   transport) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        setPort,
+                        const bslstl::StringRef&,
+                        const bsl::vector<ntsa::Port>&,
+                        ntsa::Transport::Value)
+
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        addPort,
+                        const bslstl::StringRef&,
+                        const bsl::vector<ntsa::Port>&,
+                        ntsa::Transport::Value)
+
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        addPort,
+                        const bslstl::StringRef&,
+                        ntsa::Port,
+                        ntsa::Transport::Value)
 
     NTF_MOCK_METHOD_NEW(ntsa::Error,
                         setLocalIpAddress,
@@ -1434,60 +1429,36 @@ class ResolverMock : public ntci::Resolver
                         setHostnameFullyQualified,
                         const bsl::string&)
 
-  public:
-    ntsa::Error getIpAddress(
-        const bslstl::StringRef&          domainName,
-        const ntca::GetIpAddressOptions&  options,
-        const ntci::GetIpAddressCallback& callback) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error getDomainName(
-        const ntsa::IpAddress&             ipAddress,
-        const ntca::GetDomainNameOptions&  options,
-        const ntci::GetDomainNameCallback& callback) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error getPort(const bslstl::StringRef&     serviceName,
-                        const ntca::GetPortOptions&  options,
-                        const ntci::GetPortCallback& callback) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error getServiceName(
-        ntsa::Port                          port,
-        const ntca::GetServiceNameOptions&  options,
-        const ntci::GetServiceNameCallback& callback) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error getEndpoint(const bslstl::StringRef&         text,
-                            const ntca::GetEndpointOptions&  options,
-                            const ntci::GetEndpointCallback& callback) override
-    {
-        if (d_getEndpoint_result.isNull()) {
-            UNEXPECTED_CALL();
-        }
-        if (d_getEndpoint_arg1.has_value()) {
-            NTCCFG_TEST_EQ(text, d_getEndpoint_arg1.value());
-            d_getEndpoint_arg1.reset();
-        }
-        if (d_getEndpoint_arg2.has_value()) {
-            NTCCFG_TEST_EQ(options, d_getEndpoint_arg2.value());
-            d_getEndpoint_arg2.reset();
-        }
-        NTCCFG_TEST_FALSE(d_getEndpoint_callback.has_value());
-        d_getEndpoint_callback = callback;
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        getIpAddress,
+                        const bslstl::StringRef&,
+                        const ntca::GetIpAddressOptions&,
+                        const ntci::GetIpAddressCallback&)
 
-        const auto res = d_getEndpoint_result.value();
-        d_getEndpoint_result.reset();
-        return res;
-    }
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        getDomainName,
+                        const ntsa::IpAddress&,
+                        const ntca::GetDomainNameOptions&,
+                        const ntci::GetDomainNameCallback&)
+
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        getPort,
+                        const bslstl::StringRef&,
+                        const ntca::GetPortOptions&,
+                        const ntci::GetPortCallback&)
+
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        getServiceName,
+                        ntsa::Port,
+                        const ntca::GetServiceNameOptions&,
+                        const ntci::GetServiceNameCallback&)
+
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        getEndpoint,
+                        const bslstl::StringRef&,
+                        const ntca::GetEndpointOptions&,
+                        const ntci::GetEndpointCallback&)
+
     NTF_MOCK_METHOD_NEW(ntsa::Error,
                         getLocalIpAddress,
                         bsl::vector<ntsa::IpAddress>*,
@@ -1497,43 +1468,22 @@ class ResolverMock : public ntci::Resolver
     NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Strand>,
                         createStrand,
                         bslma::Allocator*)
-  public:
-    bsl::shared_ptr<ntci::Timer> createTimer(
-        const ntca::TimerOptions&                  options,
-        const bsl::shared_ptr<ntci::TimerSession>& session,
-        bslma::Allocator*                          basicAllocator) override
-    {
-        UNEXPECTED_CALL();
-        return bsl::shared_ptr<ntci::Timer>();
-    }
-    bsl::shared_ptr<ntci::Timer> createTimer(
-        const ntca::TimerOptions&  options,
-        const ntci::TimerCallback& callback,
-        bslma::Allocator*          basicAllocator) override
-    {
-        UNEXPECTED_CALL();
-        return bsl::shared_ptr<ntci::Timer>();
-    }
+
+    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Timer>,
+                        createTimer,
+                        const ntca::TimerOptions&,
+                        const bsl::shared_ptr<ntci::TimerSession>&,
+                        bslma::Allocator*)
+
+    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Timer>,
+                        createTimer,
+                        const ntca::TimerOptions&,
+                        const ntci::TimerCallback&,
+                        bslma::Allocator*)
     NTF_MOCK_METHOD_CONST_NEW(bsls::TimeInterval, currentTime)
-  public:
-    // auxiliary functions
-    void expect_getEndpoint_WillOnceReturn(
-        const bdlb::NullableValue<bslstl::StringRef>&        text,
-        const bdlb::NullableValue<ntca::GetEndpointOptions>& options,
-        ntsa::Error                                          error)
-    {
-        d_getEndpoint_arg1   = text;
-        d_getEndpoint_arg2   = options;
-        d_getEndpoint_result = error;
-    }
 
   private:
     bsl::shared_ptr<ntci::Strand> dummyStrand;
-
-    bdlb::NullableValue<bslstl::StringRef>         d_getEndpoint_arg1;
-    bdlb::NullableValue<ntca::GetEndpointOptions>  d_getEndpoint_arg2;
-    bdlb::NullableValue<ntci::GetEndpointCallback> d_getEndpoint_callback;
-    bdlb::NullableValue<ntsa::Error>               d_getEndpoint_result;
 };
 
 class BufferFactoryMock : public bdlbb::BlobBufferFactory
@@ -4352,9 +4302,13 @@ NTCCFG_TEST_CASE(22)
 
         NTCI_LOG_DEBUG("Trigger internal timer to initiate connection...");
 
-        resolverMock->expect_getEndpoint_WillOnceReturn(epName,
-                                                        doNotCare,
-                                                        ntsa::Error());
+        NTF_EXPECT_3(*resolverMock,
+                     getEndpoint,
+                     NTF_EQ(epName),
+                     IGNORE_ARG,
+                     IGNORE_ARG)
+            .ONCE()
+            .RETURN(ntsa::Error());
 
         ntca::TimerEvent timerEvent;
         timerEvent.setType(ntca::TimerEventType::e_DEADLINE);

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1604,7 +1604,8 @@ class StreamSocketMock : public ntsi::StreamSocket
         return ntsa::Error();
     }
 
-    NTF_MOCK_METHOD(ntsa::Handle, release)
+    NTF_MOCK_METHOD(ntsa::Handle, release);
+
   public:
 
     ntsa::Error bind(const ntsa::Endpoint& endpoint,
@@ -1694,8 +1695,8 @@ class StreamSocketMock : public ntsi::StreamSocket
         return ntsa::Error();
     }
 
-    NTF_MOCK_METHOD_0_CONST(bsl::size_t, maxBuffersPerSend)
-    NTF_MOCK_METHOD_0_CONST(bsl::size_t, maxBuffersPerReceive)
+    NTF_MOCK_METHOD_CONST(bsl::size_t, maxBuffersPerSend)
+    NTF_MOCK_METHOD_CONST(bsl::size_t, maxBuffersPerReceive)
 
   public:
 
@@ -5645,7 +5646,7 @@ NTCCFG_TEST_CASE(22)
             ntsa::Error::invalid());
         //TODO: is that ok to detach socket that has not been attached?
 
-        socketMock->expect_close().willOnce().willReturn(ntsa::Error());
+//        socketMock->expect_close().willOnce().willReturn(ntsa::Error());
 
         socket->shutdown(ntsa::ShutdownType::e_BOTH,
                          ntsa::ShutdownMode::e_GRACEFUL);
@@ -5818,7 +5819,7 @@ NTCCFG_TEST_CASE(23)
             bdlb::NullOptType::makeInitialValue(),
             ntsa::Error());
 
-        socketMock->expect_close().willOnce().willReturn(ntsa::Error());
+//        socketMock->expect_close().willOnce().willReturn(ntsa::Error());
 
         socket->shutdown(ntsa::ShutdownType::e_BOTH,
                          ntsa::ShutdownMode::e_GRACEFUL);

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1380,6 +1380,33 @@ class ResolverMock : public ntci::Resolver
     NTF_MOCK_METHOD(void, execute, const Functor&)
     NTF_MOCK_METHOD(void, moveAndExecute, FunctorSequence*, const Functor&)
     NTF_MOCK_METHOD_CONST(bsl::shared_ptr<ntci::Strand>&, strand)
+
+  // public:
+  //   bsl::shared_ptr<ntci::Strand>& strand() const override
+  //   {
+  //       return d_invocation_strand.invoke();
+  //   }
+  //   struct MethodInfo1358 {
+  //       const char* name;
+  //                   NTF_CAT2(MethodInfo, __LINE__)
+  //       ()
+  //       : name("strand")
+  //       {
+  //       }
+  //   };
+  //
+  // public:
+  //   ntf_mock::Invocation0<bsl::shared_ptr<ntci::Strand>&,
+  //                         NTF_CAT2(MethodInfo, __LINE__)>&
+  //   expect_strand()
+  //   {
+  //       return d_invocation_strand.expect();
+  //   }
+  //
+  // private:
+  //   mutable ntf_mock::Invocation0<bsl::shared_ptr<ntci::Strand>&, MethodInfo>
+  //       d_invocation_strand;
+
     NTF_MOCK_METHOD(ntsa::Error, start)
     NTF_MOCK_METHOD(void, shutdown)
     NTF_MOCK_METHOD(void, linger)
@@ -4279,6 +4306,378 @@ NTCCFG_TEST_CASE(24)
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
 
+NTCCFG_TEST_CASE(25)
+{
+    NTCI_LOG_CONTEXT();
+
+    ntccfg::TestAllocator ta;
+    {
+        NTCI_LOG_DEBUG("Fixture setup, socket creation...");
+
+        bdlb::NullableValue<ntca::ConnectEvent> connectResult;
+
+        test::Fixture test(&ta);
+        test.setupReactorBase();
+
+        const ntca::StreamSocketOptions options;
+
+        bsl::shared_ptr<ntcr::StreamSocket> socket;
+        socket.createInplace(&ta,
+                             options,
+                             test.d_resolverMock,
+                             test.d_reactorMock,
+                             test.d_nullPool,
+                             test.d_nullMetrics,
+                             &ta);
+
+        NTCI_LOG_DEBUG("Inject mocked ntsi::StreamSocket");
+        {
+            test.injectStreamSocket(*socket);
+        }
+
+        ntci::TimerCallback  retryTimerCallback;
+        const ntsa::Endpoint targetEp{"127.0.0.1:1234"};
+        NTCI_LOG_DEBUG("Connection initiation...");
+        {
+            const bsl::size_t  k_CONNECT_RETRY_COUNT = 5;
+            bsls::TimeInterval deadlineTime;
+            {
+                deadlineTime.setTotalHours(1);
+
+                NTF_EXPECT_3(*test.d_reactorMock,
+                             createTimer,
+                             IGNORE_ARG_S(const ntca::TimerOptions&),
+                             IGNORE_ARG_S(const ntci::TimerCallback&),
+                             IGNORE_ARG_S(bslma::Allocator*))
+                    .ONCE()
+                    .RETURN(test.d_connectDeadlineTimerMock);
+
+                NTF_EXPECT_2(*test.d_connectDeadlineTimerMock,
+                             schedule,
+                             NTF_EQ(deadlineTime),
+                             NTF_EQ(bsls::TimeInterval()))
+                    .ONCE()
+                    .RETURN(ntsa::Error());
+            }
+
+            {
+                NTF_EXPECT_3(*test.d_reactorMock,
+                             createTimer,
+                             IGNORE_ARG_S(const ntca::TimerOptions&),
+                             IGNORE_ARG_S(const ntci::TimerCallback&),
+                             IGNORE_ARG_S(bslma::Allocator*))
+                    .ONCE()
+                    .SAVE_ARG_2(TO(&retryTimerCallback))
+                    .RETURN(test.d_connectRetryTimerMock);
+
+                NTF_EXPECT_2(*test.d_connectRetryTimerMock,
+                             schedule,
+                             IGNORE_ARG,
+                             IGNORE_ARG)
+                    .ONCE()
+                    .RETURN(ntsa::Error());
+            }
+
+            const ntci::ConnectFunction connectCallback =
+                [&connectResult](
+                    const bsl::shared_ptr<ntci::Connector>& connector,
+                    const ntca::ConnectEvent&               event) {
+                    NTCCFG_TEST_FALSE(connectResult.has_value());
+                    connectResult = event;
+                };
+
+            ntca::ConnectOptions connectOptions;
+            connectOptions.setDeadline(deadlineTime);
+            connectOptions.setRetryCount(k_CONNECT_RETRY_COUNT);
+
+            socket->connect(targetEp, connectOptions, connectCallback);
+        }
+
+        NTCI_LOG_DEBUG("Trigger internal timer to initiate connection...");
+        {
+            const ntsa::Endpoint sourceEp{"127.0.0.1:22"};
+
+            NTF_EXPECT_1(
+                *test.d_reactorMock,
+                attachSocket,
+                NTF_EQ_SPEC(socket,
+                            const bsl::shared_ptr<ntci::ReactorSocket>&))
+                .ONCE()
+                .RETURN(test::Fixture::k_NO_ERROR);
+
+            NTF_EXPECT_2(*test.d_reactorMock,
+                         showWritable,
+                         NTF_EQ(socket),
+                         IGNORE_ARG)
+                .ONCE()
+                .RETURN(ntsa::Error());
+
+            NTF_EXPECT_1(*test.d_streamSocketMock, connect, NTF_EQ(targetEp))
+                .ONCE()
+                .RETURN(ntsa::Error());
+
+            NTF_EXPECT_1(*test.d_streamSocketMock, sourceEndpoint, IGNORE_ARG)
+                .ONCE()
+                .RETURN(test::Fixture::k_NO_ERROR)
+                .SET_ARG_1(FROM_DEREF(sourceEp));
+
+            NTF_EXPECT_0(*test.d_streamSocketMock, close)
+                .ONCE()
+                .RETURN(test::Fixture::k_NO_ERROR);
+
+            ntca::TimerEvent timerEvent;
+            timerEvent.setType(ntca::TimerEventType::e_DEADLINE);
+            retryTimerCallback(test.d_connectRetryTimerMock,
+                               timerEvent,
+                               test.d_nullStrand);
+        }
+
+        NTCI_LOG_DEBUG("Indicate from the reactor that connection has failed");
+        {
+            NTF_EXPECT_1(*test.d_streamSocketMock, getLastError, IGNORE_ARG)
+                .ONCE()
+                .SET_ARG_1(FROM_DEREF(test::Fixture::k_NO_ERROR))
+                .RETURN(test::Fixture::k_NO_ERROR);
+
+            NTF_EXPECT_1(*test.d_streamSocketMock, remoteEndpoint, IGNORE_ARG)
+                .ONCE()
+                .RETURN(ntsa::Error::invalid());
+
+            NTF_EXPECT_2(
+                *test.d_reactorMock,
+                detachSocket,
+                NTF_EQ_SPEC(socket,
+                            const bsl::shared_ptr<ntci::ReactorSocket>&),
+                IGNORE_ARG)
+                .ONCE()
+                .RETURN(ntsa::Error::invalid());
+
+            ntca::ReactorEvent                   event;
+            bsl::shared_ptr<ntci::ReactorSocket> reactorSocket = socket;
+            reactorSocket->processSocketWritable(event);
+
+            NTCI_LOG_DEBUG("Ensure that connection callback was called and "
+                           "connection error was indicated");
+            {
+                NTCCFG_TEST_TRUE(connectResult.has_value());
+                NTCCFG_TEST_EQ(connectResult.value().type(),
+                               ntca::ConnectEventType::e_ERROR);
+                connectResult.reset();
+            }
+        }
+        NTCI_LOG_DEBUG(
+            "Shutdown socket while waiting for the retry timer to fire");
+        {
+            NTF_EXPECT_0(*test.d_connectRetryTimerMock, close)
+                .ONCE()
+                .RETURN(test::Fixture::k_NO_ERROR);
+            NTF_EXPECT_0(*test.d_connectDeadlineTimerMock, close)
+                .ONCE()
+                .RETURN(test::Fixture::k_NO_ERROR);
+
+            ntci::Reactor::Functor callback;
+            NTF_EXPECT_1(*test.d_reactorMock, execute, IGNORE_ARG)
+                .ONCE()
+                .SAVE_ARG_1(TO(&callback));
+
+            socket->shutdown(ntsa::ShutdownType::e_BOTH,
+                             ntsa::ShutdownMode::e_GRACEFUL);
+
+            callback();
+            NTCCFG_TEST_TRUE(connectResult.has_value());
+            NTCCFG_TEST_EQ(connectResult.value().type(),
+                           ntca::ConnectEventType::e_ERROR);
+        }
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(26)
+{
+    NTCI_LOG_CONTEXT();
+
+    ntccfg::TestAllocator ta;
+    {
+        NTCI_LOG_DEBUG("Fixture setup, socket creation...");
+
+        bdlb::NullableValue<ntca::ConnectEvent> connectResult;
+
+        test::Fixture test(&ta);
+        test.setupReactorBase();
+
+        const ntca::StreamSocketOptions options;
+
+        bsl::shared_ptr<ntcr::StreamSocket> socket;
+        socket.createInplace(&ta,
+                             options,
+                             test.d_resolverMock,
+                             test.d_reactorMock,
+                             test.d_nullPool,
+                             test.d_nullMetrics,
+                             &ta);
+
+        NTCI_LOG_DEBUG("Inject mocked ntsi::StreamSocket");
+        {
+            test.injectStreamSocket(*socket);
+        }
+
+        ntci::TimerCallback  retryTimerCallback;
+        const ntsa::Endpoint targetEp{"127.0.0.1:1234"};
+        NTCI_LOG_DEBUG("Connection initiation...");
+        {
+            const bsl::size_t  k_CONNECT_RETRY_COUNT = 5;
+            bsls::TimeInterval deadlineTime;
+            {
+                deadlineTime.setTotalHours(1);
+
+                NTF_EXPECT_3(*test.d_reactorMock,
+                             createTimer,
+                             IGNORE_ARG_S(const ntca::TimerOptions&),
+                             IGNORE_ARG_S(const ntci::TimerCallback&),
+                             IGNORE_ARG_S(bslma::Allocator*))
+                    .ONCE()
+                    .RETURN(test.d_connectDeadlineTimerMock);
+
+                NTF_EXPECT_2(*test.d_connectDeadlineTimerMock,
+                             schedule,
+                             NTF_EQ(deadlineTime),
+                             NTF_EQ(bsls::TimeInterval()))
+                    .ONCE()
+                    .RETURN(ntsa::Error());
+            }
+
+            {
+                NTF_EXPECT_3(*test.d_reactorMock,
+                             createTimer,
+                             IGNORE_ARG_S(const ntca::TimerOptions&),
+                             IGNORE_ARG_S(const ntci::TimerCallback&),
+                             IGNORE_ARG_S(bslma::Allocator*))
+                    .ONCE()
+                    .SAVE_ARG_2(TO(&retryTimerCallback))
+                    .RETURN(test.d_connectRetryTimerMock);
+
+                NTF_EXPECT_2(*test.d_connectRetryTimerMock,
+                             schedule,
+                             IGNORE_ARG,
+                             IGNORE_ARG)
+                    .ONCE()
+                    .RETURN(ntsa::Error());
+            }
+
+            const ntci::ConnectFunction connectCallback =
+                [&connectResult](
+                    const bsl::shared_ptr<ntci::Connector>& connector,
+                    const ntca::ConnectEvent&               event) {
+                    NTCCFG_TEST_FALSE(connectResult.has_value());
+                    connectResult = event;
+                };
+
+            ntca::ConnectOptions connectOptions;
+            connectOptions.setDeadline(deadlineTime);
+            connectOptions.setRetryCount(k_CONNECT_RETRY_COUNT);
+
+            socket->connect(targetEp, connectOptions, connectCallback);
+        }
+
+        NTCI_LOG_DEBUG("Trigger internal timer to initiate connection...");
+        {
+            const ntsa::Endpoint sourceEp{"127.0.0.1:22"};
+
+            NTF_EXPECT_1(
+                *test.d_reactorMock,
+                attachSocket,
+                NTF_EQ_SPEC(socket,
+                            const bsl::shared_ptr<ntci::ReactorSocket>&))
+                .ONCE()
+                .RETURN(test::Fixture::k_NO_ERROR);
+
+            NTF_EXPECT_2(*test.d_reactorMock,
+                         showWritable,
+                         NTF_EQ(socket),
+                         IGNORE_ARG)
+                .ONCE()
+                .RETURN(ntsa::Error());
+
+            NTF_EXPECT_1(*test.d_streamSocketMock, connect, NTF_EQ(targetEp))
+                .ONCE()
+                .RETURN(ntsa::Error());
+
+            NTF_EXPECT_1(*test.d_streamSocketMock, sourceEndpoint, IGNORE_ARG)
+                .ONCE()
+                .RETURN(test::Fixture::k_NO_ERROR)
+                .SET_ARG_1(FROM_DEREF(sourceEp));
+
+            NTF_EXPECT_0(*test.d_streamSocketMock, close)
+                .ONCE()
+                .RETURN(test::Fixture::k_NO_ERROR);
+
+            ntca::TimerEvent timerEvent;
+            timerEvent.setType(ntca::TimerEventType::e_DEADLINE);
+            retryTimerCallback(test.d_connectRetryTimerMock,
+                               timerEvent,
+                               test.d_nullStrand);
+        }
+
+        NTCI_LOG_DEBUG("Indicate from the reactor that connection has failed");
+        {
+            NTF_EXPECT_1(*test.d_streamSocketMock, getLastError, IGNORE_ARG)
+                .ONCE()
+                .SET_ARG_1(FROM_DEREF(test::Fixture::k_NO_ERROR))
+                .RETURN(test::Fixture::k_NO_ERROR);
+
+            NTF_EXPECT_1(*test.d_streamSocketMock, remoteEndpoint, IGNORE_ARG)
+                .ONCE()
+                .RETURN(ntsa::Error::invalid());
+
+            NTF_EXPECT_2(
+                *test.d_reactorMock,
+                detachSocket,
+                NTF_EQ_SPEC(socket,
+                            const bsl::shared_ptr<ntci::ReactorSocket>&),
+                IGNORE_ARG)
+                .ONCE()
+                .RETURN(test::Fixture::k_NO_ERROR);
+
+            ntca::ReactorEvent                   event;
+            bsl::shared_ptr<ntci::ReactorSocket> reactorSocket = socket;
+            reactorSocket->processSocketWritable(event);
+
+            // NTCI_LOG_DEBUG("Ensure that connection callback was called and "
+            //                "connection error was indicated");
+            // {
+            //     NTCCFG_TEST_TRUE(connectResult.has_value());
+            //     NTCCFG_TEST_EQ(connectResult.value().type(),
+            //                    ntca::ConnectEventType::e_ERROR);
+            //     connectResult.reset();
+            // }
+        }
+        // NTCI_LOG_DEBUG(
+        //     "Shutdown socket while waiting for the retry timer to fire");
+        // {
+        //     NTF_EXPECT_0(*test.d_connectRetryTimerMock, close)
+        //         .ONCE()
+        //         .RETURN(test::Fixture::k_NO_ERROR);
+        //     NTF_EXPECT_0(*test.d_connectDeadlineTimerMock, close)
+        //         .ONCE()
+        //         .RETURN(test::Fixture::k_NO_ERROR);
+        //
+        //     ntci::Reactor::Functor callback;
+        //     NTF_EXPECT_1(*test.d_reactorMock, execute, IGNORE_ARG)
+        //         .ONCE()
+        //         .SAVE_ARG_1(TO(&callback));
+        //
+        //     socket->shutdown(ntsa::ShutdownType::e_BOTH,
+        //                      ntsa::ShutdownMode::e_GRACEFUL);
+        //
+        //     callback();
+        //     NTCCFG_TEST_TRUE(connectResult.has_value());
+        //     NTCCFG_TEST_EQ(connectResult.value().type(),
+        //                    ntca::ConnectEventType::e_ERROR);
+        // }
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
 NTCCFG_TEST_DRIVER
 {
     NTCCFG_TEST_REGISTER(1);
@@ -4312,5 +4711,7 @@ NTCCFG_TEST_DRIVER
     NTCCFG_TEST_REGISTER(22);
     NTCCFG_TEST_REGISTER(23);
     NTCCFG_TEST_REGISTER(24);
+    NTCCFG_TEST_REGISTER(25);
+    NTCCFG_TEST_REGISTER(26);
 }
 NTCCFG_TEST_DRIVER_END;

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1677,6 +1677,7 @@ void wegweg()
         MyMock m;
         NTF_EXPECT_1(m, f3, NTF_EQ(2)).SAVE_ARG_1(TO(&to));
         // NTF_EXPECT_1(m, f3, NTF_EQ(2)).SAVE_ARG_1(TO(to)); //SHALL FAIL
+        NTF_EXPECT_1(m, f3, NTF_EQ(2)).SET_ARG_1(FROM(5)); //TODO: SHALL FAIL
     }
 
     {  // void 1 arg int*
@@ -1689,6 +1690,11 @@ void wegweg()
         NTF_EXPECT_1(m, f4, NTF_EQ_DEREF(k)).SAVE_ARG_1(TO(&to));
         NTF_EXPECT_1(m, f4, NTF_EQ_DEREF(k)).SAVE_ARG_1(TO_DEREF(to));
         // NTF_EXPECT_1(m, f4, NTF_EQ_DEREF(k)).SAVE_ARG_1(TO(to)); //SHALL FAIL
+
+        // NTF_EXPECT_1(m, f4, NTF_EQ(&k)).SET_ARG_1(FROM(5)); //SHALL FAIL
+        NTF_EXPECT_1(m, f4, NTF_EQ(&k)).SET_ARG_1(FROM_DEREF(5));
+
+        NTF_EXPECT_1(m, f4, NTF_EQ(&k)).SET_ARG_1(FROM(to)); // TODO: SHALL FAIL as  it is useless
     }
 
     {  // void 1 arg int const *
@@ -1701,6 +1707,13 @@ void wegweg()
         int const* to_const = 0;
         NTF_EXPECT_1(m, f5, NTF_EQ_DEREF(k)).SAVE_ARG_1(TO(&to_const));
         NTF_EXPECT_1(m, f5, NTF_EQ_DEREF(k)).SAVE_ARG_1(TO_DEREF(to));
+
+
+        // NTF_EXPECT_1(m, f5, NTF_EQ(&k)).SET_ARG_1(FROM(5));// SHALL FAIL
+        // NTF_EXPECT_1(m, f5, NTF_EQ(&k)).SET_ARG_1(FROM_DEREF(5)); //SHALL_FAIL
+
+        const int *tmp;
+        NTF_EXPECT_1(m, f5, NTF_EQ(&k)).SET_ARG_1(FROM(tmp)); //TODO: SHALL also fail as it is useless
     }
 
     {  // void 1 arg int &
@@ -1712,6 +1725,9 @@ void wegweg()
 
         NTF_EXPECT_1(m, f6, NTF_EQ(k)).SAVE_ARG_1(TO(to));
         // NTF_EXPECT_1(m, f6, NTF_EQ(k)).SAVE_ARG_1(TO_DEREF(to)); // SHALL FAIL
+
+        NTF_EXPECT_1(m, f6, NTF_EQ(k)).SET_ARG_1(FROM(5));
+        // NTF_EXPECT_1(m, f6, NTF_EQ(k)).SET_ARG_1(FROM_DEREF(to)); // SHALL FAIL
     }
 
     {  // void 1 arg int const &
@@ -1722,6 +1738,12 @@ void wegweg()
         // NTF_EXPECT_1(m, f7, NTF_EQ_DEREF(k)); //SHALL FAIL
         NTF_EXPECT_1(m, f7, NTF_EQ(k)).SAVE_ARG_1(TO(to));
         // NTF_EXPECT_1(m, f7, NTF_EQ(k)).SAVE_ARG_1(TO_DEREF(&to)); // SHALL FAIL
+
+
+        NTF_EXPECT_1(m, f7, NTF_EQ(k)).SET_ARG_1(FROM(5)); // TODO: SHALL FAIL
+
+        int &k_r = k;
+        NTF_EXPECT_1(m, f7, NTF_EQ(k)).SET_ARG_1(FROM(k_r)); // TODO: SHALL FAIL
     }
 }
 

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -24,6 +24,7 @@
 #include <ntcd_reactor.h>
 #include <ntcd_resolver.h>
 #include <ntcd_simulation.h>
+#include <ntcd_timer.h>
 #include <ntci_log.h>
 #include <ntcm_monitorableutil.h>
 #include <ntcs_datapool.h>
@@ -52,8 +53,6 @@
 #include <bslmt_threadgroup.h>
 #include <bslmt_threadutil.h>
 #include <bsl_unordered_map.h>
-
-//#include <pdh.h>
 
 using namespace BloombergLP;
 
@@ -1375,185 +1374,6 @@ void variation(const test::Parameters& parameters)
                                          NTCCFG_BIND_PLACEHOLDER_3));
 }
 
-namespace mock {
-
-NTF_MOCK_CLASS(ReactorMock, ntci::Reactor)
-
-NTF_MOCK_METHOD(bsl::shared_ptr<ntci::DatagramSocket>,
-                createDatagramSocket,
-                const ntca::DatagramSocketOptions&,
-                bslma::Allocator*)
-NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createIncomingData)
-NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createOutgoingData)
-NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createIncomingBlob)
-NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createOutgoingBlob)
-NTF_MOCK_METHOD(void, createIncomingBlobBuffer, bdlbb::BlobBuffer*)
-NTF_MOCK_METHOD(void, createOutgoingBlobBuffer, bdlbb::BlobBuffer*)
-
-NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
-                      incomingBlobBufferFactory)
-NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
-                      outgoingBlobBufferFactory)
-
-NTF_MOCK_METHOD(ntci::Waiter, registerWaiter, const ntca::WaiterOptions&)
-NTF_MOCK_METHOD(void, deregisterWaiter, ntci::Waiter)
-NTF_MOCK_METHOD(void, run, ntci::Waiter)
-NTF_MOCK_METHOD(void, poll, ntci::Waiter)
-NTF_MOCK_METHOD(void, interruptOne)
-NTF_MOCK_METHOD(void, interruptAll)
-NTF_MOCK_METHOD(void, stop)
-NTF_MOCK_METHOD(void, restart)
-NTF_MOCK_METHOD(void, execute, const Functor&)
-NTF_MOCK_METHOD(void, moveAndExecute, FunctorSequence*, const Functor&)
-NTF_MOCK_METHOD(bsl::shared_ptr<ntci::ListenerSocket>,
-                createListenerSocket,
-                const ntca::ListenerSocketOptions&,
-                bslma::Allocator*)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                attachSocket,
-                const bsl::shared_ptr<ntci::ReactorSocket>&)
-NTF_MOCK_METHOD(ntsa::Error, attachSocket, ntsa::Handle)
-NTF_MOCK_METHOD(ntsa::Error,
-                showReadable,
-                const bsl::shared_ptr<ntci::ReactorSocket>&,
-                const ntca::ReactorEventOptions&)
-NTF_MOCK_METHOD(ntsa::Error,
-                showReadable,
-                ntsa::Handle,
-                const ntca::ReactorEventOptions&,
-                const ntci::ReactorEventCallback&)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                showWritable,
-                const bsl::shared_ptr<ntci::ReactorSocket>&,
-                const ntca::ReactorEventOptions&)
-NTF_MOCK_METHOD(ntsa::Error,
-                showWritable,
-                ntsa::Handle,
-                const ntca::ReactorEventOptions&,
-                const ntci::ReactorEventCallback&)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                showError,
-                const bsl::shared_ptr<ntci::ReactorSocket>&,
-                const ntca::ReactorEventOptions&)
-NTF_MOCK_METHOD(ntsa::Error,
-                showError,
-                ntsa::Handle,
-                const ntca::ReactorEventOptions&,
-                const ntci::ReactorEventCallback&)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                hideReadable,
-                const bsl::shared_ptr<ntci::ReactorSocket>&)
-NTF_MOCK_METHOD(ntsa::Error, hideReadable, ntsa::Handle)
-NTF_MOCK_METHOD(ntsa::Error,
-                hideWritable,
-                const bsl::shared_ptr<ntci::ReactorSocket>&)
-NTF_MOCK_METHOD(ntsa::Error, hideWritable, ntsa::Handle)
-NTF_MOCK_METHOD(ntsa::Error,
-                hideError,
-                const bsl::shared_ptr<ntci::ReactorSocket>&)
-NTF_MOCK_METHOD(ntsa::Error, hideError, ntsa::Handle)
-NTF_MOCK_METHOD(ntsa::Error,
-                detachSocket,
-                const bsl::shared_ptr<ntci::ReactorSocket>&)
-NTF_MOCK_METHOD(ntsa::Error, detachSocket, ntsa::Handle)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                detachSocket,
-                const bsl::shared_ptr<ntci::ReactorSocket>&,
-                const ntci::SocketDetachedCallback&)
-NTF_MOCK_METHOD(ntsa::Error,
-                detachSocket,
-                ntsa::Handle,
-                const ntci::SocketDetachedCallback&)
-
-NTF_MOCK_METHOD(ntsa::Error, closeAll)
-NTF_MOCK_METHOD(void, incrementLoad, const ntca::LoadBalancingOptions&)
-NTF_MOCK_METHOD(void, decrementLoad, const ntca::LoadBalancingOptions&)
-
-NTF_MOCK_METHOD(void, drainFunctions)
-NTF_MOCK_METHOD(void, clearFunctions)
-NTF_MOCK_METHOD(void, clearTimers)
-NTF_MOCK_METHOD(void, clearSockets)
-NTF_MOCK_METHOD(void, clear)
-NTF_MOCK_METHOD_CONST(size_t, numSockets)
-NTF_MOCK_METHOD_CONST(size_t, maxSockets)
-NTF_MOCK_METHOD_CONST(size_t, numTimers)
-NTF_MOCK_METHOD_CONST(size_t, maxTimers)
-NTF_MOCK_METHOD_CONST(bool, autoAttach)
-NTF_MOCK_METHOD_CONST(bool, autoDetach)
-NTF_MOCK_METHOD_CONST(bool, oneShot)
-NTF_MOCK_METHOD_CONST(ntca::ReactorEventTrigger::Value, trigger)
-NTF_MOCK_METHOD_CONST(size_t, load)
-NTF_MOCK_METHOD_CONST(bslmt::ThreadUtil::Handle, threadHandle)
-NTF_MOCK_METHOD_CONST(size_t, threadIndex)
-NTF_MOCK_METHOD_CONST(bool, empty)
-NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<ntci::DataPool>&, dataPool)
-
-NTF_MOCK_METHOD_CONST(bool, supportsOneShot, bool)
-NTF_MOCK_METHOD_CONST(bool, supportsTrigger, ntca::ReactorEventTrigger::Value)
-
-NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Reactor>,
-                acquireReactor,
-                const ntca::LoadBalancingOptions&)
-NTF_MOCK_METHOD(void,
-                releaseReactor,
-                const bsl::shared_ptr<ntci::Reactor>&,
-                const ntca::LoadBalancingOptions&)
-NTF_MOCK_METHOD(bool, acquireHandleReservation)
-NTF_MOCK_METHOD(void, releaseHandleReservation)
-
-NTF_MOCK_METHOD_CONST(size_t, numReactors)
-NTF_MOCK_METHOD_CONST(size_t, numThreads)
-NTF_MOCK_METHOD_CONST(size_t, minThreads)
-NTF_MOCK_METHOD_CONST(size_t, maxThreads)
-
-NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Strand>, createStrand, bslma::Allocator*)
-
-NTF_MOCK_METHOD(bsl::shared_ptr<ntci::StreamSocket>,
-                createStreamSocket,
-                const ntca::StreamSocketOptions&,
-                bslma::Allocator*)
-
-NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
-                createTimer,
-                const ntca::TimerOptions&,
-                const bsl::shared_ptr<ntci::TimerSession>&,
-                bslma::Allocator*)
-NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
-                createTimer,
-                const ntca::TimerOptions&,
-                const ntci::TimerCallback&,
-                bslma::Allocator*)
-NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<ntci::Strand>&, strand)
-NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
-NTF_MOCK_CLASS_END;
-
-NTF_MOCK_CLASS(TimerMock, ntci::Timer)
-NTF_MOCK_METHOD(ntsa::Error,
-                schedule,
-                const bsls::TimeInterval&,
-                const bsls::TimeInterval&)
-NTF_MOCK_METHOD(ntsa::Error, cancel)
-NTF_MOCK_METHOD(ntsa::Error, close)
-NTF_MOCK_METHOD(void,
-                arrive,
-                const bsl::shared_ptr<ntci::Timer>&,
-                const bsls::TimeInterval&,
-                const bsls::TimeInterval&)
-NTF_MOCK_METHOD_CONST(void*, handle)
-NTF_MOCK_METHOD_CONST(int, id)
-NTF_MOCK_METHOD_CONST(bool, oneShot)
-NTF_MOCK_METHOD_CONST(bslmt::ThreadUtil::Handle, threadHandle)
-NTF_MOCK_METHOD_CONST(size_t, threadIndex)
-NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<ntci::Strand>&, strand)
-NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
-NTF_MOCK_CLASS_END;
-}  // close namespace mock
-
 struct Fixture {
      Fixture(bslma::Allocator* allocator);
     ~Fixture();
@@ -1570,11 +1390,11 @@ struct Fixture {
     bsl::shared_ptr<bdlbb::BlobBufferFactory> d_bufferFactory;
     bsl::shared_ptr<ntcd::DataPoolMock>       d_dataPoolMock;
     bsl::shared_ptr<ntci::DataPool>           d_dataPool;
-    bsl::shared_ptr<mock::ReactorMock>        d_reactorMock;
+    bsl::shared_ptr<ntcd::ReactorMock>        d_reactorMock;
     bsl::shared_ptr<ntcd::ResolverMock>       d_resolverMock;
     bsl::shared_ptr<ntcd::StreamSocketMock>   d_streamSocketMock;
-    bsl::shared_ptr<mock::TimerMock>          d_connectRetryTimerMock;
-    bsl::shared_ptr<mock::TimerMock>          d_connectDeadlineTimerMock;
+    bsl::shared_ptr<ntcd::TimerMock>          d_connectRetryTimerMock;
+    bsl::shared_ptr<ntcd::TimerMock>          d_connectDeadlineTimerMock;
 
     const bsl::shared_ptr<bdlbb::Blob>       d_nullBlob;
     const bsl::shared_ptr<ntci::Strand>      d_nullStrand;

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1379,53 +1379,31 @@ namespace mock {
 class ResolverMock : public ntci::Resolver
 {
   public:
-    void execute(const Functor& functor) override
-    {
-        UNEXPECTED_CALL();
-    }
-    void moveAndExecute(FunctorSequence* functorSequence,
-                        const Functor&   functor) override
-    {
-        UNEXPECTED_CALL();
-    }
+    NTF_MOCK_METHOD_NEW(void, execute, const Functor&)
+    NTF_MOCK_METHOD_NEW(void, moveAndExecute, FunctorSequence*, const Functor&)
+  public:
     const bsl::shared_ptr<ntci::Strand>& strand() const override
     {
         UNEXPECTED_CALL();
         return dummyStrand;
     }
-    ntsa::Error start() override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    void shutdown() override
-    {
-        UNEXPECTED_CALL();
-    }
-    void linger() override
-    {
-        UNEXPECTED_CALL();
-    }
-    ntsa::Error setIpAddress(
-        const bslstl::StringRef&            domainName,
-        const bsl::vector<ntsa::IpAddress>& ipAddressList) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error addIpAddress(
-        const bslstl::StringRef&            domainName,
-        const bsl::vector<ntsa::IpAddress>& ipAddressList) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error addIpAddress(const bslstl::StringRef& domainName,
-                             const ntsa::IpAddress&   ipAddress) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
+    NTF_MOCK_METHOD_NEW(ntsa::Error, start)
+    NTF_MOCK_METHOD_NEW(void, shutdown)
+    NTF_MOCK_METHOD_NEW(void, linger)
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        setIpAddress,
+                        const bslstl::StringRef&,
+                        const bsl::vector<ntsa::IpAddress>&)
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        addIpAddress,
+                        const bslstl::StringRef&,
+                        const bsl::vector<ntsa::IpAddress>&)
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        addIpAddress,
+                        const bslstl::StringRef&,
+                        const ntsa::IpAddress&)
+
+  public:
     ntsa::Error setPort(const bslstl::StringRef&       serviceName,
                         const bsl::vector<ntsa::Port>& portList,
                         ntsa::Transport::Value         transport) override
@@ -1447,22 +1425,16 @@ class ResolverMock : public ntci::Resolver
         UNEXPECTED_CALL();
         return ntsa::Error();
     }
-    ntsa::Error setLocalIpAddress(
-        const bsl::vector<ntsa::IpAddress>& ipAddressList) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error setHostname(const bsl::string& name) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error setHostnameFullyQualified(const bsl::string& name) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
+
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        setLocalIpAddress,
+                        const bsl::vector<ntsa::IpAddress>&)
+    NTF_MOCK_METHOD_NEW(ntsa::Error, setHostname, const bsl::string&)
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        setHostnameFullyQualified,
+                        const bsl::string&)
+
+  public:
     ntsa::Error getIpAddress(
         const bslstl::StringRef&          domainName,
         const ntca::GetIpAddressOptions&  options,
@@ -1516,29 +1488,16 @@ class ResolverMock : public ntci::Resolver
         d_getEndpoint_result.reset();
         return res;
     }
-    ntsa::Error getLocalIpAddress(
-        bsl::vector<ntsa::IpAddress>* result,
-        const ntsa::IpAddressOptions& options) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error getHostname(bsl::string* result) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error getHostnameFullyQualified(bsl::string* result) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    bsl::shared_ptr<ntci::Strand> createStrand(
-        bslma::Allocator* basicAllocator) override
-    {
-        UNEXPECTED_CALL();
-        return bsl::shared_ptr<ntci::Strand>();
-    }
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        getLocalIpAddress,
+                        bsl::vector<ntsa::IpAddress>*,
+                        const ntsa::IpAddressOptions&)
+    NTF_MOCK_METHOD_NEW(ntsa::Error, getHostname, bsl::string*)
+    NTF_MOCK_METHOD_NEW(ntsa::Error, getHostnameFullyQualified, bsl::string*)
+    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Strand>,
+                        createStrand,
+                        bslma::Allocator*)
+  public:
     bsl::shared_ptr<ntci::Timer> createTimer(
         const ntca::TimerOptions&                  options,
         const bsl::shared_ptr<ntci::TimerSession>& session,
@@ -1555,12 +1514,8 @@ class ResolverMock : public ntci::Resolver
         UNEXPECTED_CALL();
         return bsl::shared_ptr<ntci::Timer>();
     }
-    bsls::TimeInterval currentTime() const override
-    {
-        UNEXPECTED_CALL();
-        return bsls::TimeInterval();
-    }
-
+    NTF_MOCK_METHOD_CONST_NEW(bsls::TimeInterval, currentTime)
+  public:
     // auxiliary functions
     void expect_getEndpoint_WillOnceReturn(
         const bdlb::NullableValue<bslstl::StringRef>&        text,
@@ -1583,7 +1538,6 @@ class ResolverMock : public ntci::Resolver
 
 class BufferFactoryMock : public bdlbb::BlobBufferFactory
 {
-  public:
     NTF_MOCK_METHOD(void, allocate, bdlbb::BlobBuffer*)
 };
 #endif
@@ -1765,20 +1719,8 @@ class StreamSocketMock : public ntsi::StreamSocket
     NTF_MOCK_METHOD_NEW(ntsa::Error, acquire, ntsa::Handle)
     NTF_MOCK_METHOD_NEW(ntsa::Handle, release)
 
-  public:
-    ntsa::Error bind(const ntsa::Endpoint& endpoint,
-                     bool                  reuseAddress) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error bindAny(ntsa::Transport::Value transport,
-                        bool                   reuseAddress) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-
+    NTF_MOCK_METHOD_NEW(ntsa::Error, bind, const ntsa::Endpoint&, bool)
+    NTF_MOCK_METHOD_NEW(ntsa::Error, bindAny, ntsa::Transport::Value, bool)
     NTF_MOCK_METHOD_NEW(ntsa::Error, connect, const ntsa::Endpoint&)
   public:
     ntsa::Error send(ntsa::SendContext*       context,
@@ -1821,164 +1763,13 @@ class StreamSocketMock : public ntsi::StreamSocket
     NTF_MOCK_METHOD_NEW(ntsa::Error, setBlocking, bool)
     NTF_MOCK_METHOD_NEW(ntsa::Error, setOption, const ntsa::SocketOption&)
 
-  public:
-    ntsa::Error getOption(ntsa::SocketOption*           option,
-                          ntsa::SocketOptionType::Value type) override
-    {
-        return d_invocation_getOption.invoke(option, type);
-    }
-
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        getOption,
+                        ntsa::SocketOption*,
+                        ntsa::SocketOptionType::Value)
     NTF_MOCK_METHOD_NEW(ntsa::Error, getLastError, ntsa::Error*)
     NTF_MOCK_METHOD_CONST_NEW(bsl::size_t, maxBuffersPerSend)
     NTF_MOCK_METHOD_CONST_NEW(bsl::size_t, maxBuffersPerReceive)
-
-  public:
-    struct Invocation_getOption {
-      private:
-        struct InvocationData {
-            int                                                d_expectedCalls;
-            bdlb::NullableValue<ntsa::SocketOption*>           d_arg1;
-            bdlb::NullableValue<ntsa::SocketOptionType::Value> d_arg2;
-            bdlb::NullableValue<ntsa::Error>                   d_result;
-            ntsa::SocketOption**                               d_arg1_out;
-            ntsa::SocketOptionType::Value*                     d_arg2_out;
-            bdlb::NullableValue<ntsa::SocketOption>            d_arg1_set;
-
-            InvocationData()
-            : d_expectedCalls(0)
-            , d_arg1()
-            , d_arg2()
-            , d_result()
-            , d_arg1_out(0)
-            , d_arg2_out(0)
-            , d_arg1_set()
-            {
-            }
-        };
-
-      public:
-        Invocation_getOption& expect(
-            const bdlb::NullableValue<ntsa::SocketOption*>&           arg1,
-            const bdlb::NullableValue<ntsa::SocketOptionType::Value>& arg2)
-        {
-            d_invocations.emplace_back();
-            InvocationData& invocation = d_invocations.back();
-
-            invocation.d_arg1 = arg1;
-            invocation.d_arg2 = arg2;
-
-            return *this;
-        }
-        Invocation_getOption& willOnce()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
-
-            invocation.d_expectedCalls = 1;
-            return *this;
-        }
-        Invocation_getOption& willAlways()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
-
-            invocation.d_expectedCalls = -1;
-            return *this;
-        }
-        //        Invocation_createTimer& times(int val){} //TODO: multiple calls
-
-        Invocation_getOption& willReturn(ntsa::Error result)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.back();
-            invocation.d_result        = result;
-            return *this;
-        }
-
-        Invocation_getOption& saveArg1(ntsa::SocketOption*& arg1)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.back();
-            invocation.d_arg1_out      = &arg1;
-            return *this;
-        }
-
-        Invocation_getOption& setArg1(const ntsa::SocketOption& arg1)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.back();
-            invocation.d_arg1_set      = arg1;
-            return *this;
-        }
-
-        Invocation_getOption& saveArg2(ntsa::SocketOptionType::Value& arg2)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.back();
-            invocation.d_arg2_out      = &arg2;
-            return *this;
-        }
-
-        ntsa::Error invoke(ntsa::SocketOption*           arg1,
-                           ntsa::SocketOptionType::Value arg2)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.front();
-
-            if (invocation.d_expectedCalls != -1) {
-                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
-            }
-
-            if (invocation.d_arg1.has_value()) {
-                NTCCFG_TEST_EQ(arg1, invocation.d_arg1.value());
-            }
-
-            if (invocation.d_arg2.has_value()) {
-                NTCCFG_TEST_EQ(arg2, invocation.d_arg2.value());
-            }
-
-            if (invocation.d_arg1_out) {
-                *invocation.d_arg1_out = arg1;
-            }
-
-            if (invocation.d_arg2_out) {
-                *invocation.d_arg2_out = arg2;
-            }
-
-            if (invocation.d_arg1_set.has_value()) {
-                *arg1 = invocation.d_arg1_set.value();
-            }
-
-            NTCCFG_TEST_TRUE(invocation.d_result.has_value());
-            const auto result = invocation.d_result.value();
-
-            if (invocation.d_expectedCalls != -1) {
-                --invocation.d_expectedCalls;
-                if (invocation.d_expectedCalls == 0) {
-                    d_invocations.pop_front();
-                }
-            }
-
-            return result;
-        }
-
-      private:
-        bsl::list<InvocationData> d_invocations;
-    };
-
-    Invocation_getOption& expect_getOption(
-        const bdlb::NullableValue<ntsa::SocketOption*>&           arg1,
-        const bdlb::NullableValue<ntsa::SocketOptionType::Value>& arg2)
-    {
-        return d_invocation_getOption.expect(arg1, arg2);
-    }
-
-  private:
-    mutable Invocation_getOption d_invocation_getOption;
 };
 
 class DataPoolMock : public ntci::DataPool
@@ -2012,13 +1803,10 @@ class DataPoolMock : public ntci::DataPool
 class ReactorMock : public ntci::Reactor
 {
   public:
-    bsl::shared_ptr<ntci::DatagramSocket> createDatagramSocket(
-        const ntca::DatagramSocketOptions& options,
-        bslma::Allocator*                  basicAllocator) override
-    {
-        UNEXPECTED_CALL();
-        return bsl::shared_ptr<ntci::DatagramSocket>();
-    }
+    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::DatagramSocket>,
+                        createDatagramSocket,
+                        const ntca::DatagramSocketOptions&,
+                        bslma::Allocator*)
     NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntsa::Data>, createIncomingData)
     NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntsa::Data>, createOutgoingData)
     NTF_MOCK_METHOD_NEW(bsl::shared_ptr<bdlbb::Blob>, createIncomingBlob)
@@ -2054,53 +1842,24 @@ class ReactorMock : public ntci::Reactor
     NTF_MOCK_METHOD_NEW(void, interruptAll)
     NTF_MOCK_METHOD_NEW(void, stop)
     NTF_MOCK_METHOD_NEW(void, restart)
+    NTF_MOCK_METHOD_NEW(void, execute, const Functor&)
+    NTF_MOCK_METHOD_NEW(void, moveAndExecute, FunctorSequence*, const Functor&)
+    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::ListenerSocket>,
+                        createListenerSocket,
+                        const ntca::ListenerSocketOptions&,
+                        bslma::Allocator*)
 
-  public:
-    void execute(const Functor& functor) override
-    {
-        if (!d_execute_expected) {
-            UNEXPECTED_CALL();
-        }
-        d_execute_expected = false;
-        NTCCFG_TEST_FALSE(d_execute_functor.has_value());
-        d_execute_functor = functor;
-    }
-    void moveAndExecute(FunctorSequence* functorSequence,
-                        const Functor&   functor) override
-    {
-        UNEXPECTED_CALL();
-    }
-    bsl::shared_ptr<ntci::ListenerSocket> createListenerSocket(
-        const ntca::ListenerSocketOptions& options,
-        bslma::Allocator*                  basicAllocator) override
-    {
-        UNEXPECTED_CALL();
-        return bsl::shared_ptr<ntci::ListenerSocket>();
-    }
-    ntsa::Error attachSocket(
-        const bsl::shared_ptr<ntci::ReactorSocket>& socket) override
-    {
-        if (d_attachSocket_result.isNull()) {
-            UNEXPECTED_CALL();
-        }
-        if (d_attachSocket_arg1.has_value()) {
-            NTCCFG_TEST_EQ(socket, d_attachSocket_arg1.value());
-            d_attachSocket_arg1.reset();
-        }
-        const auto res = d_attachSocket_result.value();
-        d_attachSocket_result.reset();
-        return res;
-    }
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        attachSocket,
+                        const bsl::shared_ptr<ntci::ReactorSocket>&)
     NTF_MOCK_METHOD_NEW(ntsa::Error, attachSocket, ntsa::Handle)
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        showReadable,
+                        const bsl::shared_ptr<ntci::ReactorSocket>&,
+                        const ntca::ReactorEventOptions&)
+
   public:
     ntsa::Error showReadable(
-        const bsl::shared_ptr<ntci::ReactorSocket>& socket,
-        const ntca::ReactorEventOptions&            options) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error showReadable(
         ntsa::Handle                      handle,
         const ntca::ReactorEventOptions&  options,
         const ntci::ReactorEventCallback& callback) override
@@ -2108,23 +1867,13 @@ class ReactorMock : public ntci::Reactor
         UNEXPECTED_CALL();
         return ntsa::Error();
     }
-    ntsa::Error showWritable(
-        const bsl::shared_ptr<ntci::ReactorSocket>& socket,
-        const ntca::ReactorEventOptions&            options) override
-    {
-        if (d_showWritable_result.isNull()) {
-            UNEXPECTED_CALL();
-        }
 
-        if (d_showWritable_arg1.has_value()) {
-            NTCCFG_TEST_EQ(socket, d_showWritable_arg1.value());
-            d_showWritable_arg1.reset();
-        }
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        showWritable,
+                        const bsl::shared_ptr<ntci::ReactorSocket>&,
+                        const ntca::ReactorEventOptions&)
 
-        const auto res = d_showWritable_result.value();
-        d_showWritable_result.reset();
-        return res;
-    }
+  public:
     ntsa::Error showWritable(
         ntsa::Handle                      handle,
         const ntca::ReactorEventOptions&  options,
@@ -2133,12 +1882,12 @@ class ReactorMock : public ntci::Reactor
         UNEXPECTED_CALL();
         return ntsa::Error();
     }
-    ntsa::Error showError(const bsl::shared_ptr<ntci::ReactorSocket>& socket,
-                          const ntca::ReactorEventOptions& options) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
+
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        showError,
+                        const bsl::shared_ptr<ntci::ReactorSocket>&,
+                        const ntca::ReactorEventOptions&)
+  public:
     ntsa::Error showError(ntsa::Handle                      handle,
                           const ntca::ReactorEventOptions&  options,
                           const ntci::ReactorEventCallback& callback) override
@@ -2238,12 +1987,10 @@ class ReactorMock : public ntci::Reactor
     NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Reactor>,
                         acquireReactor,
                         const ntca::LoadBalancingOptions&)
-  public:
-    void releaseReactor(const bsl::shared_ptr<ntci::Reactor>& reactor,
-                        const ntca::LoadBalancingOptions&     options) override
-    {
-        UNEXPECTED_CALL();
-    }
+    NTF_MOCK_METHOD_NEW(void,
+                        releaseReactor,
+                        const bsl::shared_ptr<ntci::Reactor>&,
+                        const ntca::LoadBalancingOptions&)
     NTF_MOCK_METHOD_NEW(bool, acquireHandleReservation)
     NTF_MOCK_METHOD_NEW(void, releaseHandleReservation)
 
@@ -2255,14 +2002,12 @@ class ReactorMock : public ntci::Reactor
     NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Strand>,
                         createStrand,
                         bslma::Allocator*)
+
+    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::StreamSocket>,
+                        createStreamSocket,
+                        const ntca::StreamSocketOptions&,
+                        bslma::Allocator*)
   public:
-    bsl::shared_ptr<ntci::StreamSocket> createStreamSocket(
-        const ntca::StreamSocketOptions& options,
-        bslma::Allocator*                basicAllocator) override
-    {
-        UNEXPECTED_CALL();
-        return bsl::shared_ptr<ntci::StreamSocket>();
-    }
     bsl::shared_ptr<ntci::Timer> createTimer(
         const ntca::TimerOptions&                  options,
         const bsl::shared_ptr<ntci::TimerSession>& session,
@@ -2465,35 +2210,6 @@ class ReactorMock : public ntci::Reactor
         return d_invocation_createTimer.expect(arg1, arg2, arg3);
     }
 
-    void expect_execute_WillOnceReturn()
-    {
-        d_execute_expected = true;
-    }
-
-    void expect_attachSocket_WillOnceReturn(
-        const bdlb::NullableValue<bsl::shared_ptr<ntci::ReactorSocket> >&
-                           socket,
-        const ntsa::Error& result)
-    {
-        NTCCFG_TEST_TRUE(d_attachSocket_result.isNull());
-        NTCCFG_TEST_TRUE(d_attachSocket_arg1.isNull());
-
-        d_attachSocket_result = result;
-        d_attachSocket_arg1   = socket;
-    }
-
-    void expect_showWritable_WillOnceReturn(
-        const bdlb::NullableValue<bsl::shared_ptr<ntci::ReactorSocket> >&
-                           socket,
-        const ntsa::Error& error)
-    {
-        NTCCFG_TEST_TRUE(d_showWritable_result.isNull());
-        NTCCFG_TEST_TRUE(d_showWritable_arg1.isNull());
-
-        d_showWritable_result = error;
-        d_showWritable_arg1   = socket;
-    }
-
     void expect_detachSocket_WillOnceReturn(
         const bdlb::NullableValue<bsl::shared_ptr<ntci::ReactorSocket> >&
                                                                  socket,
@@ -2503,21 +2219,6 @@ class ReactorMock : public ntci::Reactor
         d_detachSocket_result = result;
         d_detachSocket_arg1   = socket;
         d_detachSocket_arg2   = callback;
-    }
-
-    //    ntci::TimerCallback extract_timerCallback()
-    //    {
-    //        NTCCFG_TEST_TRUE(d_timerCallback.has_value());
-    //        const auto res = d_timerCallback.value();
-    //        d_timerCallback.reset();
-    //        return res;
-    //    }
-
-    ntci::Reactor::Functor extract_execute_functor()
-    {
-        ntci::Reactor::Functor res = d_execute_functor.value();
-        d_execute_functor.reset();
-        return res;
     }
 
     ntci::SocketDetachedCallback extract_detachCallback()
@@ -2535,16 +2236,6 @@ class ReactorMock : public ntci::Reactor
                                   d_outgoingBlobBufferFactory_result;
     bsl::shared_ptr<ntci::Strand> dummyStrand;
     bdlb::NullableValue<bsl::shared_ptr<ntci::DataPool> > d_dataPool_result;
-    bool                                                  d_execute_expected;
-    bdlb::NullableValue<ntci::Reactor::Functor>           d_execute_functor;
-
-    bdlb::NullableValue<bsl::shared_ptr<ntci::ReactorSocket> >
-                                     d_attachSocket_arg1;
-    bdlb::NullableValue<ntsa::Error> d_attachSocket_result;
-
-    bdlb::NullableValue<bsl::shared_ptr<ntci::ReactorSocket> >
-                                     d_showWritable_arg1;
-    bdlb::NullableValue<ntsa::Error> d_showWritable_result;
 
     bdlb::NullableValue<ntsa::Error> d_detachSocket_result;
     bdlb::NullableValue<bsl::shared_ptr<ntci::ReactorSocket> >
@@ -2556,15 +2247,12 @@ class ReactorMock : public ntci::Reactor
 
 class TimerMock : public ntci::Timer
 {
-  public:
-    ntsa::Error schedule(const bsls::TimeInterval& deadline,
-                         const bsls::TimeInterval& period) override
-    {
-        return d_schedule_invocation.invoke(deadline, period);
-    }
-
-    NTF_MOCK_METHOD(ntsa::Error, cancel)
-    NTF_MOCK_METHOD(ntsa::Error, close)
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        schedule,
+                        const bsls::TimeInterval&,
+                        const bsls::TimeInterval&)
+    NTF_MOCK_METHOD_NEW(ntsa::Error, cancel)
+    NTF_MOCK_METHOD_NEW(ntsa::Error, close)
   public:
     void arrive(const bsl::shared_ptr<ntci::Timer>& self,
                 const bsls::TimeInterval&           now,
@@ -2577,10 +2265,10 @@ class TimerMock : public ntci::Timer
         UNEXPECTED_CALL();
         return nullptr;
     }
-    NTF_MOCK_METHOD_CONST(int, id)
-    NTF_MOCK_METHOD_CONST(bool, oneShot)
-    NTF_MOCK_METHOD_CONST(bslmt::ThreadUtil::Handle, threadHandle)
-    NTF_MOCK_METHOD_CONST(size_t, threadIndex)
+    NTF_MOCK_METHOD_CONST_NEW(int, id)
+    NTF_MOCK_METHOD_CONST_NEW(bool, oneShot)
+    NTF_MOCK_METHOD_CONST_NEW(bslmt::ThreadUtil::Handle, threadHandle)
+    NTF_MOCK_METHOD_CONST_NEW(size_t, threadIndex)
 
   public:
     const bsl::shared_ptr<ntci::Strand>& strand() const override
@@ -2588,143 +2276,10 @@ class TimerMock : public ntci::Timer
         UNEXPECTED_CALL();
         return dummyStrand;
     }
-    NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
-  public:
-    struct Invocation_schedule {
-        //        const bsls::TimeInterval& deadline,
-        //                         const bsls::TimeInterval& period
-      private:
-        struct InvocationData {
-            int                                     d_expectedCalls;
-            bdlb::NullableValue<bsls::TimeInterval> d_arg1;
-            bdlb::NullableValue<bsls::TimeInterval> d_arg2;
-            bdlb::NullableValue<ntsa::Error>        d_result;
-            bsls::TimeInterval*                     d_arg1_out;
-            bsls::TimeInterval*                     d_arg2_out;
-
-            InvocationData()
-            : d_expectedCalls(0)
-            , d_arg1()
-            , d_arg2()
-            , d_result()
-            , d_arg1_out(0)
-            , d_arg2_out(0)
-            {
-            }
-        };
-
-      public:
-        Invocation_schedule& expect(
-            const bdlb::NullableValue<bsls::TimeInterval>& arg1,
-            const bdlb::NullableValue<bsls::TimeInterval>& arg2)
-        {
-            d_invocations.emplace_back();
-            InvocationData& invocation = d_invocations.back();
-            invocation.d_arg1          = arg1;
-            invocation.d_arg2          = arg2;
-            return *this;
-        }
-        Invocation_schedule& willOnce()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
-
-            invocation.d_expectedCalls = 1;
-            return *this;
-        }
-        Invocation_schedule& willAlways()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
-
-            invocation.d_expectedCalls = -1;
-            return *this;
-        }
-        //        Invocation_createTimer& times(int val){} //TODO: multiple calls
-
-        Invocation_schedule& willReturn(const ntsa::Error result)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.back();
-            invocation.d_result        = result;
-            return *this;
-        }
-
-        Invocation_schedule& saveArg1(bsls::TimeInterval& arg)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_arg1_out, 0);
-            invocation.d_arg1_out = &arg;
-            return *this;
-        }
-        Invocation_schedule& saveArg2(bsls::TimeInterval& arg)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_arg2_out, 0);
-            invocation.d_arg2_out = &arg;
-            return *this;
-        }
-
-        ntsa::Error invoke(const bsls::TimeInterval& arg1,
-                           const bsls::TimeInterval& arg2)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.front();
-
-            if (invocation.d_expectedCalls != -1) {
-                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
-            }
-
-            if (invocation.d_arg1.has_value()) {
-                NTCCFG_TEST_EQ(arg1, invocation.d_arg1.value());
-            }
-
-            if (invocation.d_arg2.has_value()) {
-                NTCCFG_TEST_EQ(arg2, invocation.d_arg2.value());
-            }
-
-            if (invocation.d_arg1_out) {
-                *invocation.d_arg1_out = arg1;
-            }
-
-            if (invocation.d_arg2_out) {
-                *invocation.d_arg2_out = arg2;
-            }
-
-            NTCCFG_TEST_TRUE(invocation.d_result.has_value());
-            const auto result = invocation.d_result.value();
-
-            if (invocation.d_expectedCalls != -1) {
-                --invocation.d_expectedCalls;
-                if (invocation.d_expectedCalls == 0) {
-                    d_invocations.pop_front();
-                }
-            }
-
-            return result;
-        }
-
-      private:
-        bsl::list<InvocationData> d_invocations;
-    };
-
-    Invocation_schedule& expect_schedule(
-        const bdlb::NullableValue<bsls::TimeInterval>& arg1,
-        const bdlb::NullableValue<bsls::TimeInterval>& arg2)
-    {
-        return d_schedule_invocation.expect(arg1, arg2);
-    }
+    NTF_MOCK_METHOD_CONST_NEW(bsls::TimeInterval, currentTime)
 
   private:
     bsl::shared_ptr<ntci::Strand> dummyStrand;
-
-    Invocation_schedule d_schedule_invocation;
 };
 #endif
 }  // close namespace mock
@@ -4796,19 +4351,21 @@ NTCCFG_TEST_CASE(22)
         ntsa::SocketOption rcvBufferSizeOption;
         rcvBufferSizeOption.makeReceiveBufferSize(100500);
 
-        socketMock
-            ->expect_getOption(doNotCare,
-                               ntsa::SocketOptionType::e_SEND_BUFFER_SIZE)
-            .willOnce()
-            .willReturn(ntsa::Error())
-            .setArg1(sendBufferSizeOption);
+        NTF_EXPECT_2(*socketMock,
+                     getOption,
+                     IGNORE_ARG,
+                     NTF_EQ(ntsa::SocketOptionType::e_SEND_BUFFER_SIZE))
+            .ONCE()
+            .RETURN(ntsa::Error())
+            .SET_ARG_1(FROM_DEREF(sendBufferSizeOption));
 
-        socketMock
-            ->expect_getOption(doNotCare,
-                               ntsa::SocketOptionType::e_RECEIVE_BUFFER_SIZE)
-            .willOnce()
-            .willReturn(ntsa::Error())
-            .setArg1(rcvBufferSizeOption);
+        NTF_EXPECT_2(*socketMock,
+                     getOption,
+                     IGNORE_ARG,
+                     NTF_EQ(ntsa::SocketOptionType::e_RECEIVE_BUFFER_SIZE))
+            .ONCE()
+            .RETURN(ntsa::Error())
+            .SET_ARG_1(FROM_DEREF(rcvBufferSizeOption));
 
         socketMock->expect_maxBuffersPerSend().willOnce().willReturn(22);
         socketMock->expect_maxBuffersPerReceive().willOnce().willReturn(22);
@@ -4831,9 +4388,9 @@ NTCCFG_TEST_CASE(22)
             .willReturn(connectRetryTimerMock)
             .saveArg2(retryTimerCallback);
 
-        connectRetryTimerMock->expect_schedule(doNotCare, doNotCare)
-            .willOnce()
-            .willReturn(ntsa::Error());
+        NTF_EXPECT_2(*connectRetryTimerMock, schedule, IGNORE_ARG, IGNORE_ARG)
+            .ONCE()
+            .RETURN(ntsa::Error());
 
         const ntci::ConnectFunction connectCallback =
             [&connectResult](const bsl::shared_ptr<ntci::Connector>& connector,
@@ -4863,7 +4420,11 @@ NTCCFG_TEST_CASE(22)
 
         connectRetryTimerMock->expect_close().willOnce().willReturn(
             ntsa::Error());
-        reactorMock->expect_execute_WillOnceReturn();
+
+        ntci::Reactor::Functor callback;
+        NTF_EXPECT_1(*reactorMock, execute, IGNORE_ARG)
+            .ONCE()
+            .SAVE_ARG_1(TO(&callback));
 
         reactorMock->expect_detachSocket_WillOnceReturn(
             socket,
@@ -4876,7 +4437,6 @@ NTCCFG_TEST_CASE(22)
         socket->shutdown(ntsa::ShutdownType::e_BOTH,
                          ntsa::ShutdownMode::e_GRACEFUL);
 
-        const auto callback = reactorMock->extract_execute_functor();
         callback();
         NTCCFG_TEST_TRUE(connectResult.has_value());
         NTCCFG_TEST_EQ(connectResult.value().type(),
@@ -4975,19 +4535,21 @@ NTCCFG_TEST_CASE(23)
         ntsa::SocketOption rcvBufferSizeOption;
         rcvBufferSizeOption.makeReceiveBufferSize(100500);
 
-        socketMock
-            ->expect_getOption(doNotCare,
-                               ntsa::SocketOptionType::e_SEND_BUFFER_SIZE)
-            .willOnce()
-            .willReturn(ntsa::Error())
-            .setArg1(sendBufferSizeOption);
+        NTF_EXPECT_2(*socketMock,
+                     getOption,
+                     IGNORE_ARG,
+                     NTF_EQ(ntsa::SocketOptionType::e_SEND_BUFFER_SIZE))
+            .ONCE()
+            .RETURN(ntsa::Error())
+            .SET_ARG_1(FROM_DEREF(sendBufferSizeOption));
 
-        socketMock
-            ->expect_getOption(doNotCare,
-                               ntsa::SocketOptionType::e_RECEIVE_BUFFER_SIZE)
-            .willOnce()
-            .willReturn(ntsa::Error())
-            .setArg1(rcvBufferSizeOption);
+        NTF_EXPECT_2(*socketMock,
+                     getOption,
+                     IGNORE_ARG,
+                     NTF_EQ(ntsa::SocketOptionType::e_RECEIVE_BUFFER_SIZE))
+            .ONCE()
+            .RETURN(ntsa::Error())
+            .SET_ARG_1(FROM_DEREF(rcvBufferSizeOption));
 
         socketMock->expect_maxBuffersPerSend().willOnce().willReturn(22);
         socketMock->expect_maxBuffersPerReceive().willOnce().willReturn(22);
@@ -5010,9 +4572,9 @@ NTCCFG_TEST_CASE(23)
             .willReturn(connectRetryTimerMock)
             .saveArg2(retryTimerCallback);
 
-        connectRetryTimerMock->expect_schedule(doNotCare, doNotCare)
-            .willOnce()
-            .willReturn(ntsa::Error());
+        NTF_EXPECT_2(*connectRetryTimerMock, schedule, IGNORE_ARG, IGNORE_ARG)
+            .ONCE()
+            .RETURN(ntsa::Error());
 
         const ntci::ConnectFunction connectCallback =
             [&connectResult](const bsl::shared_ptr<ntci::Connector>& connector,
@@ -5030,8 +4592,16 @@ NTCCFG_TEST_CASE(23)
 
         NTCI_LOG_DEBUG("Trigger internal timer to initiate connection...");
 
-        reactorMock->expect_attachSocket_WillOnceReturn(socket, ntsa::Error());
-        reactorMock->expect_showWritable_WillOnceReturn(socket, ntsa::Error());
+        NTF_EXPECT_1(
+            *reactorMock,
+            attachSocket,
+            NTF_EQ_SPEC(socket, const bsl::shared_ptr<ntci::ReactorSocket>&))
+            .ONCE()
+            .RETURN(ntsa::Error());
+
+        NTF_EXPECT_2(*reactorMock, showWritable, NTF_EQ(socket), IGNORE_ARG)
+            .ONCE()
+            .RETURN(ntsa::Error());
 
         NTF_EXPECT_1(*socketMock, connect, NTF_EQ(targetEp))
             .ONCE()
@@ -5064,10 +4634,12 @@ NTCCFG_TEST_CASE(23)
         const auto detachCallback = reactorMock->extract_detachCallback();
         NTCCFG_TEST_TRUE(detachCallback);
 
-        reactorMock->expect_execute_WillOnceReturn();
+        ntci::Reactor::Functor callback;
+        NTF_EXPECT_1(*reactorMock, execute, IGNORE_ARG)
+            .ONCE()
+            .SAVE_ARG_1(TO(&callback));
         detachCallback(nullStrand);
 
-        const auto callback = reactorMock->extract_execute_functor();
         callback();
 
         NTCCFG_TEST_TRUE(connectResult.has_value());
@@ -5155,10 +4727,12 @@ NTCCFG_TEST_CASE(24)
                 .willReturn(connectDeadlineTimerMock)
                 .saveArg2(deadlineTimerCallback);
 
-            connectDeadlineTimerMock
-                ->expect_schedule(deadlineTime, bsls::TimeInterval())
-                .willOnce()
-                .willReturn(ntsa::Error());
+            NTF_EXPECT_2(*connectDeadlineTimerMock,
+                         schedule,
+                         NTF_EQ(deadlineTime),
+                         NTF_EQ(bsls::TimeInterval()))
+                .ONCE()
+                .RETURN(ntsa::Error());
         }
 
         bsl::shared_ptr<test::mock::TimerMock> connectRetryTimerMock;
@@ -5171,9 +4745,12 @@ NTCCFG_TEST_CASE(24)
                 .willReturn(connectRetryTimerMock)
                 .saveArg2(retryTimerCallback);
 
-            connectRetryTimerMock->expect_schedule(doNotCare, doNotCare)
-                .willOnce()
-                .willReturn(ntsa::Error());
+            NTF_EXPECT_2(*connectRetryTimerMock,
+                         schedule,
+                         IGNORE_ARG,
+                         IGNORE_ARG)
+                .ONCE()
+                .RETURN(ntsa::Error());
         }
 
         const ntci::ConnectFunction connectCallback =
@@ -5196,8 +4773,17 @@ NTCCFG_TEST_CASE(24)
             .ALWAYS()
             .RETURN(true);
         NTF_EXPECT_0(*reactorMock, releaseHandleReservation).ALWAYS();
-        reactorMock->expect_attachSocket_WillOnceReturn(socket, ntsa::Error());
-        reactorMock->expect_showWritable_WillOnceReturn(socket, ntsa::Error());
+
+        NTF_EXPECT_1(
+            *reactorMock,
+            attachSocket,
+            NTF_EQ_SPEC(socket, const bsl::shared_ptr<ntci::ReactorSocket>&))
+            .ONCE()
+            .RETURN(ntsa::Error());
+
+        NTF_EXPECT_2(*reactorMock, showWritable, NTF_EQ(socket), IGNORE_ARG)
+            .ONCE()
+            .RETURN(ntsa::Error());
 
         ntca::TimerEvent timerEvent;
         timerEvent.setType(ntca::TimerEventType::e_DEADLINE);
@@ -5223,10 +4809,13 @@ NTCCFG_TEST_CASE(24)
         const auto detachCallback = reactorMock->extract_detachCallback();
         NTCCFG_TEST_TRUE(detachCallback);
 
-        reactorMock->expect_execute_WillOnceReturn();
+        ntci::Reactor::Functor callback;
+        NTF_EXPECT_1(*reactorMock, execute, IGNORE_ARG)
+            .ONCE()
+            .SAVE_ARG_1(TO(&callback));
+
         detachCallback(nullStrand);
 
-        const auto callback = reactorMock->extract_execute_functor();
         callback();
 
         NTCCFG_TEST_TRUE(connectResult.has_value());

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1374,387 +1374,347 @@ void variation(const test::Parameters& parameters)
 
 namespace mock {
 
-class ResolverMock : public ntci::Resolver
-{
-  public:
-    NTF_MOCK_METHOD(void, execute, const Functor&)
-    NTF_MOCK_METHOD(void, moveAndExecute, FunctorSequence*, const Functor&)
-    NTF_MOCK_METHOD_CONST(bsl::shared_ptr<ntci::Strand>&, strand)
+NTF_MOCK_CLASS(ResolverMock, ntci::Resolver)
+NTF_MOCK_METHOD(void, execute, const Functor&)
+NTF_MOCK_METHOD(void, moveAndExecute, FunctorSequence*, const Functor&)
+NTF_MOCK_METHOD_CONST(bsl::shared_ptr<ntci::Strand>&, strand)
 
-  // public:
-  //   bsl::shared_ptr<ntci::Strand>& strand() const override
-  //   {
-  //       return d_invocation_strand.invoke();
-  //   }
-  //   struct MethodInfo1358 {
-  //       const char* name;
-  //                   NTF_CAT2(MethodInfo, __LINE__)
-  //       ()
-  //       : name("strand")
-  //       {
-  //       }
-  //   };
-  //
-  // public:
-  //   ntf_mock::Invocation0<bsl::shared_ptr<ntci::Strand>&,
-  //                         NTF_CAT2(MethodInfo, __LINE__)>&
-  //   expect_strand()
-  //   {
-  //       return d_invocation_strand.expect();
-  //   }
-  //
-  // private:
-  //   mutable ntf_mock::Invocation0<bsl::shared_ptr<ntci::Strand>&, MethodInfo>
-  //       d_invocation_strand;
+NTF_MOCK_METHOD(ntsa::Error, start)
+NTF_MOCK_METHOD(void, shutdown)
+NTF_MOCK_METHOD(void, linger)
+NTF_MOCK_METHOD(ntsa::Error,
+                setIpAddress,
+                const bslstl::StringRef&,
+                const bsl::vector<ntsa::IpAddress>&)
+NTF_MOCK_METHOD(ntsa::Error,
+                addIpAddress,
+                const bslstl::StringRef&,
+                const bsl::vector<ntsa::IpAddress>&)
+NTF_MOCK_METHOD(ntsa::Error,
+                addIpAddress,
+                const bslstl::StringRef&,
+                const ntsa::IpAddress&)
 
-    NTF_MOCK_METHOD(ntsa::Error, start)
-    NTF_MOCK_METHOD(void, shutdown)
-    NTF_MOCK_METHOD(void, linger)
-    NTF_MOCK_METHOD(ntsa::Error,
-                    setIpAddress,
-                    const bslstl::StringRef&,
-                    const bsl::vector<ntsa::IpAddress>&)
-    NTF_MOCK_METHOD(ntsa::Error,
-                    addIpAddress,
-                    const bslstl::StringRef&,
-                    const bsl::vector<ntsa::IpAddress>&)
-    NTF_MOCK_METHOD(ntsa::Error,
-                    addIpAddress,
-                    const bslstl::StringRef&,
-                    const ntsa::IpAddress&)
+NTF_MOCK_METHOD(ntsa::Error,
+                setPort,
+                const bslstl::StringRef&,
+                const bsl::vector<ntsa::Port>&,
+                ntsa::Transport::Value)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    setPort,
-                    const bslstl::StringRef&,
-                    const bsl::vector<ntsa::Port>&,
-                    ntsa::Transport::Value)
+NTF_MOCK_METHOD(ntsa::Error,
+                addPort,
+                const bslstl::StringRef&,
+                const bsl::vector<ntsa::Port>&,
+                ntsa::Transport::Value)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    addPort,
-                    const bslstl::StringRef&,
-                    const bsl::vector<ntsa::Port>&,
-                    ntsa::Transport::Value)
+NTF_MOCK_METHOD(ntsa::Error,
+                addPort,
+                const bslstl::StringRef&,
+                ntsa::Port,
+                ntsa::Transport::Value)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    addPort,
-                    const bslstl::StringRef&,
-                    ntsa::Port,
-                    ntsa::Transport::Value)
+NTF_MOCK_METHOD(ntsa::Error,
+                setLocalIpAddress,
+                const bsl::vector<ntsa::IpAddress>&)
+NTF_MOCK_METHOD(ntsa::Error, setHostname, const bsl::string&)
+NTF_MOCK_METHOD(ntsa::Error, setHostnameFullyQualified, const bsl::string&)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    setLocalIpAddress,
-                    const bsl::vector<ntsa::IpAddress>&)
-    NTF_MOCK_METHOD(ntsa::Error, setHostname, const bsl::string&)
-    NTF_MOCK_METHOD(ntsa::Error, setHostnameFullyQualified, const bsl::string&)
+NTF_MOCK_METHOD(ntsa::Error,
+                getIpAddress,
+                const bslstl::StringRef&,
+                const ntca::GetIpAddressOptions&,
+                const ntci::GetIpAddressCallback&)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    getIpAddress,
-                    const bslstl::StringRef&,
-                    const ntca::GetIpAddressOptions&,
-                    const ntci::GetIpAddressCallback&)
+NTF_MOCK_METHOD(ntsa::Error,
+                getDomainName,
+                const ntsa::IpAddress&,
+                const ntca::GetDomainNameOptions&,
+                const ntci::GetDomainNameCallback&)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    getDomainName,
-                    const ntsa::IpAddress&,
-                    const ntca::GetDomainNameOptions&,
-                    const ntci::GetDomainNameCallback&)
+NTF_MOCK_METHOD(ntsa::Error,
+                getPort,
+                const bslstl::StringRef&,
+                const ntca::GetPortOptions&,
+                const ntci::GetPortCallback&)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    getPort,
-                    const bslstl::StringRef&,
-                    const ntca::GetPortOptions&,
-                    const ntci::GetPortCallback&)
+NTF_MOCK_METHOD(ntsa::Error,
+                getServiceName,
+                ntsa::Port,
+                const ntca::GetServiceNameOptions&,
+                const ntci::GetServiceNameCallback&)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    getServiceName,
-                    ntsa::Port,
-                    const ntca::GetServiceNameOptions&,
-                    const ntci::GetServiceNameCallback&)
+NTF_MOCK_METHOD(ntsa::Error,
+                getEndpoint,
+                const bslstl::StringRef&,
+                const ntca::GetEndpointOptions&,
+                const ntci::GetEndpointCallback&)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    getEndpoint,
-                    const bslstl::StringRef&,
-                    const ntca::GetEndpointOptions&,
-                    const ntci::GetEndpointCallback&)
+NTF_MOCK_METHOD(ntsa::Error,
+                getLocalIpAddress,
+                bsl::vector<ntsa::IpAddress>*,
+                const ntsa::IpAddressOptions&)
+NTF_MOCK_METHOD(ntsa::Error, getHostname, bsl::string*)
+NTF_MOCK_METHOD(ntsa::Error, getHostnameFullyQualified, bsl::string*)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Strand>, createStrand, bslma::Allocator*)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    getLocalIpAddress,
-                    bsl::vector<ntsa::IpAddress>*,
-                    const ntsa::IpAddressOptions&)
-    NTF_MOCK_METHOD(ntsa::Error, getHostname, bsl::string*)
-    NTF_MOCK_METHOD(ntsa::Error, getHostnameFullyQualified, bsl::string*)
-    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Strand>,
-                    createStrand,
-                    bslma::Allocator*)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
+                createTimer,
+                const ntca::TimerOptions&,
+                const bsl::shared_ptr<ntci::TimerSession>&,
+                bslma::Allocator*)
 
-    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
-                    createTimer,
-                    const ntca::TimerOptions&,
-                    const bsl::shared_ptr<ntci::TimerSession>&,
-                    bslma::Allocator*)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
+                createTimer,
+                const ntca::TimerOptions&,
+                const ntci::TimerCallback&,
+                bslma::Allocator*)
+NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
+NTF_MOCK_CLASS_END;
 
-    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
-                    createTimer,
-                    const ntca::TimerOptions&,
-                    const ntci::TimerCallback&,
-                    bslma::Allocator*)
-    NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
-};
 
-class BufferFactoryMock : public bdlbb::BlobBufferFactory
-{
-    NTF_MOCK_METHOD(void, allocate, bdlbb::BlobBuffer*)
-};
+NTF_MOCK_CLASS(BufferFactoryMock, bdlbb::BlobBufferFactory)
+NTF_MOCK_METHOD(void, allocate, bdlbb::BlobBuffer*)
+NTF_MOCK_CLASS_END;
 
-class StreamSocketMock : public ntsi::StreamSocket
-{
-  public:
-    NTF_MOCK_METHOD_CONST(ntsa::Handle, handle)
-    NTF_MOCK_METHOD(ntsa::Error, open, ntsa::Transport::Value)
-    NTF_MOCK_METHOD(ntsa::Error, acquire, ntsa::Handle)
-    NTF_MOCK_METHOD(ntsa::Handle, release)
+NTF_MOCK_CLASS(StreamSocketMock, ntsi::StreamSocket)
 
-    NTF_MOCK_METHOD(ntsa::Error, bind, const ntsa::Endpoint&, bool)
-    NTF_MOCK_METHOD(ntsa::Error, bindAny, ntsa::Transport::Value, bool)
-    NTF_MOCK_METHOD(ntsa::Error, connect, const ntsa::Endpoint&)
+NTF_MOCK_METHOD_CONST(ntsa::Handle, handle)
+NTF_MOCK_METHOD(ntsa::Error, open, ntsa::Transport::Value)
+NTF_MOCK_METHOD(ntsa::Error, acquire, ntsa::Handle)
+NTF_MOCK_METHOD(ntsa::Handle, release)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    send,
-                    ntsa::SendContext*,
-                    const bdlbb::Blob&,
-                    const ntsa::SendOptions&)
-    NTF_MOCK_METHOD(ntsa::Error,
-                    send,
-                    ntsa::SendContext*,
-                    const ntsa::Data&,
-                    const ntsa::SendOptions&)
+NTF_MOCK_METHOD(ntsa::Error, bind, const ntsa::Endpoint&, bool)
+NTF_MOCK_METHOD(ntsa::Error, bindAny, ntsa::Transport::Value, bool)
+NTF_MOCK_METHOD(ntsa::Error, connect, const ntsa::Endpoint&)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    receive,
-                    ntsa::ReceiveContext*,
-                    bdlbb::Blob*,
-                    const ntsa::ReceiveOptions&)
-    NTF_MOCK_METHOD(ntsa::Error,
-                    receive,
-                    ntsa::ReceiveContext*,
-                    ntsa::Data*,
-                    const ntsa::ReceiveOptions&)
+NTF_MOCK_METHOD(ntsa::Error,
+                send,
+                ntsa::SendContext*,
+                const bdlbb::Blob&,
+                const ntsa::SendOptions&)
+NTF_MOCK_METHOD(ntsa::Error,
+                send,
+                ntsa::SendContext*,
+                const ntsa::Data&,
+                const ntsa::SendOptions&)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    receiveNotifications,
-                    ntsa::NotificationQueue*)
-    NTF_MOCK_METHOD(ntsa::Error, shutdown, ntsa::ShutdownType::Value)
-    NTF_MOCK_METHOD(ntsa::Error, unlink)
-    NTF_MOCK_METHOD(ntsa::Error, close)
-    NTF_MOCK_METHOD_CONST(ntsa::Error, sourceEndpoint, ntsa::Endpoint*)
-    NTF_MOCK_METHOD_CONST(ntsa::Error, remoteEndpoint, ntsa::Endpoint*)
-    NTF_MOCK_METHOD(ntsa::Error, setBlocking, bool)
-    NTF_MOCK_METHOD(ntsa::Error, setOption, const ntsa::SocketOption&)
+NTF_MOCK_METHOD(ntsa::Error,
+                receive,
+                ntsa::ReceiveContext*,
+                bdlbb::Blob*,
+                const ntsa::ReceiveOptions&)
+NTF_MOCK_METHOD(ntsa::Error,
+                receive,
+                ntsa::ReceiveContext*,
+                ntsa::Data*,
+                const ntsa::ReceiveOptions&)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    getOption,
-                    ntsa::SocketOption*,
-                    ntsa::SocketOptionType::Value)
-    NTF_MOCK_METHOD(ntsa::Error, getLastError, ntsa::Error*)
-    NTF_MOCK_METHOD_CONST(bsl::size_t, maxBuffersPerSend)
-    NTF_MOCK_METHOD_CONST(bsl::size_t, maxBuffersPerReceive)
-};
+NTF_MOCK_METHOD(ntsa::Error, receiveNotifications, ntsa::NotificationQueue*)
+NTF_MOCK_METHOD(ntsa::Error, shutdown, ntsa::ShutdownType::Value)
+NTF_MOCK_METHOD(ntsa::Error, unlink)
+NTF_MOCK_METHOD(ntsa::Error, close)
+NTF_MOCK_METHOD_CONST(ntsa::Error, sourceEndpoint, ntsa::Endpoint*)
+NTF_MOCK_METHOD_CONST(ntsa::Error, remoteEndpoint, ntsa::Endpoint*)
+NTF_MOCK_METHOD(ntsa::Error, setBlocking, bool)
+NTF_MOCK_METHOD(ntsa::Error, setOption, const ntsa::SocketOption&)
 
-class DataPoolMock : public ntci::DataPool
-{
-  public:
-    NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createIncomingData)
-    NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createOutgoingData);
-    NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createIncomingBlob);
-    NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createOutgoingBlob);
-    NTF_MOCK_METHOD(void, createIncomingBlobBuffer, bdlbb::BlobBuffer*)
-    NTF_MOCK_METHOD(void, createOutgoingBlobBuffer, bdlbb::BlobBuffer*)
-    NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
-                          incomingBlobBufferFactory)
-    NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
-                          outgoingBlobBufferFactory)
-};
+NTF_MOCK_METHOD(ntsa::Error,
+                getOption,
+                ntsa::SocketOption*,
+                ntsa::SocketOptionType::Value)
+NTF_MOCK_METHOD(ntsa::Error, getLastError, ntsa::Error*)
+NTF_MOCK_METHOD_CONST(bsl::size_t, maxBuffersPerSend)
+NTF_MOCK_METHOD_CONST(bsl::size_t, maxBuffersPerReceive)
+NTF_MOCK_CLASS_END;
 
-class ReactorMock : public ntci::Reactor
-{
-    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::DatagramSocket>,
-                    createDatagramSocket,
-                    const ntca::DatagramSocketOptions&,
-                    bslma::Allocator*)
-    NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createIncomingData)
-    NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createOutgoingData)
-    NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createIncomingBlob)
-    NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createOutgoingBlob)
-    NTF_MOCK_METHOD(void, createIncomingBlobBuffer, bdlbb::BlobBuffer*)
-    NTF_MOCK_METHOD(void, createOutgoingBlobBuffer, bdlbb::BlobBuffer*)
+NTF_MOCK_CLASS(DataPoolMock, ntci::DataPool)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createIncomingData)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createOutgoingData);
+NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createIncomingBlob);
+NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createOutgoingBlob);
+NTF_MOCK_METHOD(void, createIncomingBlobBuffer, bdlbb::BlobBuffer*)
+NTF_MOCK_METHOD(void, createOutgoingBlobBuffer, bdlbb::BlobBuffer*)
+NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
+                      incomingBlobBufferFactory)
+NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
+                      outgoingBlobBufferFactory)
+NTF_MOCK_CLASS_END;
 
-    NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
-                          incomingBlobBufferFactory)
-    NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
-                          outgoingBlobBufferFactory)
+NTF_MOCK_CLASS(ReactorMock, ntci::Reactor)
 
-    NTF_MOCK_METHOD(ntci::Waiter, registerWaiter, const ntca::WaiterOptions&)
-    NTF_MOCK_METHOD(void, deregisterWaiter, ntci::Waiter)
-    NTF_MOCK_METHOD(void, run, ntci::Waiter)
-    NTF_MOCK_METHOD(void, poll, ntci::Waiter)
-    NTF_MOCK_METHOD(void, interruptOne)
-    NTF_MOCK_METHOD(void, interruptAll)
-    NTF_MOCK_METHOD(void, stop)
-    NTF_MOCK_METHOD(void, restart)
-    NTF_MOCK_METHOD(void, execute, const Functor&)
-    NTF_MOCK_METHOD(void, moveAndExecute, FunctorSequence*, const Functor&)
-    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::ListenerSocket>,
-                    createListenerSocket,
-                    const ntca::ListenerSocketOptions&,
-                    bslma::Allocator*)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::DatagramSocket>,
+                createDatagramSocket,
+                const ntca::DatagramSocketOptions&,
+                bslma::Allocator*)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createIncomingData)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createOutgoingData)
+NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createIncomingBlob)
+NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createOutgoingBlob)
+NTF_MOCK_METHOD(void, createIncomingBlobBuffer, bdlbb::BlobBuffer*)
+NTF_MOCK_METHOD(void, createOutgoingBlobBuffer, bdlbb::BlobBuffer*)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    attachSocket,
-                    const bsl::shared_ptr<ntci::ReactorSocket>&)
-    NTF_MOCK_METHOD(ntsa::Error, attachSocket, ntsa::Handle)
-    NTF_MOCK_METHOD(ntsa::Error,
-                    showReadable,
-                    const bsl::shared_ptr<ntci::ReactorSocket>&,
-                    const ntca::ReactorEventOptions&)
-    NTF_MOCK_METHOD(ntsa::Error,
-                    showReadable,
-                    ntsa::Handle,
-                    const ntca::ReactorEventOptions&,
-                    const ntci::ReactorEventCallback&)
+NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
+                      incomingBlobBufferFactory)
+NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
+                      outgoingBlobBufferFactory)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    showWritable,
-                    const bsl::shared_ptr<ntci::ReactorSocket>&,
-                    const ntca::ReactorEventOptions&)
-    NTF_MOCK_METHOD(ntsa::Error,
-                    showWritable,
-                    ntsa::Handle,
-                    const ntca::ReactorEventOptions&,
-                    const ntci::ReactorEventCallback&)
+NTF_MOCK_METHOD(ntci::Waiter, registerWaiter, const ntca::WaiterOptions&)
+NTF_MOCK_METHOD(void, deregisterWaiter, ntci::Waiter)
+NTF_MOCK_METHOD(void, run, ntci::Waiter)
+NTF_MOCK_METHOD(void, poll, ntci::Waiter)
+NTF_MOCK_METHOD(void, interruptOne)
+NTF_MOCK_METHOD(void, interruptAll)
+NTF_MOCK_METHOD(void, stop)
+NTF_MOCK_METHOD(void, restart)
+NTF_MOCK_METHOD(void, execute, const Functor&)
+NTF_MOCK_METHOD(void, moveAndExecute, FunctorSequence*, const Functor&)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::ListenerSocket>,
+                createListenerSocket,
+                const ntca::ListenerSocketOptions&,
+                bslma::Allocator*)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    showError,
-                    const bsl::shared_ptr<ntci::ReactorSocket>&,
-                    const ntca::ReactorEventOptions&)
-    NTF_MOCK_METHOD(ntsa::Error,
-                    showError,
-                    ntsa::Handle,
-                    const ntca::ReactorEventOptions&,
-                    const ntci::ReactorEventCallback&)
+NTF_MOCK_METHOD(ntsa::Error,
+                attachSocket,
+                const bsl::shared_ptr<ntci::ReactorSocket>&)
+NTF_MOCK_METHOD(ntsa::Error, attachSocket, ntsa::Handle)
+NTF_MOCK_METHOD(ntsa::Error,
+                showReadable,
+                const bsl::shared_ptr<ntci::ReactorSocket>&,
+                const ntca::ReactorEventOptions&)
+NTF_MOCK_METHOD(ntsa::Error,
+                showReadable,
+                ntsa::Handle,
+                const ntca::ReactorEventOptions&,
+                const ntci::ReactorEventCallback&)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    hideReadable,
-                    const bsl::shared_ptr<ntci::ReactorSocket>&)
-    NTF_MOCK_METHOD(ntsa::Error, hideReadable, ntsa::Handle)
-    NTF_MOCK_METHOD(ntsa::Error,
-                    hideWritable,
-                    const bsl::shared_ptr<ntci::ReactorSocket>&)
-    NTF_MOCK_METHOD(ntsa::Error, hideWritable, ntsa::Handle)
-    NTF_MOCK_METHOD(ntsa::Error,
-                    hideError,
-                    const bsl::shared_ptr<ntci::ReactorSocket>&)
-    NTF_MOCK_METHOD(ntsa::Error, hideError, ntsa::Handle)
-    NTF_MOCK_METHOD(ntsa::Error,
-                    detachSocket,
-                    const bsl::shared_ptr<ntci::ReactorSocket>&)
-    NTF_MOCK_METHOD(ntsa::Error, detachSocket, ntsa::Handle)
+NTF_MOCK_METHOD(ntsa::Error,
+                showWritable,
+                const bsl::shared_ptr<ntci::ReactorSocket>&,
+                const ntca::ReactorEventOptions&)
+NTF_MOCK_METHOD(ntsa::Error,
+                showWritable,
+                ntsa::Handle,
+                const ntca::ReactorEventOptions&,
+                const ntci::ReactorEventCallback&)
 
-    NTF_MOCK_METHOD(ntsa::Error,
-                    detachSocket,
-                    const bsl::shared_ptr<ntci::ReactorSocket>&,
-                    const ntci::SocketDetachedCallback&)
-    NTF_MOCK_METHOD(ntsa::Error,
-                    detachSocket,
-                    ntsa::Handle,
-                    const ntci::SocketDetachedCallback&)
+NTF_MOCK_METHOD(ntsa::Error,
+                showError,
+                const bsl::shared_ptr<ntci::ReactorSocket>&,
+                const ntca::ReactorEventOptions&)
+NTF_MOCK_METHOD(ntsa::Error,
+                showError,
+                ntsa::Handle,
+                const ntca::ReactorEventOptions&,
+                const ntci::ReactorEventCallback&)
 
-    NTF_MOCK_METHOD(ntsa::Error, closeAll)
-    NTF_MOCK_METHOD(void, incrementLoad, const ntca::LoadBalancingOptions&)
-    NTF_MOCK_METHOD(void, decrementLoad, const ntca::LoadBalancingOptions&)
+NTF_MOCK_METHOD(ntsa::Error,
+                hideReadable,
+                const bsl::shared_ptr<ntci::ReactorSocket>&)
+NTF_MOCK_METHOD(ntsa::Error, hideReadable, ntsa::Handle)
+NTF_MOCK_METHOD(ntsa::Error,
+                hideWritable,
+                const bsl::shared_ptr<ntci::ReactorSocket>&)
+NTF_MOCK_METHOD(ntsa::Error, hideWritable, ntsa::Handle)
+NTF_MOCK_METHOD(ntsa::Error,
+                hideError,
+                const bsl::shared_ptr<ntci::ReactorSocket>&)
+NTF_MOCK_METHOD(ntsa::Error, hideError, ntsa::Handle)
+NTF_MOCK_METHOD(ntsa::Error,
+                detachSocket,
+                const bsl::shared_ptr<ntci::ReactorSocket>&)
+NTF_MOCK_METHOD(ntsa::Error, detachSocket, ntsa::Handle)
 
-    NTF_MOCK_METHOD(void, drainFunctions)
-    NTF_MOCK_METHOD(void, clearFunctions)
-    NTF_MOCK_METHOD(void, clearTimers)
-    NTF_MOCK_METHOD(void, clearSockets)
-    NTF_MOCK_METHOD(void, clear)
-    NTF_MOCK_METHOD_CONST(size_t, numSockets)
-    NTF_MOCK_METHOD_CONST(size_t, maxSockets)
-    NTF_MOCK_METHOD_CONST(size_t, numTimers)
-    NTF_MOCK_METHOD_CONST(size_t, maxTimers)
-    NTF_MOCK_METHOD_CONST(bool, autoAttach)
-    NTF_MOCK_METHOD_CONST(bool, autoDetach)
-    NTF_MOCK_METHOD_CONST(bool, oneShot)
-    NTF_MOCK_METHOD_CONST(ntca::ReactorEventTrigger::Value, trigger)
-    NTF_MOCK_METHOD_CONST(size_t, load)
-    NTF_MOCK_METHOD_CONST(bslmt::ThreadUtil::Handle, threadHandle)
-    NTF_MOCK_METHOD_CONST(size_t, threadIndex)
-    NTF_MOCK_METHOD_CONST(bool, empty)
-    NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<ntci::DataPool>&, dataPool)
+NTF_MOCK_METHOD(ntsa::Error,
+                detachSocket,
+                const bsl::shared_ptr<ntci::ReactorSocket>&,
+                const ntci::SocketDetachedCallback&)
+NTF_MOCK_METHOD(ntsa::Error,
+                detachSocket,
+                ntsa::Handle,
+                const ntci::SocketDetachedCallback&)
 
-    NTF_MOCK_METHOD_CONST(bool, supportsOneShot, bool)
-    NTF_MOCK_METHOD_CONST(bool,
-                          supportsTrigger,
-                          ntca::ReactorEventTrigger::Value)
+NTF_MOCK_METHOD(ntsa::Error, closeAll)
+NTF_MOCK_METHOD(void, incrementLoad, const ntca::LoadBalancingOptions&)
+NTF_MOCK_METHOD(void, decrementLoad, const ntca::LoadBalancingOptions&)
 
-    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Reactor>,
-                    acquireReactor,
-                    const ntca::LoadBalancingOptions&)
-    NTF_MOCK_METHOD(void,
-                    releaseReactor,
-                    const bsl::shared_ptr<ntci::Reactor>&,
-                    const ntca::LoadBalancingOptions&)
-    NTF_MOCK_METHOD(bool, acquireHandleReservation)
-    NTF_MOCK_METHOD(void, releaseHandleReservation)
+NTF_MOCK_METHOD(void, drainFunctions)
+NTF_MOCK_METHOD(void, clearFunctions)
+NTF_MOCK_METHOD(void, clearTimers)
+NTF_MOCK_METHOD(void, clearSockets)
+NTF_MOCK_METHOD(void, clear)
+NTF_MOCK_METHOD_CONST(size_t, numSockets)
+NTF_MOCK_METHOD_CONST(size_t, maxSockets)
+NTF_MOCK_METHOD_CONST(size_t, numTimers)
+NTF_MOCK_METHOD_CONST(size_t, maxTimers)
+NTF_MOCK_METHOD_CONST(bool, autoAttach)
+NTF_MOCK_METHOD_CONST(bool, autoDetach)
+NTF_MOCK_METHOD_CONST(bool, oneShot)
+NTF_MOCK_METHOD_CONST(ntca::ReactorEventTrigger::Value, trigger)
+NTF_MOCK_METHOD_CONST(size_t, load)
+NTF_MOCK_METHOD_CONST(bslmt::ThreadUtil::Handle, threadHandle)
+NTF_MOCK_METHOD_CONST(size_t, threadIndex)
+NTF_MOCK_METHOD_CONST(bool, empty)
+NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<ntci::DataPool>&, dataPool)
 
-    NTF_MOCK_METHOD_CONST(size_t, numReactors)
-    NTF_MOCK_METHOD_CONST(size_t, numThreads)
-    NTF_MOCK_METHOD_CONST(size_t, minThreads)
-    NTF_MOCK_METHOD_CONST(size_t, maxThreads)
+NTF_MOCK_METHOD_CONST(bool, supportsOneShot, bool)
+NTF_MOCK_METHOD_CONST(bool, supportsTrigger, ntca::ReactorEventTrigger::Value)
 
-    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Strand>,
-                    createStrand,
-                    bslma::Allocator*)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Reactor>,
+                acquireReactor,
+                const ntca::LoadBalancingOptions&)
+NTF_MOCK_METHOD(void,
+                releaseReactor,
+                const bsl::shared_ptr<ntci::Reactor>&,
+                const ntca::LoadBalancingOptions&)
+NTF_MOCK_METHOD(bool, acquireHandleReservation)
+NTF_MOCK_METHOD(void, releaseHandleReservation)
 
-    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::StreamSocket>,
-                    createStreamSocket,
-                    const ntca::StreamSocketOptions&,
-                    bslma::Allocator*)
+NTF_MOCK_METHOD_CONST(size_t, numReactors)
+NTF_MOCK_METHOD_CONST(size_t, numThreads)
+NTF_MOCK_METHOD_CONST(size_t, minThreads)
+NTF_MOCK_METHOD_CONST(size_t, maxThreads)
 
-    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
-                    createTimer,
-                    const ntca::TimerOptions&,
-                    const bsl::shared_ptr<ntci::TimerSession>&,
-                    bslma::Allocator*)
-    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
-                    createTimer,
-                    const ntca::TimerOptions&,
-                    const ntci::TimerCallback&,
-                    bslma::Allocator*)
-    NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<ntci::Strand>&, strand)
-    NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
-};
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Strand>, createStrand, bslma::Allocator*)
 
-class TimerMock : public ntci::Timer
-{
-    NTF_MOCK_METHOD(ntsa::Error,
-                    schedule,
-                    const bsls::TimeInterval&,
-                    const bsls::TimeInterval&)
-    NTF_MOCK_METHOD(ntsa::Error, cancel)
-    NTF_MOCK_METHOD(ntsa::Error, close)
-    NTF_MOCK_METHOD(void,
-                    arrive,
-                    const bsl::shared_ptr<ntci::Timer>&,
-                    const bsls::TimeInterval&,
-                    const bsls::TimeInterval&)
-    NTF_MOCK_METHOD_CONST(void*, handle)
-    NTF_MOCK_METHOD_CONST(int, id)
-    NTF_MOCK_METHOD_CONST(bool, oneShot)
-    NTF_MOCK_METHOD_CONST(bslmt::ThreadUtil::Handle, threadHandle)
-    NTF_MOCK_METHOD_CONST(size_t, threadIndex)
-    NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<ntci::Strand>&, strand)
-    NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
-};
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::StreamSocket>,
+                createStreamSocket,
+                const ntca::StreamSocketOptions&,
+                bslma::Allocator*)
+
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
+                createTimer,
+                const ntca::TimerOptions&,
+                const bsl::shared_ptr<ntci::TimerSession>&,
+                bslma::Allocator*)
+NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
+                createTimer,
+                const ntca::TimerOptions&,
+                const ntci::TimerCallback&,
+                bslma::Allocator*)
+NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<ntci::Strand>&, strand)
+NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
+NTF_MOCK_CLASS_END;
+
+NTF_MOCK_CLASS(TimerMock, ntci::Timer)
+NTF_MOCK_METHOD(ntsa::Error,
+                schedule,
+                const bsls::TimeInterval&,
+                const bsls::TimeInterval&)
+NTF_MOCK_METHOD(ntsa::Error, cancel)
+NTF_MOCK_METHOD(ntsa::Error, close)
+NTF_MOCK_METHOD(void,
+                arrive,
+                const bsl::shared_ptr<ntci::Timer>&,
+                const bsls::TimeInterval&,
+                const bsls::TimeInterval&)
+NTF_MOCK_METHOD_CONST(void*, handle)
+NTF_MOCK_METHOD_CONST(int, id)
+NTF_MOCK_METHOD_CONST(bool, oneShot)
+NTF_MOCK_METHOD_CONST(bslmt::ThreadUtil::Handle, threadHandle)
+NTF_MOCK_METHOD_CONST(size_t, threadIndex)
+NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<ntci::Strand>&, strand)
+NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
+NTF_MOCK_CLASS_END;
 }  // close namespace mock
 
 struct Fixture {

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1592,18 +1592,8 @@ class StreamSocketMock : public ntsi::StreamSocket
 {
   public:
     NTF_MOCK_METHOD_CONST(ntsa::Handle, handle)
-
-    ntsa::Error open(ntsa::Transport::Value transport) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error acquire(ntsa::Handle handle) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-
+    NTF_MOCK_METHOD(ntsa::Error, open, ntsa::Transport::Value)
+    NTF_MOCK_METHOD(ntsa::Error, acquire, ntsa::Handle)
     NTF_MOCK_METHOD(ntsa::Handle, release);
 
   public:
@@ -5646,7 +5636,7 @@ NTCCFG_TEST_CASE(22)
             ntsa::Error::invalid());
         //TODO: is that ok to detach socket that has not been attached?
 
-//        socketMock->expect_close().willOnce().willReturn(ntsa::Error());
+        socketMock->expect_close().willOnce().willReturn(ntsa::Error());
 
         socket->shutdown(ntsa::ShutdownType::e_BOTH,
                          ntsa::ShutdownMode::e_GRACEFUL);
@@ -5819,7 +5809,7 @@ NTCCFG_TEST_CASE(23)
             bdlb::NullOptType::makeInitialValue(),
             ntsa::Error());
 
-//        socketMock->expect_close().willOnce().willReturn(ntsa::Error());
+        socketMock->expect_close().willOnce().willReturn(ntsa::Error());
 
         socket->shutdown(ntsa::ShutdownType::e_BOTH,
                          ntsa::ShutdownMode::e_GRACEFUL);

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 Bloomberg Finance L.P.
+// Copyright 2020-2024 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -1380,108 +1380,106 @@ namespace mock {
 class ResolverMock : public ntci::Resolver
 {
   public:
-    NTF_MOCK_METHOD_NEW(void, execute, const Functor&)
-    NTF_MOCK_METHOD_NEW(void, moveAndExecute, FunctorSequence*, const Functor&)
+    NTF_MOCK_METHOD(void, execute, const Functor&)
+    NTF_MOCK_METHOD(void, moveAndExecute, FunctorSequence*, const Functor&)
   public:
     const bsl::shared_ptr<ntci::Strand>& strand() const override
     {
         UNEXPECTED_CALL();
         return dummyStrand;
     }
-    NTF_MOCK_METHOD_NEW(ntsa::Error, start)
-    NTF_MOCK_METHOD_NEW(void, shutdown)
-    NTF_MOCK_METHOD_NEW(void, linger)
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        setIpAddress,
-                        const bslstl::StringRef&,
-                        const bsl::vector<ntsa::IpAddress>&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        addIpAddress,
-                        const bslstl::StringRef&,
-                        const bsl::vector<ntsa::IpAddress>&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        addIpAddress,
-                        const bslstl::StringRef&,
-                        const ntsa::IpAddress&)
+    NTF_MOCK_METHOD(ntsa::Error, start)
+    NTF_MOCK_METHOD(void, shutdown)
+    NTF_MOCK_METHOD(void, linger)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    setIpAddress,
+                    const bslstl::StringRef&,
+                    const bsl::vector<ntsa::IpAddress>&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    addIpAddress,
+                    const bslstl::StringRef&,
+                    const bsl::vector<ntsa::IpAddress>&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    addIpAddress,
+                    const bslstl::StringRef&,
+                    const ntsa::IpAddress&)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        setPort,
-                        const bslstl::StringRef&,
-                        const bsl::vector<ntsa::Port>&,
-                        ntsa::Transport::Value)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    setPort,
+                    const bslstl::StringRef&,
+                    const bsl::vector<ntsa::Port>&,
+                    ntsa::Transport::Value)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        addPort,
-                        const bslstl::StringRef&,
-                        const bsl::vector<ntsa::Port>&,
-                        ntsa::Transport::Value)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    addPort,
+                    const bslstl::StringRef&,
+                    const bsl::vector<ntsa::Port>&,
+                    ntsa::Transport::Value)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        addPort,
-                        const bslstl::StringRef&,
-                        ntsa::Port,
-                        ntsa::Transport::Value)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    addPort,
+                    const bslstl::StringRef&,
+                    ntsa::Port,
+                    ntsa::Transport::Value)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        setLocalIpAddress,
-                        const bsl::vector<ntsa::IpAddress>&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, setHostname, const bsl::string&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        setHostnameFullyQualified,
-                        const bsl::string&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    setLocalIpAddress,
+                    const bsl::vector<ntsa::IpAddress>&)
+    NTF_MOCK_METHOD(ntsa::Error, setHostname, const bsl::string&)
+    NTF_MOCK_METHOD(ntsa::Error, setHostnameFullyQualified, const bsl::string&)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        getIpAddress,
-                        const bslstl::StringRef&,
-                        const ntca::GetIpAddressOptions&,
-                        const ntci::GetIpAddressCallback&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    getIpAddress,
+                    const bslstl::StringRef&,
+                    const ntca::GetIpAddressOptions&,
+                    const ntci::GetIpAddressCallback&)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        getDomainName,
-                        const ntsa::IpAddress&,
-                        const ntca::GetDomainNameOptions&,
-                        const ntci::GetDomainNameCallback&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    getDomainName,
+                    const ntsa::IpAddress&,
+                    const ntca::GetDomainNameOptions&,
+                    const ntci::GetDomainNameCallback&)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        getPort,
-                        const bslstl::StringRef&,
-                        const ntca::GetPortOptions&,
-                        const ntci::GetPortCallback&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    getPort,
+                    const bslstl::StringRef&,
+                    const ntca::GetPortOptions&,
+                    const ntci::GetPortCallback&)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        getServiceName,
-                        ntsa::Port,
-                        const ntca::GetServiceNameOptions&,
-                        const ntci::GetServiceNameCallback&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    getServiceName,
+                    ntsa::Port,
+                    const ntca::GetServiceNameOptions&,
+                    const ntci::GetServiceNameCallback&)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        getEndpoint,
-                        const bslstl::StringRef&,
-                        const ntca::GetEndpointOptions&,
-                        const ntci::GetEndpointCallback&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    getEndpoint,
+                    const bslstl::StringRef&,
+                    const ntca::GetEndpointOptions&,
+                    const ntci::GetEndpointCallback&)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        getLocalIpAddress,
-                        bsl::vector<ntsa::IpAddress>*,
-                        const ntsa::IpAddressOptions&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, getHostname, bsl::string*)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, getHostnameFullyQualified, bsl::string*)
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Strand>,
-                        createStrand,
-                        bslma::Allocator*)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    getLocalIpAddress,
+                    bsl::vector<ntsa::IpAddress>*,
+                    const ntsa::IpAddressOptions&)
+    NTF_MOCK_METHOD(ntsa::Error, getHostname, bsl::string*)
+    NTF_MOCK_METHOD(ntsa::Error, getHostnameFullyQualified, bsl::string*)
+    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Strand>,
+                    createStrand,
+                    bslma::Allocator*)
 
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Timer>,
-                        createTimer,
-                        const ntca::TimerOptions&,
-                        const bsl::shared_ptr<ntci::TimerSession>&,
-                        bslma::Allocator*)
+    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
+                    createTimer,
+                    const ntca::TimerOptions&,
+                    const bsl::shared_ptr<ntci::TimerSession>&,
+                    bslma::Allocator*)
 
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Timer>,
-                        createTimer,
-                        const ntca::TimerOptions&,
-                        const ntci::TimerCallback&,
-                        bslma::Allocator*)
-    NTF_MOCK_METHOD_CONST_NEW(bsls::TimeInterval, currentTime)
+    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
+                    createTimer,
+                    const ntca::TimerOptions&,
+                    const ntci::TimerCallback&,
+                    bslma::Allocator*)
+    NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
 
   private:
     bsl::shared_ptr<ntci::Strand> dummyStrand;
@@ -1489,7 +1487,7 @@ class ResolverMock : public ntci::Resolver
 
 class BufferFactoryMock : public bdlbb::BlobBufferFactory
 {
-    NTF_MOCK_METHOD_NEW(void, allocate, bdlbb::BlobBuffer*)
+    NTF_MOCK_METHOD(void, allocate, bdlbb::BlobBuffer*)
 };
 #endif
 
@@ -1515,13 +1513,13 @@ struct My {
 };
 
 struct MyMock : public My {
-    NTF_MOCK_METHOD_NEW_0(void, f)
-    NTF_MOCK_METHOD_NEW_0(int, f2)
-    NTF_MOCK_METHOD_NEW_1(void, f3, int)
-    NTF_MOCK_METHOD_NEW_1(void, f4, int*)
-    NTF_MOCK_METHOD_NEW_1(void, f5, const int*)
-    NTF_MOCK_METHOD_NEW_1(void, f6, int&)
-    NTF_MOCK_METHOD_NEW_1(void, f7, const int&)
+    NTF_MOCK_METHOD_0(void, f)
+    NTF_MOCK_METHOD_0(int, f2)
+    NTF_MOCK_METHOD_1(void, f3, int)
+    NTF_MOCK_METHOD_1(void, f4, int*)
+    NTF_MOCK_METHOD_1(void, f5, const int*)
+    NTF_MOCK_METHOD_1(void, f6, int&)
+    NTF_MOCK_METHOD_1(void, f7, const int&)
 };
 
 void wegweg()
@@ -1618,66 +1616,66 @@ void wegweg()
 class StreamSocketMock : public ntsi::StreamSocket
 {
   public:
-    NTF_MOCK_METHOD_CONST_NEW(ntsa::Handle, handle)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, open, ntsa::Transport::Value)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, acquire, ntsa::Handle)
-    NTF_MOCK_METHOD_NEW(ntsa::Handle, release)
+    NTF_MOCK_METHOD_CONST(ntsa::Handle, handle)
+    NTF_MOCK_METHOD(ntsa::Error, open, ntsa::Transport::Value)
+    NTF_MOCK_METHOD(ntsa::Error, acquire, ntsa::Handle)
+    NTF_MOCK_METHOD(ntsa::Handle, release)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error, bind, const ntsa::Endpoint&, bool)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, bindAny, ntsa::Transport::Value, bool)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, connect, const ntsa::Endpoint&)
+    NTF_MOCK_METHOD(ntsa::Error, bind, const ntsa::Endpoint&, bool)
+    NTF_MOCK_METHOD(ntsa::Error, bindAny, ntsa::Transport::Value, bool)
+    NTF_MOCK_METHOD(ntsa::Error, connect, const ntsa::Endpoint&)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        send,
-                        ntsa::SendContext*,
-                        const bdlbb::Blob&,
-                        const ntsa::SendOptions&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        send,
-                        ntsa::SendContext*,
-                        const ntsa::Data&,
-                        const ntsa::SendOptions&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    send,
+                    ntsa::SendContext*,
+                    const bdlbb::Blob&,
+                    const ntsa::SendOptions&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    send,
+                    ntsa::SendContext*,
+                    const ntsa::Data&,
+                    const ntsa::SendOptions&)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        receive,
-                        ntsa::ReceiveContext*,
-                        bdlbb::Blob*,
-                        const ntsa::ReceiveOptions&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        receive,
-                        ntsa::ReceiveContext*,
-                        ntsa::Data*,
-                        const ntsa::ReceiveOptions&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    receive,
+                    ntsa::ReceiveContext*,
+                    bdlbb::Blob*,
+                    const ntsa::ReceiveOptions&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    receive,
+                    ntsa::ReceiveContext*,
+                    ntsa::Data*,
+                    const ntsa::ReceiveOptions&)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        receiveNotifications,
-                        ntsa::NotificationQueue*)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, shutdown, ntsa::ShutdownType::Value)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, unlink)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, close)
-    NTF_MOCK_METHOD_CONST_NEW(ntsa::Error, sourceEndpoint, ntsa::Endpoint*)
-    NTF_MOCK_METHOD_CONST_NEW(ntsa::Error, remoteEndpoint, ntsa::Endpoint*)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, setBlocking, bool)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, setOption, const ntsa::SocketOption&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    receiveNotifications,
+                    ntsa::NotificationQueue*)
+    NTF_MOCK_METHOD(ntsa::Error, shutdown, ntsa::ShutdownType::Value)
+    NTF_MOCK_METHOD(ntsa::Error, unlink)
+    NTF_MOCK_METHOD(ntsa::Error, close)
+    NTF_MOCK_METHOD_CONST(ntsa::Error, sourceEndpoint, ntsa::Endpoint*)
+    NTF_MOCK_METHOD_CONST(ntsa::Error, remoteEndpoint, ntsa::Endpoint*)
+    NTF_MOCK_METHOD(ntsa::Error, setBlocking, bool)
+    NTF_MOCK_METHOD(ntsa::Error, setOption, const ntsa::SocketOption&)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        getOption,
-                        ntsa::SocketOption*,
-                        ntsa::SocketOptionType::Value)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, getLastError, ntsa::Error*)
-    NTF_MOCK_METHOD_CONST_NEW(bsl::size_t, maxBuffersPerSend)
-    NTF_MOCK_METHOD_CONST_NEW(bsl::size_t, maxBuffersPerReceive)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    getOption,
+                    ntsa::SocketOption*,
+                    ntsa::SocketOptionType::Value)
+    NTF_MOCK_METHOD(ntsa::Error, getLastError, ntsa::Error*)
+    NTF_MOCK_METHOD_CONST(bsl::size_t, maxBuffersPerSend)
+    NTF_MOCK_METHOD_CONST(bsl::size_t, maxBuffersPerReceive)
 };
 
 class DataPoolMock : public ntci::DataPool
 {
   public:
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntsa::Data>, createIncomingData)
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntsa::Data>, createOutgoingData);
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<bdlbb::Blob>, createIncomingBlob);
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<bdlbb::Blob>, createOutgoingBlob);
-    NTF_MOCK_METHOD_NEW(void, createIncomingBlobBuffer, bdlbb::BlobBuffer*)
-    NTF_MOCK_METHOD_NEW(void, createOutgoingBlobBuffer, bdlbb::BlobBuffer*)
+    NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createIncomingData)
+    NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createOutgoingData);
+    NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createIncomingBlob);
+    NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createOutgoingBlob);
+    NTF_MOCK_METHOD(void, createIncomingBlobBuffer, bdlbb::BlobBuffer*)
+    NTF_MOCK_METHOD(void, createOutgoingBlobBuffer, bdlbb::BlobBuffer*)
 
   public:
     const bsl::shared_ptr<bdlbb::BlobBufferFactory>& incomingBlobBufferFactory()
@@ -1700,16 +1698,16 @@ class DataPoolMock : public ntci::DataPool
 class ReactorMock : public ntci::Reactor
 {
   public:
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::DatagramSocket>,
-                        createDatagramSocket,
-                        const ntca::DatagramSocketOptions&,
-                        bslma::Allocator*)
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntsa::Data>, createIncomingData)
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntsa::Data>, createOutgoingData)
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<bdlbb::Blob>, createIncomingBlob)
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<bdlbb::Blob>, createOutgoingBlob)
-    NTF_MOCK_METHOD_NEW(void, createIncomingBlobBuffer, bdlbb::BlobBuffer*)
-    NTF_MOCK_METHOD_NEW(void, createOutgoingBlobBuffer, bdlbb::BlobBuffer*)
+    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::DatagramSocket>,
+                    createDatagramSocket,
+                    const ntca::DatagramSocketOptions&,
+                    bslma::Allocator*)
+    NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createIncomingData)
+    NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createOutgoingData)
+    NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createIncomingBlob)
+    NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createOutgoingBlob)
+    NTF_MOCK_METHOD(void, createIncomingBlobBuffer, bdlbb::BlobBuffer*)
+    NTF_MOCK_METHOD(void, createOutgoingBlobBuffer, bdlbb::BlobBuffer*)
 
   public:
     const bsl::shared_ptr<bdlbb::BlobBufferFactory>& incomingBlobBufferFactory()
@@ -1729,104 +1727,102 @@ class ReactorMock : public ntci::Reactor
         return d_outgoingBlobBufferFactory_result.value();
     }
 
-    NTF_MOCK_METHOD_NEW(ntci::Waiter,
-                        registerWaiter,
-                        const ntca::WaiterOptions&)
-    NTF_MOCK_METHOD_NEW(void, deregisterWaiter, ntci::Waiter)
-    NTF_MOCK_METHOD_NEW(void, run, ntci::Waiter)
-    NTF_MOCK_METHOD_NEW(void, poll, ntci::Waiter)
-    NTF_MOCK_METHOD_NEW(void, interruptOne)
-    NTF_MOCK_METHOD_NEW(void, interruptAll)
-    NTF_MOCK_METHOD_NEW(void, stop)
-    NTF_MOCK_METHOD_NEW(void, restart)
-    NTF_MOCK_METHOD_NEW(void, execute, const Functor&)
-    NTF_MOCK_METHOD_NEW(void, moveAndExecute, FunctorSequence*, const Functor&)
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::ListenerSocket>,
-                        createListenerSocket,
-                        const ntca::ListenerSocketOptions&,
-                        bslma::Allocator*)
+    NTF_MOCK_METHOD(ntci::Waiter, registerWaiter, const ntca::WaiterOptions&)
+    NTF_MOCK_METHOD(void, deregisterWaiter, ntci::Waiter)
+    NTF_MOCK_METHOD(void, run, ntci::Waiter)
+    NTF_MOCK_METHOD(void, poll, ntci::Waiter)
+    NTF_MOCK_METHOD(void, interruptOne)
+    NTF_MOCK_METHOD(void, interruptAll)
+    NTF_MOCK_METHOD(void, stop)
+    NTF_MOCK_METHOD(void, restart)
+    NTF_MOCK_METHOD(void, execute, const Functor&)
+    NTF_MOCK_METHOD(void, moveAndExecute, FunctorSequence*, const Functor&)
+    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::ListenerSocket>,
+                    createListenerSocket,
+                    const ntca::ListenerSocketOptions&,
+                    bslma::Allocator*)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        attachSocket,
-                        const bsl::shared_ptr<ntci::ReactorSocket>&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, attachSocket, ntsa::Handle)
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        showReadable,
-                        const bsl::shared_ptr<ntci::ReactorSocket>&,
-                        const ntca::ReactorEventOptions&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        showReadable,
-                        ntsa::Handle,
-                        const ntca::ReactorEventOptions&,
-                        const ntci::ReactorEventCallback&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    attachSocket,
+                    const bsl::shared_ptr<ntci::ReactorSocket>&)
+    NTF_MOCK_METHOD(ntsa::Error, attachSocket, ntsa::Handle)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    showReadable,
+                    const bsl::shared_ptr<ntci::ReactorSocket>&,
+                    const ntca::ReactorEventOptions&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    showReadable,
+                    ntsa::Handle,
+                    const ntca::ReactorEventOptions&,
+                    const ntci::ReactorEventCallback&)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        showWritable,
-                        const bsl::shared_ptr<ntci::ReactorSocket>&,
-                        const ntca::ReactorEventOptions&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        showWritable,
-                        ntsa::Handle,
-                        const ntca::ReactorEventOptions&,
-                        const ntci::ReactorEventCallback&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    showWritable,
+                    const bsl::shared_ptr<ntci::ReactorSocket>&,
+                    const ntca::ReactorEventOptions&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    showWritable,
+                    ntsa::Handle,
+                    const ntca::ReactorEventOptions&,
+                    const ntci::ReactorEventCallback&)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        showError,
-                        const bsl::shared_ptr<ntci::ReactorSocket>&,
-                        const ntca::ReactorEventOptions&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        showError,
-                        ntsa::Handle,
-                        const ntca::ReactorEventOptions&,
-                        const ntci::ReactorEventCallback&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    showError,
+                    const bsl::shared_ptr<ntci::ReactorSocket>&,
+                    const ntca::ReactorEventOptions&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    showError,
+                    ntsa::Handle,
+                    const ntca::ReactorEventOptions&,
+                    const ntci::ReactorEventCallback&)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        hideReadable,
-                        const bsl::shared_ptr<ntci::ReactorSocket>&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, hideReadable, ntsa::Handle)
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        hideWritable,
-                        const bsl::shared_ptr<ntci::ReactorSocket>&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, hideWritable, ntsa::Handle)
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        hideError,
-                        const bsl::shared_ptr<ntci::ReactorSocket>&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, hideError, ntsa::Handle)
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        detachSocket,
-                        const bsl::shared_ptr<ntci::ReactorSocket>&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, detachSocket, ntsa::Handle)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    hideReadable,
+                    const bsl::shared_ptr<ntci::ReactorSocket>&)
+    NTF_MOCK_METHOD(ntsa::Error, hideReadable, ntsa::Handle)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    hideWritable,
+                    const bsl::shared_ptr<ntci::ReactorSocket>&)
+    NTF_MOCK_METHOD(ntsa::Error, hideWritable, ntsa::Handle)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    hideError,
+                    const bsl::shared_ptr<ntci::ReactorSocket>&)
+    NTF_MOCK_METHOD(ntsa::Error, hideError, ntsa::Handle)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    detachSocket,
+                    const bsl::shared_ptr<ntci::ReactorSocket>&)
+    NTF_MOCK_METHOD(ntsa::Error, detachSocket, ntsa::Handle)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        detachSocket,
-                        const bsl::shared_ptr<ntci::ReactorSocket>&,
-                        const ntci::SocketDetachedCallback&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        detachSocket,
-                        ntsa::Handle,
-                        const ntci::SocketDetachedCallback&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    detachSocket,
+                    const bsl::shared_ptr<ntci::ReactorSocket>&,
+                    const ntci::SocketDetachedCallback&)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    detachSocket,
+                    ntsa::Handle,
+                    const ntci::SocketDetachedCallback&)
 
-    NTF_MOCK_METHOD_NEW(ntsa::Error, closeAll)
-    NTF_MOCK_METHOD_NEW(void, incrementLoad, const ntca::LoadBalancingOptions&)
-    NTF_MOCK_METHOD_NEW(void, decrementLoad, const ntca::LoadBalancingOptions&)
+    NTF_MOCK_METHOD(ntsa::Error, closeAll)
+    NTF_MOCK_METHOD(void, incrementLoad, const ntca::LoadBalancingOptions&)
+    NTF_MOCK_METHOD(void, decrementLoad, const ntca::LoadBalancingOptions&)
 
-    NTF_MOCK_METHOD_NEW(void, drainFunctions)
-    NTF_MOCK_METHOD_NEW(void, clearFunctions)
-    NTF_MOCK_METHOD_NEW(void, clearTimers)
-    NTF_MOCK_METHOD_NEW(void, clearSockets)
-    NTF_MOCK_METHOD_NEW(void, clear)
-    NTF_MOCK_METHOD_CONST_NEW(size_t, numSockets)
-    NTF_MOCK_METHOD_CONST_NEW(size_t, maxSockets)
-    NTF_MOCK_METHOD_CONST_NEW(size_t, numTimers)
-    NTF_MOCK_METHOD_CONST_NEW(size_t, maxTimers)
-    NTF_MOCK_METHOD_CONST_NEW(bool, autoAttach)
-    NTF_MOCK_METHOD_CONST_NEW(bool, autoDetach)
-    NTF_MOCK_METHOD_CONST_NEW(bool, oneShot)
-    NTF_MOCK_METHOD_CONST_NEW(ntca::ReactorEventTrigger::Value, trigger)
-    NTF_MOCK_METHOD_CONST_NEW(size_t, load)
-    NTF_MOCK_METHOD_CONST_NEW(bslmt::ThreadUtil::Handle, threadHandle)
-    NTF_MOCK_METHOD_CONST_NEW(size_t, threadIndex)
-    NTF_MOCK_METHOD_CONST_NEW(bool, empty)
+    NTF_MOCK_METHOD(void, drainFunctions)
+    NTF_MOCK_METHOD(void, clearFunctions)
+    NTF_MOCK_METHOD(void, clearTimers)
+    NTF_MOCK_METHOD(void, clearSockets)
+    NTF_MOCK_METHOD(void, clear)
+    NTF_MOCK_METHOD_CONST(size_t, numSockets)
+    NTF_MOCK_METHOD_CONST(size_t, maxSockets)
+    NTF_MOCK_METHOD_CONST(size_t, numTimers)
+    NTF_MOCK_METHOD_CONST(size_t, maxTimers)
+    NTF_MOCK_METHOD_CONST(bool, autoAttach)
+    NTF_MOCK_METHOD_CONST(bool, autoDetach)
+    NTF_MOCK_METHOD_CONST(bool, oneShot)
+    NTF_MOCK_METHOD_CONST(ntca::ReactorEventTrigger::Value, trigger)
+    NTF_MOCK_METHOD_CONST(size_t, load)
+    NTF_MOCK_METHOD_CONST(bslmt::ThreadUtil::Handle, threadHandle)
+    NTF_MOCK_METHOD_CONST(size_t, threadIndex)
+    NTF_MOCK_METHOD_CONST(bool, empty)
 
   public:
     const bsl::shared_ptr<ntci::DataPool>& dataPool() const override
@@ -1837,52 +1833,52 @@ class ReactorMock : public ntci::Reactor
         return d_dataPool_result.value();
     }
 
-    NTF_MOCK_METHOD_CONST_NEW(bool, supportsOneShot, bool)
-    NTF_MOCK_METHOD_CONST_NEW(bool,
-                              supportsTrigger,
-                              ntca::ReactorEventTrigger::Value)
+    NTF_MOCK_METHOD_CONST(bool, supportsOneShot, bool)
+    NTF_MOCK_METHOD_CONST(bool,
+                          supportsTrigger,
+                          ntca::ReactorEventTrigger::Value)
 
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Reactor>,
-                        acquireReactor,
-                        const ntca::LoadBalancingOptions&)
-    NTF_MOCK_METHOD_NEW(void,
-                        releaseReactor,
-                        const bsl::shared_ptr<ntci::Reactor>&,
-                        const ntca::LoadBalancingOptions&)
-    NTF_MOCK_METHOD_NEW(bool, acquireHandleReservation)
-    NTF_MOCK_METHOD_NEW(void, releaseHandleReservation)
+    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Reactor>,
+                    acquireReactor,
+                    const ntca::LoadBalancingOptions&)
+    NTF_MOCK_METHOD(void,
+                    releaseReactor,
+                    const bsl::shared_ptr<ntci::Reactor>&,
+                    const ntca::LoadBalancingOptions&)
+    NTF_MOCK_METHOD(bool, acquireHandleReservation)
+    NTF_MOCK_METHOD(void, releaseHandleReservation)
 
-    NTF_MOCK_METHOD_CONST_NEW(size_t, numReactors)
-    NTF_MOCK_METHOD_CONST_NEW(size_t, numThreads)
-    NTF_MOCK_METHOD_CONST_NEW(size_t, minThreads)
-    NTF_MOCK_METHOD_CONST_NEW(size_t, maxThreads)
+    NTF_MOCK_METHOD_CONST(size_t, numReactors)
+    NTF_MOCK_METHOD_CONST(size_t, numThreads)
+    NTF_MOCK_METHOD_CONST(size_t, minThreads)
+    NTF_MOCK_METHOD_CONST(size_t, maxThreads)
 
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Strand>,
-                        createStrand,
-                        bslma::Allocator*)
+    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Strand>,
+                    createStrand,
+                    bslma::Allocator*)
 
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::StreamSocket>,
-                        createStreamSocket,
-                        const ntca::StreamSocketOptions&,
-                        bslma::Allocator*)
+    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::StreamSocket>,
+                    createStreamSocket,
+                    const ntca::StreamSocketOptions&,
+                    bslma::Allocator*)
 
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Timer>,
-                        createTimer,
-                        const ntca::TimerOptions&,
-                        const bsl::shared_ptr<ntci::TimerSession>&,
-                        bslma::Allocator*)
-    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Timer>,
-                        createTimer,
-                        const ntca::TimerOptions&,
-                        const ntci::TimerCallback&,
-                        bslma::Allocator*)
+    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
+                    createTimer,
+                    const ntca::TimerOptions&,
+                    const bsl::shared_ptr<ntci::TimerSession>&,
+                    bslma::Allocator*)
+    NTF_MOCK_METHOD(bsl::shared_ptr<ntci::Timer>,
+                    createTimer,
+                    const ntca::TimerOptions&,
+                    const ntci::TimerCallback&,
+                    bslma::Allocator*)
   public:
     const bsl::shared_ptr<ntci::Strand>& strand() const override
     {
         UNEXPECTED_CALL();
         return dummyStrand;
     }
-    NTF_MOCK_METHOD_CONST_NEW(bsls::TimeInterval, currentTime)
+    NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
 
   public:
     // auxiliary methods
@@ -1915,22 +1911,22 @@ class ReactorMock : public ntci::Reactor
 
 class TimerMock : public ntci::Timer
 {
-    NTF_MOCK_METHOD_NEW(ntsa::Error,
-                        schedule,
-                        const bsls::TimeInterval&,
-                        const bsls::TimeInterval&)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, cancel)
-    NTF_MOCK_METHOD_NEW(ntsa::Error, close)
-    NTF_MOCK_METHOD_NEW(void,
-                        arrive,
-                        const bsl::shared_ptr<ntci::Timer>&,
-                        const bsls::TimeInterval&,
-                        const bsls::TimeInterval&)
-    NTF_MOCK_METHOD_CONST_NEW(void*, handle)
-    NTF_MOCK_METHOD_CONST_NEW(int, id)
-    NTF_MOCK_METHOD_CONST_NEW(bool, oneShot)
-    NTF_MOCK_METHOD_CONST_NEW(bslmt::ThreadUtil::Handle, threadHandle)
-    NTF_MOCK_METHOD_CONST_NEW(size_t, threadIndex)
+    NTF_MOCK_METHOD(ntsa::Error,
+                    schedule,
+                    const bsls::TimeInterval&,
+                    const bsls::TimeInterval&)
+    NTF_MOCK_METHOD(ntsa::Error, cancel)
+    NTF_MOCK_METHOD(ntsa::Error, close)
+    NTF_MOCK_METHOD(void,
+                    arrive,
+                    const bsl::shared_ptr<ntci::Timer>&,
+                    const bsls::TimeInterval&,
+                    const bsls::TimeInterval&)
+    NTF_MOCK_METHOD_CONST(void*, handle)
+    NTF_MOCK_METHOD_CONST(int, id)
+    NTF_MOCK_METHOD_CONST(bool, oneShot)
+    NTF_MOCK_METHOD_CONST(bslmt::ThreadUtil::Handle, threadHandle)
+    NTF_MOCK_METHOD_CONST(size_t, threadIndex)
 
   public:
     const bsl::shared_ptr<ntci::Strand>& strand() const override
@@ -1938,7 +1934,7 @@ class TimerMock : public ntci::Timer
         UNEXPECTED_CALL();
         return dummyStrand;
     }
-    NTF_MOCK_METHOD_CONST_NEW(bsls::TimeInterval, currentTime)
+    NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
 
   private:
     bsl::shared_ptr<ntci::Strand> dummyStrand;
@@ -4298,7 +4294,9 @@ NTCCFG_TEST_CASE(23)
         NTCI_LOG_DEBUG(
             "Shutdown socket while it is waiting for connection result");
 
-        NTF_EXPECT_0(*connectRetryTimerMock, close).ONCE().RETURN(ntsa::Error());
+        NTF_EXPECT_0(*connectRetryTimerMock, close)
+            .ONCE()
+            .RETURN(ntsa::Error());
 
         ntci::SocketDetachedCallback detachCallback;
 

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1376,6 +1376,7 @@ namespace mock {
 
 #define UNEXPECTED_CALL(unused) NTCCFG_TEST_TRUE(false && "unexpected call")
 #if 1
+
 class ResolverMock : public ntci::Resolver
 {
   public:
@@ -1488,7 +1489,7 @@ class ResolverMock : public ntci::Resolver
 
 class BufferFactoryMock : public bdlbb::BlobBufferFactory
 {
-    NTF_MOCK_METHOD(void, allocate, bdlbb::BlobBuffer*)
+    NTF_MOCK_METHOD_NEW(void, allocate, bdlbb::BlobBuffer*)
 };
 #endif
 
@@ -1500,53 +1501,6 @@ struct MyClass {
     virtual void doSmth5(const int*){};
     virtual void doSmth6(const int&){};
 };
-
-class MyClassMock : public MyClass
-{
-  public:
-    NTF_MOCK_METHOD(void, doSmth, int);
-    NTF_MOCK_METHOD(void, doSmth2, int*);
-    NTF_MOCK_METHOD(void, doSmth3, int&);
-    NTF_MOCK_METHOD(void, doSmth4, const int);
-    NTF_MOCK_METHOD(void, doSmth5, const int*);
-    NTF_MOCK_METHOD(void, doSmth6, const int&);
-};
-
-void func()
-{
-    int  k   = 5;
-    int* k_p = &k;
-
-    int  tmp1   = 0;
-    int* tmp1_p = &tmp1;
-
-    int& k_r = k;
-
-    const int* k_cp = &k;
-
-    MyClassMock m;
-
-    {
-        m.expect_doSmth(5).willOnce().saveArg1(&tmp1);
-    }
-
-    {
-        m.expect_doSmth2(k_p).willOnce().setArg1To(6).saveArg1(&tmp1_p);
-    }
-
-    {
-        m.expect_doSmth3(k_r).willOnce().setArg1To(6).saveArg1(tmp1_p);
-    }
-
-    {
-        m.expect_doSmth4(55).willOnce().saveArg1(&tmp1);
-    }
-
-    {
-        // m.expect_doSmth5(k_p).willOnce().saveArg1(&k_cp);
-        // m.expect_doSmth5(k_cp).willOnce();
-    }
-}
 
 namespace {
 
@@ -1672,35 +1626,28 @@ class StreamSocketMock : public ntsi::StreamSocket
     NTF_MOCK_METHOD_NEW(ntsa::Error, bind, const ntsa::Endpoint&, bool)
     NTF_MOCK_METHOD_NEW(ntsa::Error, bindAny, ntsa::Transport::Value, bool)
     NTF_MOCK_METHOD_NEW(ntsa::Error, connect, const ntsa::Endpoint&)
-  public:
-    ntsa::Error send(ntsa::SendContext*       context,
-                     const bdlbb::Blob&       data,
-                     const ntsa::SendOptions& options) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error send(ntsa::SendContext*       context,
-                     const ntsa::Data&        data,
-                     const ntsa::SendOptions& options) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error receive(ntsa::ReceiveContext*       context,
-                        bdlbb::Blob*                data,
-                        const ntsa::ReceiveOptions& options) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error receive(ntsa::ReceiveContext*       context,
-                        ntsa::Data*                 data,
-                        const ntsa::ReceiveOptions& options) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
+
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        send,
+                        ntsa::SendContext*,
+                        const bdlbb::Blob&,
+                        const ntsa::SendOptions&)
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        send,
+                        ntsa::SendContext*,
+                        const ntsa::Data&,
+                        const ntsa::SendOptions&)
+
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        receive,
+                        ntsa::ReceiveContext*,
+                        bdlbb::Blob*,
+                        const ntsa::ReceiveOptions&)
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        receive,
+                        ntsa::ReceiveContext*,
+                        ntsa::Data*,
+                        const ntsa::ReceiveOptions&)
 
     NTF_MOCK_METHOD_NEW(ntsa::Error,
                         receiveNotifications,
@@ -1807,44 +1754,32 @@ class ReactorMock : public ntci::Reactor
                         showReadable,
                         const bsl::shared_ptr<ntci::ReactorSocket>&,
                         const ntca::ReactorEventOptions&)
-
-  public:
-    ntsa::Error showReadable(
-        ntsa::Handle                      handle,
-        const ntca::ReactorEventOptions&  options,
-        const ntci::ReactorEventCallback& callback) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        showReadable,
+                        ntsa::Handle,
+                        const ntca::ReactorEventOptions&,
+                        const ntci::ReactorEventCallback&)
 
     NTF_MOCK_METHOD_NEW(ntsa::Error,
                         showWritable,
                         const bsl::shared_ptr<ntci::ReactorSocket>&,
                         const ntca::ReactorEventOptions&)
-
-  public:
-    ntsa::Error showWritable(
-        ntsa::Handle                      handle,
-        const ntca::ReactorEventOptions&  options,
-        const ntci::ReactorEventCallback& callback) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        showWritable,
+                        ntsa::Handle,
+                        const ntca::ReactorEventOptions&,
+                        const ntci::ReactorEventCallback&)
 
     NTF_MOCK_METHOD_NEW(ntsa::Error,
                         showError,
                         const bsl::shared_ptr<ntci::ReactorSocket>&,
                         const ntca::ReactorEventOptions&)
-  public:
-    ntsa::Error showError(ntsa::Handle                      handle,
-                          const ntca::ReactorEventOptions&  options,
-                          const ntci::ReactorEventCallback& callback) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        showError,
+                        ntsa::Handle,
+                        const ntca::ReactorEventOptions&,
+                        const ntci::ReactorEventCallback&)
+
     NTF_MOCK_METHOD_NEW(ntsa::Error,
                         hideReadable,
                         const bsl::shared_ptr<ntci::ReactorSocket>&)
@@ -1930,25 +1865,36 @@ class ReactorMock : public ntci::Reactor
                         createStreamSocket,
                         const ntca::StreamSocketOptions&,
                         bslma::Allocator*)
-  public:
-    bsl::shared_ptr<ntci::Timer> createTimer(
-        const ntca::TimerOptions&                  options,
-        const bsl::shared_ptr<ntci::TimerSession>& session,
-        bslma::Allocator*                          basicAllocator) override
-    {
-        UNEXPECTED_CALL();
 
-        return bsl::shared_ptr<ntci::Timer>();
-    }
-    bsl::shared_ptr<ntci::Timer> createTimer(
-        const ntca::TimerOptions&  options,
-        const ntci::TimerCallback& callback,
-        bslma::Allocator*          basicAllocator) override
-    {
-        return d_invocation_createTimer.invoke(options,
-                                               callback,
-                                               basicAllocator);
-    }
+    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Timer>,
+                        createTimer,
+                        const ntca::TimerOptions&,
+                        const bsl::shared_ptr<ntci::TimerSession>&,
+                        bslma::Allocator*)
+    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Timer>,
+                        createTimer,
+                        const ntca::TimerOptions&,
+                        const ntci::TimerCallback&,
+                        bslma::Allocator*)
+  public:
+    // bsl::shared_ptr<ntci::Timer> createTimer(
+    //     const ntca::TimerOptions&                  options,
+    //     const bsl::shared_ptr<ntci::TimerSession>& session,
+    //     bslma::Allocator*                          basicAllocator) override
+    // {
+    //     UNEXPECTED_CALL();
+    //
+    //     return bsl::shared_ptr<ntci::Timer>();
+    // }
+    // bsl::shared_ptr<ntci::Timer> createTimer(
+    //     const ntca::TimerOptions&  options,
+    //     const ntci::TimerCallback& callback,
+    //     bslma::Allocator*          basicAllocator) override
+    // {
+    //     return d_invocation_createTimer.invoke(options,
+    //                                            callback,
+    //                                            basicAllocator);
+    // }
     const bsl::shared_ptr<ntci::Strand>& strand() const override
     {
         UNEXPECTED_CALL();
@@ -1957,154 +1903,6 @@ class ReactorMock : public ntci::Reactor
     NTF_MOCK_METHOD_CONST_NEW(bsls::TimeInterval, currentTime)
 
   public:
-    // Helper data structures
-
-    struct Invocation_createTimer {
-      private:
-        struct InvocationData {
-            int                                                d_expectedCalls;
-            bdlb::NullableValue<ntca::TimerOptions>            d_arg1;
-            bdlb::NullableValue<ntci::TimerCallback>           d_arg2;
-            bdlb::NullableValue<bslma::Allocator*>             d_arg3;
-            bdlb::NullableValue<bsl::shared_ptr<ntci::Timer> > d_result;
-            ntca::TimerOptions*                                d_arg1_out;
-            ntci::TimerCallback*                               d_arg2_out;
-            bslma::Allocator**                                 d_arg3_out;
-
-            InvocationData()
-            : d_expectedCalls(0)
-            , d_arg1()
-            , d_arg2()
-            , d_arg3()
-            , d_result()
-            , d_arg1_out(0)
-            , d_arg2_out(0)
-            , d_arg3_out(0)
-            {
-            }
-        };
-
-      public:
-        Invocation_createTimer& expect(
-            const bdlb::NullableValue<ntca::TimerOptions>&  arg1,
-            const bdlb::NullableValue<ntci::TimerCallback>& arg2,
-            const bdlb::NullableValue<bslma::Allocator*>&   arg3)
-        {
-            d_invocations.emplace_back();
-            InvocationData& invocation = d_invocations.back();
-            invocation.d_arg1          = arg1;
-            invocation.d_arg2          = arg2;
-            invocation.d_arg3          = arg3;
-            return *this;
-        }
-        Invocation_createTimer& willOnce()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
-
-            invocation.d_expectedCalls = 1;
-            return *this;
-        }
-        Invocation_createTimer& willAlways()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
-
-            invocation.d_expectedCalls = -1;
-            return *this;
-        }
-        //        Invocation_createTimer& times(int val){} //TODO: multiple calls
-
-        Invocation_createTimer& willReturn(
-            const bsl::shared_ptr<ntci::Timer>& result)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.back();
-            invocation.d_result        = result;
-            return *this;
-        }
-
-        Invocation_createTimer& saveArg1(ntca::TimerOptions& arg)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_arg1_out, 0);
-            invocation.d_arg1_out = &arg;
-            return *this;
-        }
-        Invocation_createTimer& saveArg2(ntci::TimerCallback& arg)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_arg2_out, 0);
-            invocation.d_arg2_out = &arg;
-            return *this;
-        }
-        Invocation_createTimer& saveArg3(bslma::Allocator*& arg)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_arg3_out, 0);
-            invocation.d_arg3_out = &arg;
-            return *this;
-        }
-
-        bsl::shared_ptr<ntci::Timer> invoke(const ntca::TimerOptions&  arg1,
-                                            const ntci::TimerCallback& arg2,
-                                            bslma::Allocator*          arg3)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.front();
-
-            if (invocation.d_expectedCalls != -1) {
-                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
-            }
-
-            if (invocation.d_arg1.has_value()) {
-                NTCCFG_TEST_EQ(arg1, invocation.d_arg1.value());
-            }
-
-            if (invocation.d_arg2.has_value()) {
-                NTCCFG_TEST_EQ(arg2, invocation.d_arg2.value());
-            }
-
-            if (invocation.d_arg3.has_value()) {
-                NTCCFG_TEST_EQ(arg3, invocation.d_arg3.value());
-            }
-
-            if (invocation.d_arg1_out) {
-                *invocation.d_arg1_out = arg1;
-            }
-
-            if (invocation.d_arg2_out) {
-                *invocation.d_arg2_out = arg2;
-            }
-
-            if (invocation.d_arg3_out) {
-                *invocation.d_arg3_out = arg3;
-            }
-
-            NTCCFG_TEST_TRUE(invocation.d_result.has_value());
-            const auto result = invocation.d_result.value();
-
-            if (invocation.d_expectedCalls != -1) {
-                --invocation.d_expectedCalls;
-                if (invocation.d_expectedCalls == 0) {
-                    d_invocations.pop_front();
-                }
-            }
-
-            return result;
-        }
-
-      private:
-        bsl::list<InvocationData> d_invocations;
-    };
-
   public:
     // auxiliary methods
     void expect_dataPool_WillAlwaysReturn(
@@ -2125,14 +1923,6 @@ class ReactorMock : public ntci::Reactor
         d_incomingBlobBufferFactory_result = bufferFactory;
     }
 
-    Invocation_createTimer& expect_createTimer(
-        const bdlb::NullableValue<ntca::TimerOptions>&  arg1,
-        const bdlb::NullableValue<ntci::TimerCallback>& arg2,
-        const bdlb::NullableValue<bslma::Allocator*>&   arg3)
-    {
-        return d_invocation_createTimer.expect(arg1, arg2, arg3);
-    }
-
   private:
     bdlb::NullableValue<bsl::shared_ptr<bdlbb::BlobBufferFactory> >
         d_incomingBlobBufferFactory_result;
@@ -2140,8 +1930,6 @@ class ReactorMock : public ntci::Reactor
                                   d_outgoingBlobBufferFactory_result;
     bsl::shared_ptr<ntci::Strand> dummyStrand;
     bdlb::NullableValue<bsl::shared_ptr<ntci::DataPool> > d_dataPool_result;
-
-    Invocation_createTimer d_invocation_createTimer;
 };
 
 class TimerMock : public ntci::Timer
@@ -4164,7 +3952,6 @@ NTCCFG_TEST_CASE(22)
     {
         NTCI_LOG_DEBUG("Fixture setup, socket creation...");
 
-        const bsl::nullopt_t doNotCare = bsl::nullopt;
         const ntsa::Handle   handle    = 22;
 
         bdlb::NullableValue<ntca::ConnectEvent> connectResult;
@@ -4262,8 +4049,8 @@ NTCCFG_TEST_CASE(22)
             .RETURN(ntsa::Error())
             .SET_ARG_1(FROM_DEREF(rcvBufferSizeOption));
 
-        socketMock->expect_maxBuffersPerSend().willOnce().willReturn(22);
-        socketMock->expect_maxBuffersPerReceive().willOnce().willReturn(22);
+        NTF_EXPECT_0(*socketMock, maxBuffersPerSend).ONCE().RETURN(22);
+        NTF_EXPECT_0(*socketMock, maxBuffersPerReceive).ONCE().RETURN(22);
 
         NTF_EXPECT_0(*reactorMock, acquireHandleReservation)
             .ALWAYS()
@@ -4278,10 +4065,15 @@ NTCCFG_TEST_CASE(22)
         connectRetryTimerMock.createInplace(&ta);
 
         ntci::TimerCallback retryTimerCallback;
-        reactorMock->expect_createTimer(doNotCare, doNotCare, doNotCare)
-            .willOnce()
-            .willReturn(connectRetryTimerMock)
-            .saveArg2(retryTimerCallback);
+
+        NTF_EXPECT_3(*reactorMock,
+                     createTimer,
+                     IGNORE_ARG_S( const ntca::TimerOptions&),
+                     IGNORE_ARG_S( const ntci::TimerCallback&),
+                     IGNORE_ARG_S( bslma::Allocator*))
+            .ONCE()
+            .SAVE_ARG_2(TO(&retryTimerCallback))
+            .RETURN(connectRetryTimerMock);
 
         NTF_EXPECT_2(*connectRetryTimerMock, schedule, IGNORE_ARG, IGNORE_ARG)
             .ONCE()
@@ -4469,10 +4261,15 @@ NTCCFG_TEST_CASE(23)
         connectRetryTimerMock.createInplace(&ta);
 
         ntci::TimerCallback retryTimerCallback;
-        reactorMock->expect_createTimer(doNotCare, doNotCare, doNotCare)
-            .willOnce()
-            .willReturn(connectRetryTimerMock)
-            .saveArg2(retryTimerCallback);
+
+        NTF_EXPECT_3(*reactorMock,
+                     createTimer,
+                     IGNORE_ARG_S(const ntca::TimerOptions&),
+                     IGNORE_ARG_S(const ntci::TimerCallback&),
+                     IGNORE_ARG_S(bslma::Allocator*))
+            .ONCE()
+            .SAVE_ARG_2(TO(&retryTimerCallback))
+            .RETURN(connectRetryTimerMock);
 
         NTF_EXPECT_2(*connectRetryTimerMock, schedule, IGNORE_ARG, IGNORE_ARG)
             .ONCE()
@@ -4630,10 +4427,15 @@ NTCCFG_TEST_CASE(24)
             deadlineTime.setTotalHours(1);
 
             connectDeadlineTimerMock.createInplace(&ta);
-            reactorMock->expect_createTimer(doNotCare, doNotCare, doNotCare)
-                .willOnce()
-                .willReturn(connectDeadlineTimerMock)
-                .saveArg2(deadlineTimerCallback);
+
+            NTF_EXPECT_3(*reactorMock,
+                         createTimer,
+                         IGNORE_ARG_S( const ntca::TimerOptions&),
+                         IGNORE_ARG_S( const ntci::TimerCallback&),
+                         IGNORE_ARG_S( bslma::Allocator*))
+                .ONCE()
+                .SAVE_ARG_2(TO(&deadlineTimerCallback))
+                .RETURN(connectDeadlineTimerMock);
 
             NTF_EXPECT_2(*connectDeadlineTimerMock,
                          schedule,
@@ -4648,10 +4450,14 @@ NTCCFG_TEST_CASE(24)
         {
             connectRetryTimerMock.createInplace(&ta);
 
-            reactorMock->expect_createTimer(doNotCare, doNotCare, doNotCare)
-                .willOnce()
-                .willReturn(connectRetryTimerMock)
-                .saveArg2(retryTimerCallback);
+            NTF_EXPECT_3(*reactorMock,
+                         createTimer,
+                         IGNORE_ARG_S( const ntca::TimerOptions&),
+                         IGNORE_ARG_S( const ntci::TimerCallback&),
+                         IGNORE_ARG_S( bslma::Allocator*))
+                .ONCE()
+                .SAVE_ARG_2(TO(&retryTimerCallback))
+                .RETURN(connectRetryTimerMock);
 
             NTF_EXPECT_2(*connectRetryTimerMock,
                          schedule,

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1582,10 +1582,12 @@ class ResolverMock : public ntci::Resolver
 class BufferFactoryMock : public bdlbb::BlobBufferFactory
 {
   public:
-    void allocate(bdlbb::BlobBuffer* buffer) override
-    {
-        UNEXPECTED_CALL();
-    }
+        void allocate(bdlbb::BlobBuffer* buffer) override
+        {
+            UNEXPECTED_CALL();
+        }
+
+//    NTF_MOCK_METHOD(void, allocate, bdlbb::BlobBuffer*)
 };
 
 class StreamSocketMock : public ntsi::StreamSocket
@@ -1597,7 +1599,6 @@ class StreamSocketMock : public ntsi::StreamSocket
     NTF_MOCK_METHOD(ntsa::Handle, release);
 
   public:
-
     ntsa::Error bind(const ntsa::Endpoint& endpoint,
                      bool                  reuseAddress) override
     {
@@ -1657,7 +1658,6 @@ class StreamSocketMock : public ntsi::StreamSocket
     NTF_MOCK_METHOD(ntsa::Error, unlink)
     NTF_MOCK_METHOD(ntsa::Error, close)
   public:
-
     ntsa::Error sourceEndpoint(ntsa::Endpoint* result) const override
     {
         return d_invocation_sourceEndpoint.invoke(result);
@@ -1689,7 +1689,6 @@ class StreamSocketMock : public ntsi::StreamSocket
     NTF_MOCK_METHOD_CONST(bsl::size_t, maxBuffersPerReceive)
 
   public:
-
     struct Invocation_setBlocking {
       private:
         struct InvocationData {
@@ -2378,12 +2377,12 @@ class StreamSocketMock : public ntsi::StreamSocket
     }
 
   private:
-    mutable Invocation_setBlocking          d_invocation_setBlocking;
-    mutable Invocation_setOption            d_invocation_setOption;
-    mutable Invocation_getOption            d_invocation_getOption;
-    mutable Invocation_sourceEndpoint       d_invocation_sourceEndpoint;
-    mutable Invocation_remoteEndpoint       d_invocation_remoteEndpoint;
-    mutable Invocation_connect              d_invocation_connect;
+    mutable Invocation_setBlocking    d_invocation_setBlocking;
+    mutable Invocation_setOption      d_invocation_setOption;
+    mutable Invocation_getOption      d_invocation_getOption;
+    mutable Invocation_sourceEndpoint d_invocation_sourceEndpoint;
+    mutable Invocation_remoteEndpoint d_invocation_remoteEndpoint;
+    mutable Invocation_connect        d_invocation_connect;
 };
 
 class DataPoolMock : public ntci::DataPool
@@ -5490,8 +5489,8 @@ NTCCFG_TEST_CASE(22)
     {
         NTCI_LOG_DEBUG("Fixture setup, socket creation...");
 
-        const auto         doNotCare = bdlb::NullOptType::makeInitialValue();
-        const ntsa::Handle handle    = 22;
+        const bsl::nullopt_t doNotCare = bsl::nullopt;
+        const ntsa::Handle   handle    = 22;
 
         bdlb::NullableValue<ntca::ConnectEvent> connectResult;
 
@@ -5614,10 +5613,9 @@ NTCCFG_TEST_CASE(22)
 
         NTCI_LOG_DEBUG("Trigger internal timer to initiate connection...");
 
-        resolverMock->expect_getEndpoint_WillOnceReturn(
-            epName,
-            bdlb::NullOptType::makeInitialValue(),
-            ntsa::Error());
+        resolverMock->expect_getEndpoint_WillOnceReturn(epName,
+                                                        doNotCare,
+                                                        ntsa::Error());
 
         ntca::TimerEvent timerEvent;
         timerEvent.setType(ntca::TimerEventType::e_DEADLINE);
@@ -5632,7 +5630,7 @@ NTCCFG_TEST_CASE(22)
 
         reactorMock->expect_detachSocket_WillOnceReturn(
             socket,
-            bdlb::NullOptType::makeInitialValue(),
+            doNotCare,
             ntsa::Error::invalid());
         //TODO: is that ok to detach socket that has not been attached?
 
@@ -5658,8 +5656,8 @@ NTCCFG_TEST_CASE(23)
     {
         NTCI_LOG_DEBUG("Fixture setup, socket creation...");
 
-        const auto         doNotCare = bdlb::NullOptType::makeInitialValue();
-        const ntsa::Handle handle    = 22;
+        const bsl::nullopt_t doNotCare = bsl::nullopt;
+        const ntsa::Handle   handle    = 22;
 
         bdlb::NullableValue<ntca::ConnectEvent> connectResult;
 
@@ -5804,10 +5802,9 @@ NTCCFG_TEST_CASE(23)
         connectRetryTimerMock->expect_close().willOnce().willReturn(
             ntsa::Error());
 
-        reactorMock->expect_detachSocket_WillOnceReturn(
-            socket,
-            bdlb::NullOptType::makeInitialValue(),
-            ntsa::Error());
+        reactorMock->expect_detachSocket_WillOnceReturn(socket,
+                                                        doNotCare,
+                                                        ntsa::Error());
 
         socketMock->expect_close().willOnce().willReturn(ntsa::Error());
 
@@ -5838,7 +5835,7 @@ NTCCFG_TEST_CASE(24)
     {
         NTCI_LOG_DEBUG("Fixture setup, socket creation...");
 
-        const auto doNotCare = bdlb::NullOptType::makeInitialValue();
+        const bsl::nullopt_t doNotCare = bsl::nullopt;
 
         bdlb::NullableValue<ntca::ConnectEvent> connectResult;
 

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -2044,40 +2044,18 @@ public:
         }
         return d_outgoingBlobBufferFactory_result.value();
     }
-    ntci::Waiter registerWaiter(
-        const ntca::WaiterOptions& waiterOptions) override
-    {
-        UNEXPECTED_CALL();
-        return nullptr;
-    }
-    void deregisterWaiter(ntci::Waiter waiter) override
-    {
-        UNEXPECTED_CALL();
-    }
-    void run(ntci::Waiter waiter) override
-    {
-        UNEXPECTED_CALL();
-    }
-    void poll(ntci::Waiter waiter) override
-    {
-        UNEXPECTED_CALL();
-    }
-    void interruptOne() override
-    {
-        UNEXPECTED_CALL();
-    }
-    void interruptAll() override
-    {
-        UNEXPECTED_CALL();
-    }
-    void stop() override
-    {
-        UNEXPECTED_CALL();
-    }
-    void restart() override
-    {
-        UNEXPECTED_CALL();
-    }
+
+    NTF_MOCK_METHOD_NEW(ntci::Waiter, registerWaiter, const ntca::WaiterOptions&)
+    NTF_MOCK_METHOD_NEW(void, deregisterWaiter, ntci::Waiter)
+    NTF_MOCK_METHOD_NEW(void, run, ntci::Waiter)
+    NTF_MOCK_METHOD_NEW(void, poll, ntci::Waiter)
+    NTF_MOCK_METHOD_NEW(void, interruptOne)
+    NTF_MOCK_METHOD_NEW(void, interruptAll)
+    NTF_MOCK_METHOD_NEW(void, stop)
+    NTF_MOCK_METHOD_NEW(void, restart)
+
+public:
+
     void execute(const Functor& functor) override
     {
         if (!d_execute_expected) {
@@ -2113,11 +2091,8 @@ public:
         d_attachSocket_result.reset();
         return res;
     }
-    ntsa::Error attachSocket(ntsa::Handle handle) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
+    NTF_MOCK_METHOD_NEW(ntsa::Error, attachSocket, ntsa::Handle)
+public:
     ntsa::Error showReadable(
         const bsl::shared_ptr<ntci::ReactorSocket>& socket,
         const ntca::ReactorEventOptions&            options) override
@@ -2171,12 +2146,9 @@ public:
         UNEXPECTED_CALL();
         return ntsa::Error();
     }
-    ntsa::Error hideReadable(
-        const bsl::shared_ptr<ntci::ReactorSocket>& socket) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
+    NTF_MOCK_METHOD_NEW(ntsa::Error, hideReadable, const bsl::shared_ptr<ntci::ReactorSocket>&)
+
+public:
     ntsa::Error hideReadable(ntsa::Handle handle) override
     {
         UNEXPECTED_CALL();

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1591,10 +1591,8 @@ class BufferFactoryMock : public bdlbb::BlobBufferFactory
 class StreamSocketMock : public ntsi::StreamSocket
 {
   public:
-    ntsa::Handle handle() const override
-    {
-        return d_invocation_handle.invoke();
-    }
+    NTF_MOCK_METHOD_CONST(ntsa::Handle, handle)
+
     ntsa::Error open(ntsa::Transport::Value transport) override
     {
         UNEXPECTED_CALL();
@@ -1605,11 +1603,10 @@ class StreamSocketMock : public ntsi::StreamSocket
         UNEXPECTED_CALL();
         return ntsa::Error();
     }
-    ntsa::Handle release() override
-    {
-        UNEXPECTED_CALL();
-        return 0;
-    }
+
+    NTF_MOCK_METHOD(ntsa::Handle, release)
+  public:
+
     ntsa::Error bind(const ntsa::Endpoint& endpoint,
                      bool                  reuseAddress) override
     {
@@ -1665,15 +1662,11 @@ class StreamSocketMock : public ntsi::StreamSocket
         UNEXPECTED_CALL();
         return ntsa::Error();
     }
-    ntsa::Error unlink() override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error close() override
-    {
-        return d_invocation_close.invoke();
-    }
+
+    NTF_MOCK_METHOD(ntsa::Error, unlink)
+    NTF_MOCK_METHOD(ntsa::Error, close)
+  public:
+
     ntsa::Error sourceEndpoint(ntsa::Endpoint* result) const override
     {
         return d_invocation_sourceEndpoint.invoke(result);
@@ -1700,338 +1693,11 @@ class StreamSocketMock : public ntsi::StreamSocket
         UNEXPECTED_CALL();
         return ntsa::Error();
     }
-    size_t maxBuffersPerSend() const override
-    {
-        return d_invocation_maxBuffersPerSend.invoke();
-    }
-    size_t maxBuffersPerReceive() const override
-    {
-        return d_invocation_maxBuffersPerReceive.invoke();
-    }
 
-    struct Invocation_handle {
-      private:
-        struct InvocationData {
-            int                               d_expectedCalls;
-            bdlb::NullableValue<ntsa::Handle> d_result;
+    NTF_MOCK_METHOD_0_CONST(bsl::size_t, maxBuffersPerSend)
+    NTF_MOCK_METHOD_0_CONST(bsl::size_t, maxBuffersPerReceive)
 
-            InvocationData()
-            : d_expectedCalls(0)
-            , d_result()
-            {
-            }
-        };
-
-      public:
-        Invocation_handle& expect()
-        {
-            d_invocations.emplace_back();
-            InvocationData& invocation = d_invocations.back();
-            return *this;
-        }
-        Invocation_handle& willOnce()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
-
-            invocation.d_expectedCalls = 1;
-            return *this;
-        }
-        Invocation_handle& willAlways()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
-
-            invocation.d_expectedCalls = -1;
-            return *this;
-        }
-        //        Invocation_createTimer& times(int val){} //TODO: multiple calls
-
-        Invocation_handle& willReturn(ntsa::Handle result)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.back();
-            invocation.d_result        = result;
-            return *this;
-        }
-
-        ntsa::Handle invoke()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.front();
-
-            if (invocation.d_expectedCalls != -1) {
-                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
-            }
-
-            NTCCFG_TEST_TRUE(invocation.d_result.has_value());
-            const auto result = invocation.d_result.value();
-
-            if (invocation.d_expectedCalls != -1) {
-                --invocation.d_expectedCalls;
-                if (invocation.d_expectedCalls == 0) {
-                    d_invocations.pop_front();
-                }
-            }
-
-            return result;
-        }
-
-      private:
-        bsl::list<InvocationData> d_invocations;
-    };
-
-    Invocation_handle& expect_handle()
-    {
-        return d_invocation_handle.expect();
-    }
-
-    struct Invocation_close {
-      private:
-        struct InvocationData {
-            int                              d_expectedCalls;
-            bdlb::NullableValue<ntsa::Error> d_result;
-
-            InvocationData()
-            : d_expectedCalls(0)
-            , d_result()
-            {
-            }
-        };
-
-      public:
-        Invocation_close& expect()
-        {
-            d_invocations.emplace_back();
-            InvocationData& invocation = d_invocations.back();
-            return *this;
-        }
-        Invocation_close& willOnce()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
-
-            invocation.d_expectedCalls = 1;
-            return *this;
-        }
-        Invocation_close& willAlways()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
-
-            invocation.d_expectedCalls = -1;
-            return *this;
-        }
-        //        Invocation_createTimer& times(int val){} //TODO: multiple calls
-
-        Invocation_close& willReturn(ntsa::Error result)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.back();
-            invocation.d_result        = result;
-            return *this;
-        }
-
-        ntsa::Error invoke()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.front();
-
-            if (invocation.d_expectedCalls != -1) {
-                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
-            }
-
-            NTCCFG_TEST_TRUE(invocation.d_result.has_value());
-            const auto result = invocation.d_result.value();
-
-            if (invocation.d_expectedCalls != -1) {
-                --invocation.d_expectedCalls;
-                if (invocation.d_expectedCalls == 0) {
-                    d_invocations.pop_front();
-                }
-            }
-
-            return result;
-        }
-
-      private:
-        bsl::list<InvocationData> d_invocations;
-    };
-
-    Invocation_close& expect_close()
-    {
-        return d_invocation_close.expect();
-    }
-
-    struct Invocation_maxBuffersPerSend {
-      private:
-        struct InvocationData {
-            int                              d_expectedCalls;
-            bdlb::NullableValue<bsl::size_t> d_result;
-
-            InvocationData()
-            : d_expectedCalls(0)
-            , d_result()
-            {
-            }
-        };
-
-      public:
-        Invocation_maxBuffersPerSend& expect()
-        {
-            d_invocations.emplace_back();
-            InvocationData& invocation = d_invocations.back();
-            return *this;
-        }
-        Invocation_maxBuffersPerSend& willOnce()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
-
-            invocation.d_expectedCalls = 1;
-            return *this;
-        }
-        Invocation_maxBuffersPerSend& willAlways()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
-
-            invocation.d_expectedCalls = -1;
-            return *this;
-        }
-        //        Invocation_createTimer& times(int val){} //TODO: multiple calls
-
-        Invocation_maxBuffersPerSend& willReturn(bsl::size_t result)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.back();
-            invocation.d_result        = result;
-            return *this;
-        }
-
-        bsl::size_t invoke()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.front();
-
-            if (invocation.d_expectedCalls != -1) {
-                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
-            }
-
-            NTCCFG_TEST_TRUE(invocation.d_result.has_value());
-            const auto result = invocation.d_result.value();
-
-            if (invocation.d_expectedCalls != -1) {
-                --invocation.d_expectedCalls;
-                if (invocation.d_expectedCalls == 0) {
-                    d_invocations.pop_front();
-                }
-            }
-
-            return result;
-        }
-
-      private:
-        bsl::list<InvocationData> d_invocations;
-    };
-
-    Invocation_maxBuffersPerSend& expect_maxBuffersPerSend()
-    {
-        return d_invocation_maxBuffersPerSend.expect();
-    }
-
-    struct Invocation_maxBuffersPerReceive {
-      private:
-        struct InvocationData {
-            int                              d_expectedCalls;
-            bdlb::NullableValue<bsl::size_t> d_result;
-
-            InvocationData()
-            : d_expectedCalls(0)
-            , d_result()
-            {
-            }
-        };
-
-      public:
-        Invocation_maxBuffersPerReceive& expect()
-        {
-            d_invocations.emplace_back();
-            InvocationData& invocation = d_invocations.back();
-            return *this;
-        }
-        Invocation_maxBuffersPerReceive& willOnce()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
-
-            invocation.d_expectedCalls = 1;
-            return *this;
-        }
-        Invocation_maxBuffersPerReceive& willAlways()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-
-            InvocationData& invocation = d_invocations.back();
-            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
-
-            invocation.d_expectedCalls = -1;
-            return *this;
-        }
-        //        Invocation_createTimer& times(int val){} //TODO: multiple calls
-
-        Invocation_maxBuffersPerReceive& willReturn(bsl::size_t result)
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.back();
-            invocation.d_result        = result;
-            return *this;
-        }
-
-        bsl::size_t invoke()
-        {
-            NTCCFG_TEST_FALSE(d_invocations.empty());
-            InvocationData& invocation = d_invocations.front();
-
-            if (invocation.d_expectedCalls != -1) {
-                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
-            }
-
-            NTCCFG_TEST_TRUE(invocation.d_result.has_value());
-            const auto result = invocation.d_result.value();
-
-            if (invocation.d_expectedCalls != -1) {
-                --invocation.d_expectedCalls;
-                if (invocation.d_expectedCalls == 0) {
-                    d_invocations.pop_front();
-                }
-            }
-
-            return result;
-        }
-
-      private:
-        bsl::list<InvocationData> d_invocations;
-    };
-
-    Invocation_maxBuffersPerReceive& expect_maxBuffersPerReceive()
-    {
-        return d_invocation_maxBuffersPerReceive.expect();
-    }
+  public:
 
     struct Invocation_setBlocking {
       private:
@@ -2721,10 +2387,6 @@ class StreamSocketMock : public ntsi::StreamSocket
     }
 
   private:
-    mutable Invocation_handle               d_invocation_handle;
-    mutable Invocation_close                d_invocation_close;
-    mutable Invocation_maxBuffersPerSend    d_invocation_maxBuffersPerSend;
-    mutable Invocation_maxBuffersPerReceive d_invocation_maxBuffersPerReceive;
     mutable Invocation_setBlocking          d_invocation_setBlocking;
     mutable Invocation_setOption            d_invocation_setOption;
     mutable Invocation_getOption            d_invocation_getOption;

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -3989,7 +3989,7 @@ NTCCFG_TEST_CASE(22)
 
         NTCI_LOG_DEBUG("Inject mocked ntsi::StreamSocket");
 
-        socketMock->expect_handle().willAlways().willReturn(handle);
+        NTF_EXPECT_0(*socketMock, handle).ALWAYS().RETURN(handle);
 
         NTF_EXPECT_1(*socketMock, setBlocking, NTF_EQ(false))
             .TIMES(2)
@@ -4088,8 +4088,9 @@ NTCCFG_TEST_CASE(22)
         NTCI_LOG_DEBUG("Shutdown socket while it is waiting for remote "
                        "endpoint resolution");
 
-        connectRetryTimerMock->expect_close().willOnce().willReturn(
-            ntsa::Error());
+        NTF_EXPECT_0(*connectRetryTimerMock, close)
+            .ONCE()
+            .RETURN(ntsa::Error());
 
         ntci::Reactor::Functor callback;
         NTF_EXPECT_1(*reactorMock, execute, IGNORE_ARG)
@@ -4105,7 +4106,7 @@ NTCCFG_TEST_CASE(22)
             .RETURN(ntsa::Error::invalid());
         //TODO: is that ok to detach socket that has not been attached?
 
-        socketMock->expect_close().willOnce().willReturn(ntsa::Error());
+        NTF_EXPECT_0(*socketMock, close).ONCE().RETURN(ntsa::Error());
 
         socket->shutdown(ntsa::ShutdownType::e_BOTH,
                          ntsa::ShutdownMode::e_GRACEFUL);
@@ -4185,7 +4186,7 @@ NTCCFG_TEST_CASE(23)
 
         NTCI_LOG_DEBUG("Inject mocked ntsi::StreamSocket");
 
-        socketMock->expect_handle().willAlways().willReturn(handle);
+        NTF_EXPECT_0(*socketMock, handle).ALWAYS().RETURN(handle);
 
         NTF_EXPECT_1(*socketMock, setBlocking, NTF_EQ(false))
             .TIMES(2)
@@ -4224,8 +4225,8 @@ NTCCFG_TEST_CASE(23)
             .RETURN(ntsa::Error())
             .SET_ARG_1(FROM_DEREF(rcvBufferSizeOption));
 
-        socketMock->expect_maxBuffersPerSend().willOnce().willReturn(22);
-        socketMock->expect_maxBuffersPerReceive().willOnce().willReturn(22);
+        NTF_EXPECT_0(*socketMock, maxBuffersPerSend).ONCE().RETURN(22);
+        NTF_EXPECT_0(*socketMock, maxBuffersPerReceive).ONCE().RETURN(22);
 
         NTF_EXPECT_0(*reactorMock, acquireHandleReservation)
             .ALWAYS()
@@ -4297,8 +4298,7 @@ NTCCFG_TEST_CASE(23)
         NTCI_LOG_DEBUG(
             "Shutdown socket while it is waiting for connection result");
 
-        connectRetryTimerMock->expect_close().willOnce().willReturn(
-            ntsa::Error());
+        NTF_EXPECT_0(*connectRetryTimerMock, close).ONCE().RETURN(ntsa::Error());
 
         ntci::SocketDetachedCallback detachCallback;
 
@@ -4311,7 +4311,7 @@ NTCCFG_TEST_CASE(23)
             .SAVE_ARG_2(TO(&detachCallback))
             .RETURN(ntsa::Error());
 
-        socketMock->expect_close().willOnce().willReturn(ntsa::Error());
+        NTF_EXPECT_0(*socketMock, close).ONCE().RETURN(ntsa::Error());
 
         socket->shutdown(ntsa::ShutdownType::e_BOTH,
                          ntsa::ShutdownMode::e_GRACEFUL);

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1877,24 +1877,6 @@ class ReactorMock : public ntci::Reactor
                         const ntci::TimerCallback&,
                         bslma::Allocator*)
   public:
-    // bsl::shared_ptr<ntci::Timer> createTimer(
-    //     const ntca::TimerOptions&                  options,
-    //     const bsl::shared_ptr<ntci::TimerSession>& session,
-    //     bslma::Allocator*                          basicAllocator) override
-    // {
-    //     UNEXPECTED_CALL();
-    //
-    //     return bsl::shared_ptr<ntci::Timer>();
-    // }
-    // bsl::shared_ptr<ntci::Timer> createTimer(
-    //     const ntca::TimerOptions&  options,
-    //     const ntci::TimerCallback& callback,
-    //     bslma::Allocator*          basicAllocator) override
-    // {
-    //     return d_invocation_createTimer.invoke(options,
-    //                                            callback,
-    //                                            basicAllocator);
-    // }
     const bsl::shared_ptr<ntci::Strand>& strand() const override
     {
         UNEXPECTED_CALL();
@@ -1902,7 +1884,6 @@ class ReactorMock : public ntci::Reactor
     }
     NTF_MOCK_METHOD_CONST_NEW(bsls::TimeInterval, currentTime)
 
-  public:
   public:
     // auxiliary methods
     void expect_dataPool_WillAlwaysReturn(
@@ -1940,13 +1921,11 @@ class TimerMock : public ntci::Timer
                         const bsls::TimeInterval&)
     NTF_MOCK_METHOD_NEW(ntsa::Error, cancel)
     NTF_MOCK_METHOD_NEW(ntsa::Error, close)
-  public:
-    void arrive(const bsl::shared_ptr<ntci::Timer>& self,
-                const bsls::TimeInterval&           now,
-                const bsls::TimeInterval&           deadline) override
-    {
-        UNEXPECTED_CALL();
-    }
+    NTF_MOCK_METHOD_NEW(void,
+                        arrive,
+                        const bsl::shared_ptr<ntci::Timer>&,
+                        const bsls::TimeInterval&,
+                        const bsls::TimeInterval&)
     NTF_MOCK_METHOD_CONST_NEW(void*, handle)
     NTF_MOCK_METHOD_CONST_NEW(int, id)
     NTF_MOCK_METHOD_CONST_NEW(bool, oneShot)
@@ -3952,7 +3931,7 @@ NTCCFG_TEST_CASE(22)
     {
         NTCI_LOG_DEBUG("Fixture setup, socket creation...");
 
-        const ntsa::Handle   handle    = 22;
+        const ntsa::Handle handle = 22;
 
         bdlb::NullableValue<ntca::ConnectEvent> connectResult;
 
@@ -4068,9 +4047,9 @@ NTCCFG_TEST_CASE(22)
 
         NTF_EXPECT_3(*reactorMock,
                      createTimer,
-                     IGNORE_ARG_S( const ntca::TimerOptions&),
-                     IGNORE_ARG_S( const ntci::TimerCallback&),
-                     IGNORE_ARG_S( bslma::Allocator*))
+                     IGNORE_ARG_S(const ntca::TimerOptions&),
+                     IGNORE_ARG_S(const ntci::TimerCallback&),
+                     IGNORE_ARG_S(bslma::Allocator*))
             .ONCE()
             .SAVE_ARG_2(TO(&retryTimerCallback))
             .RETURN(connectRetryTimerMock);
@@ -4430,9 +4409,9 @@ NTCCFG_TEST_CASE(24)
 
             NTF_EXPECT_3(*reactorMock,
                          createTimer,
-                         IGNORE_ARG_S( const ntca::TimerOptions&),
-                         IGNORE_ARG_S( const ntci::TimerCallback&),
-                         IGNORE_ARG_S( bslma::Allocator*))
+                         IGNORE_ARG_S(const ntca::TimerOptions&),
+                         IGNORE_ARG_S(const ntci::TimerCallback&),
+                         IGNORE_ARG_S(bslma::Allocator*))
                 .ONCE()
                 .SAVE_ARG_2(TO(&deadlineTimerCallback))
                 .RETURN(connectDeadlineTimerMock);
@@ -4452,9 +4431,9 @@ NTCCFG_TEST_CASE(24)
 
             NTF_EXPECT_3(*reactorMock,
                          createTimer,
-                         IGNORE_ARG_S( const ntca::TimerOptions&),
-                         IGNORE_ARG_S( const ntci::TimerCallback&),
-                         IGNORE_ARG_S( bslma::Allocator*))
+                         IGNORE_ARG_S(const ntca::TimerOptions&),
+                         IGNORE_ARG_S(const ntci::TimerCallback&),
+                         IGNORE_ARG_S(bslma::Allocator*))
                 .ONCE()
                 .SAVE_ARG_2(TO(&retryTimerCallback))
                 .RETURN(connectRetryTimerMock);

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1375,7 +1375,7 @@ void variation(const test::Parameters& parameters)
 }
 
 struct Fixture {
-     Fixture(bslma::Allocator* allocator);
+    Fixture(bslma::Allocator* allocator);
     ~Fixture();
 
     void setupReactorBase();
@@ -3661,7 +3661,7 @@ NTCCFG_TEST_CASE(23)
         }
 
         ntci::TimerCallback  retryTimerCallback;
-        const ntsa::Endpoint targetEp{"127.0.0.1:1234"};
+        const ntsa::Endpoint targetEp("127.0.0.1:1234");
         NTCI_LOG_DEBUG("Connection initiation...");
         {
             NTF_EXPECT_3(*test.d_reactorMock,
@@ -3687,7 +3687,7 @@ NTCCFG_TEST_CASE(23)
 
         NTCI_LOG_DEBUG("Trigger internal timer to initiate connection...");
         {
-            const ntsa::Endpoint sourceEp{"127.0.0.1:22"};
+            const ntsa::Endpoint sourceEp("127.0.0.1:22");
             NTF_EXPECT_1(
                 *test.d_reactorMock,
                 attachSocket,
@@ -3798,7 +3798,7 @@ NTCCFG_TEST_CASE(24)
         }
 
         ntci::TimerCallback  retryTimerCallback;
-        const ntsa::Endpoint targetEp{"127.0.0.1:1234"};
+        const ntsa::Endpoint targetEp("127.0.0.1:1234");
         NTCI_LOG_DEBUG("Connection initiation...");
         {
             bsls::TimeInterval deadlineTime;
@@ -3847,7 +3847,7 @@ NTCCFG_TEST_CASE(24)
 
         NTCI_LOG_DEBUG("Trigger internal timer to initiate connection...");
         {
-            const ntsa::Endpoint sourceEp{"127.0.0.1:22"};
+            const ntsa::Endpoint sourceEp("127.0.0.1:22");
 
             NTF_EXPECT_1(
                 *test.d_reactorMock,
@@ -3964,7 +3964,7 @@ NTCCFG_TEST_CASE(25)
         }
 
         ntci::TimerCallback  retryTimerCallback;
-        const ntsa::Endpoint targetEp{"127.0.0.1:1234"};
+        const ntsa::Endpoint targetEp("127.0.0.1:1234");
         NTCI_LOG_DEBUG("Connection initiation...");
         {
             const bsl::size_t  k_CONNECT_RETRY_COUNT = 5;
@@ -4015,7 +4015,7 @@ NTCCFG_TEST_CASE(25)
 
         NTCI_LOG_DEBUG("Trigger internal timer to initiate connection...");
         {
-            const ntsa::Endpoint sourceEp{"127.0.0.1:22"};
+            const ntsa::Endpoint sourceEp("127.0.0.1:22");
 
             NTF_EXPECT_1(
                 *test.d_reactorMock,
@@ -4151,7 +4151,7 @@ NTCCFG_TEST_CASE(26)
         }
 
         ntci::TimerCallback  retryTimerCallback;
-        const ntsa::Endpoint targetEp{"127.0.0.1:1234"};
+        const ntsa::Endpoint targetEp("127.0.0.1:1234");
         NTCI_LOG_DEBUG("Connection initiation...");
         {
             const bsl::size_t  k_CONNECT_RETRY_COUNT = 5;
@@ -4202,7 +4202,7 @@ NTCCFG_TEST_CASE(26)
 
         NTCI_LOG_DEBUG("Trigger internal timer to initiate connection...");
         {
-            const ntsa::Endpoint sourceEp{"127.0.0.1:22"};
+            const ntsa::Endpoint sourceEp("127.0.0.1:22");
 
             NTF_EXPECT_1(
                 *test.d_reactorMock,
@@ -4353,7 +4353,7 @@ NTCCFG_TEST_CASE(27)
         }
 
         ntci::TimerCallback  retryTimerCallback;
-        const ntsa::Endpoint targetEp{"127.0.0.1:1234"};
+        const ntsa::Endpoint targetEp("127.0.0.1:1234");
         NTCI_LOG_DEBUG("Connection initiation...");
         {
             bsls::TimeInterval deadlineTime;
@@ -4402,7 +4402,7 @@ NTCCFG_TEST_CASE(27)
 
         NTCI_LOG_DEBUG("Trigger internal timer to initiate connection...");
         {
-            const ntsa::Endpoint sourceEp{"127.0.0.1:22"};
+            const ntsa::Endpoint sourceEp("127.0.0.1:22");
 
             NTF_EXPECT_1(
                 *test.d_reactorMock,

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -17,6 +17,7 @@
 
 #include <ntccfg_bind.h>
 #include <ntccfg_test.h>
+#include <ntcd_blobbufferfactory.h>
 #include <ntcd_datautil.h>
 #include <ntcd_encryption.h>
 #include <ntcd_reactor.h>
@@ -1375,10 +1376,6 @@ void variation(const test::Parameters& parameters)
 
 namespace mock {
 
-NTF_MOCK_CLASS(BufferFactoryMock, bdlbb::BlobBufferFactory)
-NTF_MOCK_METHOD(void, allocate, bdlbb::BlobBuffer*)
-NTF_MOCK_CLASS_END;
-
 NTF_MOCK_CLASS(StreamSocketMock, ntsi::StreamSocket)
 
 NTF_MOCK_METHOD_CONST(ntsa::Handle, handle)
@@ -1632,7 +1629,7 @@ struct Fixture {
 
     bslma::Allocator* d_allocator;
 
-    bsl::shared_ptr<mock::BufferFactoryMock>  d_bufferFactoryMock;
+    bsl::shared_ptr<ntcd::BufferFactoryMock>  d_bufferFactoryMock;
     bsl::shared_ptr<bdlbb::BlobBufferFactory> d_bufferFactory;
     bsl::shared_ptr<mock::DataPoolMock>       d_dataPoolMock;
     bsl::shared_ptr<ntci::DataPool>           d_dataPool;

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -284,7 +284,7 @@ ntsa::Endpoint EndpointUtil::any(ntsa::Transport::Value transport)
         break;
     case ntsa::Transport::e_LOCAL_STREAM:
     case ntsa::Transport::e_LOCAL_DATAGRAM: {
-        ntsa::LocalName localName;
+        ntsa::LocalName   localName;
         const ntsa::Error error = ntsa::LocalName::generateUnique(&localName);
         BSLS_ASSERT_OPT(!error);
 
@@ -1369,6 +1369,914 @@ void variation(const test::Parameters& parameters)
                                          parameters,
                                          NTCCFG_BIND_PLACEHOLDER_3));
 }
+
+namespace mock {
+
+#define UNEXPECTED_CALL(unused) NTCCFG_TEST_TRUE(false && "unexpected call")
+
+class ResolverMock : public ntci::Resolver
+{
+  public:
+    void execute(const Functor& functor) override
+    {
+        UNEXPECTED_CALL();
+    }
+    void moveAndExecute(FunctorSequence* functorSequence,
+                        const Functor&   functor) override
+    {
+        UNEXPECTED_CALL();
+    }
+    const bsl::shared_ptr<ntci::Strand>& strand() const override
+    {
+        UNEXPECTED_CALL();
+        return dummyStrand;
+    }
+    ntsa::Error start() override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    void shutdown() override
+    {
+        UNEXPECTED_CALL();
+    }
+    void linger() override
+    {
+        UNEXPECTED_CALL();
+    }
+    ntsa::Error setIpAddress(
+        const bslstl::StringRef&            domainName,
+        const bsl::vector<ntsa::IpAddress>& ipAddressList) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error addIpAddress(
+        const bslstl::StringRef&            domainName,
+        const bsl::vector<ntsa::IpAddress>& ipAddressList) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error addIpAddress(const bslstl::StringRef& domainName,
+                             const ntsa::IpAddress&   ipAddress) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error setPort(const bslstl::StringRef&       serviceName,
+                        const bsl::vector<ntsa::Port>& portList,
+                        ntsa::Transport::Value         transport) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error addPort(const bslstl::StringRef&       serviceName,
+                        const bsl::vector<ntsa::Port>& portList,
+                        ntsa::Transport::Value         transport) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error addPort(const bslstl::StringRef& serviceName,
+                        ntsa::Port               port,
+                        ntsa::Transport::Value   transport) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error setLocalIpAddress(
+        const bsl::vector<ntsa::IpAddress>& ipAddressList) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error setHostname(const bsl::string& name) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error setHostnameFullyQualified(const bsl::string& name) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error getIpAddress(
+        const bslstl::StringRef&          domainName,
+        const ntca::GetIpAddressOptions&  options,
+        const ntci::GetIpAddressCallback& callback) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error getDomainName(
+        const ntsa::IpAddress&             ipAddress,
+        const ntca::GetDomainNameOptions&  options,
+        const ntci::GetDomainNameCallback& callback) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error getPort(const bslstl::StringRef&     serviceName,
+                        const ntca::GetPortOptions&  options,
+                        const ntci::GetPortCallback& callback) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error getServiceName(
+        ntsa::Port                          port,
+        const ntca::GetServiceNameOptions&  options,
+        const ntci::GetServiceNameCallback& callback) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error getEndpoint(const bslstl::StringRef&         text,
+                            const ntca::GetEndpointOptions&  options,
+                            const ntci::GetEndpointCallback& callback) override
+    {
+        if (d_getEndpoint_error.isNull()) {
+            UNEXPECTED_CALL();
+        }
+        if (d_getEndpoint_text.has_value()) {
+            NTCCFG_TEST_EQ(text, d_getEndpoint_text.value());
+            d_getEndpoint_text.reset();
+        }
+        if (d_getEndpoint_options.has_value()) {
+            NTCCFG_TEST_EQ(options, d_getEndpoint_options.value());
+            d_getEndpoint_options.reset();
+        }
+        NTCCFG_TEST_FALSE(d_getEndpoint_callback.has_value());
+        d_getEndpoint_callback = callback;
+
+        const auto res = d_getEndpoint_error.value();
+        d_getEndpoint_error.reset();
+        return res;
+    }
+    ntsa::Error getLocalIpAddress(
+        bsl::vector<ntsa::IpAddress>* result,
+        const ntsa::IpAddressOptions& options) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error getHostname(bsl::string* result) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error getHostnameFullyQualified(bsl::string* result) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    bsl::shared_ptr<ntci::Strand> createStrand(
+        bslma::Allocator* basicAllocator) override
+    {
+        UNEXPECTED_CALL();
+        return bsl::shared_ptr<ntci::Strand>();
+    }
+    bsl::shared_ptr<ntci::Timer> createTimer(
+        const ntca::TimerOptions&                  options,
+        const bsl::shared_ptr<ntci::TimerSession>& session,
+        bslma::Allocator*                          basicAllocator) override
+    {
+        UNEXPECTED_CALL();
+        return bsl::shared_ptr<ntci::Timer>();
+    }
+    bsl::shared_ptr<ntci::Timer> createTimer(
+        const ntca::TimerOptions&  options,
+        const ntci::TimerCallback& callback,
+        bslma::Allocator*          basicAllocator) override
+    {
+        UNEXPECTED_CALL();
+        return bsl::shared_ptr<ntci::Timer>();
+    }
+    bsls::TimeInterval currentTime() const override
+    {
+        UNEXPECTED_CALL();
+        return bsls::TimeInterval();
+    }
+
+    // auxilary functions
+    void set_getEndpoint_WillOnceReturn(
+        const bdlb::NullableValue<bslstl::StringRef>&        text,
+        const bdlb::NullableValue<ntca::GetEndpointOptions>& options,
+        ntsa::Error                                          error)
+    {
+        d_getEndpoint_text    = text;
+        d_getEndpoint_options = options;
+        d_getEndpoint_error   = error;
+    }
+
+  private:
+    bsl::shared_ptr<ntci::Strand> dummyStrand;
+
+    bdlb::NullableValue<bslstl::StringRef>         d_getEndpoint_text;
+    bdlb::NullableValue<ntca::GetEndpointOptions>  d_getEndpoint_options;
+    bdlb::NullableValue<ntci::GetEndpointCallback> d_getEndpoint_callback;
+    bdlb::NullableValue<ntsa::Error>               d_getEndpoint_error;
+};
+
+class BufferFactoryMock : public bdlbb::BlobBufferFactory
+{
+  public:
+    void allocate(bdlbb::BlobBuffer* buffer) override
+    {
+        UNEXPECTED_CALL();
+    }
+};
+
+class StreamSocketMock : public ntsi::StreamSocket
+{
+  public:
+    ntsa::Handle handle() const override
+    {
+        UNEXPECTED_CALL();
+        return 0;
+    }
+    ntsa::Error open(ntsa::Transport::Value transport) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error acquire(ntsa::Handle handle) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Handle release() override
+    {
+        UNEXPECTED_CALL();
+        return 0;
+    }
+};
+
+class DataPoolMock : public ntci::DataPool
+{
+  public:
+    bsl::shared_ptr<ntsa::Data> createIncomingData() override
+    {
+        UNEXPECTED_CALL();
+        return bsl::shared_ptr<ntsa::Data>();
+    }
+    bsl::shared_ptr<ntsa::Data> createOutgoingData() override
+    {
+        if (d_outgoingData.isNull()) {
+            UNEXPECTED_CALL();
+        }
+        return d_outgoingData.value();
+    }
+    bsl::shared_ptr<bdlbb::Blob> createIncomingBlob() override
+    {
+        if (d_incomingBlobBuffer.isNull()) {
+            UNEXPECTED_CALL();
+        }
+        return d_incomingBlobBuffer.value();
+    }
+    bsl::shared_ptr<bdlbb::Blob> createOutgoingBlob() override
+    {
+        if (d_outgoingBlobBuffer.isNull()) {
+            UNEXPECTED_CALL();
+        }
+        return d_outgoingBlobBuffer.value();
+    }
+    void createIncomingBlobBuffer(bdlbb::BlobBuffer* blobBuffer) override
+    {
+        UNEXPECTED_CALL();
+    }
+    void createOutgoingBlobBuffer(bdlbb::BlobBuffer* blobBuffer) override
+    {
+        UNEXPECTED_CALL();
+    }
+    const bsl::shared_ptr<bdlbb::BlobBufferFactory>& incomingBlobBufferFactory()
+        const override
+    {
+        UNEXPECTED_CALL();
+        return dummyBlobBufferFactory;
+    }
+    const bsl::shared_ptr<bdlbb::BlobBufferFactory>& outgoingBlobBufferFactory()
+        const override
+    {
+        UNEXPECTED_CALL();
+        return dummyBlobBufferFactory;
+    }
+
+    // auxilary functions
+
+    void set_createIncomingBlobBuffer_WillAlwaysReturn(
+        const bsl::shared_ptr<bdlbb::Blob>& blob)
+    {
+        d_incomingBlobBuffer = blob;
+    }
+
+    void set_createOutgoingBlobBuffer_WillAlwaysReturn(
+        const bsl::shared_ptr<bdlbb::Blob>& blob)
+    {
+        d_outgoingBlobBuffer = blob;
+    }
+
+    void set_createOutgoingData_WillAlwaysReturn(
+        bsl::shared_ptr<ntsa::Data> data)
+    {
+        d_outgoingData = data;
+    }
+
+  private:
+    bsl::shared_ptr<bdlbb::BlobBufferFactory>          dummyBlobBufferFactory;
+    bdlb::NullableValue<bsl::shared_ptr<bdlbb::Blob> > d_incomingBlobBuffer;
+    bdlb::NullableValue<bsl::shared_ptr<bdlbb::Blob> > d_outgoingBlobBuffer;
+    bdlb::NullableValue<bsl::shared_ptr<ntsa::Data> >  d_outgoingData;
+};
+
+class ReactorMock : public ntci::Reactor
+{
+  public:
+    bsl::shared_ptr<ntci::DatagramSocket> createDatagramSocket(
+        const ntca::DatagramSocketOptions& options,
+        bslma::Allocator*                  basicAllocator) override
+    {
+        UNEXPECTED_CALL();
+        return bsl::shared_ptr<ntci::DatagramSocket>();
+    }
+    bsl::shared_ptr<ntsa::Data> createIncomingData() override
+    {
+        UNEXPECTED_CALL();
+        return bsl::shared_ptr<ntsa::Data>();
+    }
+    bsl::shared_ptr<ntsa::Data> createOutgoingData() override
+    {
+        UNEXPECTED_CALL();
+        return bsl::shared_ptr<ntsa::Data>();
+    }
+    bsl::shared_ptr<bdlbb::Blob> createIncomingBlob() override
+    {
+        UNEXPECTED_CALL();
+        return bsl::shared_ptr<bdlbb::Blob>();
+    }
+    bsl::shared_ptr<bdlbb::Blob> createOutgoingBlob() override
+    {
+        UNEXPECTED_CALL();
+        return bsl::shared_ptr<bdlbb::Blob>();
+    }
+    void createIncomingBlobBuffer(bdlbb::BlobBuffer* blobBuffer) override
+    {
+        UNEXPECTED_CALL();
+    }
+    void createOutgoingBlobBuffer(bdlbb::BlobBuffer* blobBuffer) override
+    {
+        UNEXPECTED_CALL();
+    }
+    const bsl::shared_ptr<bdlbb::BlobBufferFactory>& incomingBlobBufferFactory()
+        const override
+    {
+        if (d_incomingBlobBufferFactory.isNull()) {
+            UNEXPECTED_CALL();
+        }
+        return d_incomingBlobBufferFactory.value();
+    }
+    const bsl::shared_ptr<bdlbb::BlobBufferFactory>& outgoingBlobBufferFactory()
+        const override
+    {
+        if (d_outgoingBlobBufferFactory.isNull()) {
+            UNEXPECTED_CALL();
+        }
+        return d_outgoingBlobBufferFactory.value();
+    }
+    ntci::Waiter registerWaiter(
+        const ntca::WaiterOptions& waiterOptions) override
+    {
+        UNEXPECTED_CALL();
+        return nullptr;
+    }
+    void deregisterWaiter(ntci::Waiter waiter) override
+    {
+        UNEXPECTED_CALL();
+    }
+    void run(ntci::Waiter waiter) override
+    {
+        UNEXPECTED_CALL();
+    }
+    void poll(ntci::Waiter waiter) override
+    {
+        UNEXPECTED_CALL();
+    }
+    void interruptOne() override
+    {
+        UNEXPECTED_CALL();
+    }
+    void interruptAll() override
+    {
+        UNEXPECTED_CALL();
+    }
+    void stop() override
+    {
+        UNEXPECTED_CALL();
+    }
+    void restart() override
+    {
+        UNEXPECTED_CALL();
+    }
+    void execute(const Functor& functor) override
+    {
+        if (!d_executeExpected) {
+            UNEXPECTED_CALL();
+        }
+        d_executeExpected = false;
+        NTCCFG_TEST_FALSE(d_execute_functor.has_value());
+        d_execute_functor = functor;
+    }
+    void moveAndExecute(FunctorSequence* functorSequence,
+                        const Functor&   functor) override
+    {
+        UNEXPECTED_CALL();
+    }
+    bsl::shared_ptr<ntci::ListenerSocket> createListenerSocket(
+        const ntca::ListenerSocketOptions& options,
+        bslma::Allocator*                  basicAllocator) override
+    {
+        UNEXPECTED_CALL();
+        return bsl::shared_ptr<ntci::ListenerSocket>();
+    }
+    ntsa::Error attachSocket(
+        const bsl::shared_ptr<ntci::ReactorSocket>& socket) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error attachSocket(ntsa::Handle handle) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error showReadable(
+        const bsl::shared_ptr<ntci::ReactorSocket>& socket,
+        const ntca::ReactorEventOptions&            options) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error showReadable(
+        ntsa::Handle                      handle,
+        const ntca::ReactorEventOptions&  options,
+        const ntci::ReactorEventCallback& callback) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error showWritable(
+        const bsl::shared_ptr<ntci::ReactorSocket>& socket,
+        const ntca::ReactorEventOptions&            options) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error showWritable(
+        ntsa::Handle                      handle,
+        const ntca::ReactorEventOptions&  options,
+        const ntci::ReactorEventCallback& callback) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error showError(const bsl::shared_ptr<ntci::ReactorSocket>& socket,
+                          const ntca::ReactorEventOptions& options) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error showError(ntsa::Handle                      handle,
+                          const ntca::ReactorEventOptions&  options,
+                          const ntci::ReactorEventCallback& callback) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error hideReadable(
+        const bsl::shared_ptr<ntci::ReactorSocket>& socket) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error hideReadable(ntsa::Handle handle) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error hideWritable(
+        const bsl::shared_ptr<ntci::ReactorSocket>& socket) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error hideWritable(ntsa::Handle handle) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error hideError(
+        const bsl::shared_ptr<ntci::ReactorSocket>& socket) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error hideError(ntsa::Handle handle) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error detachSocket(
+        const bsl::shared_ptr<ntci::ReactorSocket>& socket) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error detachSocket(ntsa::Handle handle) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error closeAll() override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    void incrementLoad(const ntca::LoadBalancingOptions& options) override
+    {
+        UNEXPECTED_CALL();
+    }
+    void decrementLoad(const ntca::LoadBalancingOptions& options) override
+    {
+        UNEXPECTED_CALL();
+    }
+    void drainFunctions() override
+    {
+        UNEXPECTED_CALL();
+    }
+    void clearFunctions() override
+    {
+        UNEXPECTED_CALL();
+    }
+    void clearTimers() override
+    {
+        UNEXPECTED_CALL();
+    }
+    void clearSockets() override
+    {
+        UNEXPECTED_CALL();
+    }
+    void clear() override
+    {
+        UNEXPECTED_CALL();
+    }
+    size_t numSockets() const override
+    {
+        UNEXPECTED_CALL();
+        return 0;
+    }
+    size_t maxSockets() const override
+    {
+        UNEXPECTED_CALL();
+        return 0;
+    }
+    size_t numTimers() const override
+    {
+        UNEXPECTED_CALL();
+        return 0;
+    }
+    size_t maxTimers() const override
+    {
+        UNEXPECTED_CALL();
+        return 0;
+    }
+    bool autoAttach() const override
+    {
+        UNEXPECTED_CALL();
+        return false;
+    }
+    bool autoDetach() const override
+    {
+        UNEXPECTED_CALL();
+        return false;
+    }
+    bool oneShot() const override
+    {
+        if (d_oneShot.isNull()) {
+            UNEXPECTED_CALL();
+        }
+        return d_oneShot.value();
+    }
+    ntca::ReactorEventTrigger::Value trigger() const override
+    {
+        UNEXPECTED_CALL();
+        return ntca::ReactorEventTrigger::e_LEVEL;
+    }
+    size_t load() const override
+    {
+        UNEXPECTED_CALL();
+        return 0;
+    }
+    bslmt::ThreadUtil::Handle threadHandle() const override
+    {
+        UNEXPECTED_CALL();
+        return BloombergLP::bslmt::ThreadUtil::Handle();
+    }
+    size_t threadIndex() const override
+    {
+        UNEXPECTED_CALL();
+        return 0;
+    }
+    bool empty() const override
+    {
+        UNEXPECTED_CALL();
+        return false;
+    }
+    const bsl::shared_ptr<ntci::DataPool>& dataPool() const override
+    {
+        if (d_dataPool.isNull()) {
+            UNEXPECTED_CALL();
+        }
+        return d_dataPool.value();
+    }
+    bool supportsOneShot(bool oneShot) const override
+    {
+        UNEXPECTED_CALL();
+        return false;
+    }
+    bool supportsTrigger(
+        ntca::ReactorEventTrigger::Value trigger) const override
+    {
+        UNEXPECTED_CALL();
+        return false;
+    }
+    bsl::shared_ptr<ntci::Reactor> acquireReactor(
+        const ntca::LoadBalancingOptions& options) override
+    {
+        UNEXPECTED_CALL();
+        return bsl::shared_ptr<ntci::Reactor>();
+    }
+    void releaseReactor(const bsl::shared_ptr<ntci::Reactor>& reactor,
+                        const ntca::LoadBalancingOptions&     options) override
+    {
+        UNEXPECTED_CALL();
+    }
+    bool acquireHandleReservation() override
+    {
+        UNEXPECTED_CALL();
+        return false;
+    }
+    void releaseHandleReservation() override
+    {
+        UNEXPECTED_CALL();
+    }
+    size_t numReactors() const override
+    {
+        UNEXPECTED_CALL();
+        return 0;
+    }
+    size_t numThreads() const override
+    {
+        UNEXPECTED_CALL();
+        return 0;
+    }
+    size_t minThreads() const override
+    {
+        UNEXPECTED_CALL();
+        return 0;
+    }
+    size_t maxThreads() const override
+    {
+        if (d_maxThreads.isNull()) {
+            UNEXPECTED_CALL();
+        }
+        return d_maxThreads.value();
+    }
+    bsl::shared_ptr<ntci::Strand> createStrand(
+        bslma::Allocator* basicAllocator) override
+    {
+        UNEXPECTED_CALL();
+        return bsl::shared_ptr<ntci::Strand>();
+    }
+    bsl::shared_ptr<ntci::StreamSocket> createStreamSocket(
+        const ntca::StreamSocketOptions& options,
+        bslma::Allocator*                basicAllocator) override
+    {
+        UNEXPECTED_CALL();
+        return bsl::shared_ptr<ntci::StreamSocket>();
+    }
+    bsl::shared_ptr<ntci::Timer> createTimer(
+        const ntca::TimerOptions&                  options,
+        const bsl::shared_ptr<ntci::TimerSession>& session,
+        bslma::Allocator*                          basicAllocator) override
+    {
+        if (d_timer.isNull()) {
+            UNEXPECTED_CALL();
+        }
+        const auto timer = d_timer.value();
+        d_timer->clear();
+        return timer;
+    }
+    bsl::shared_ptr<ntci::Timer> createTimer(
+        const ntca::TimerOptions&  options,
+        const ntci::TimerCallback& callback,
+        bslma::Allocator*          basicAllocator) override
+    {
+        if (d_timer.isNull()) {
+            UNEXPECTED_CALL();
+        }
+
+        NTCCFG_TEST_TRUE(d_timerCallback.isNull());
+        d_timerCallback = callback;
+
+        const auto timer = d_timer.value();
+        d_timer.reset();
+        return timer;
+    }
+    const bsl::shared_ptr<ntci::Strand>& strand() const override
+    {
+        UNEXPECTED_CALL();
+        return dummyStrand;
+    }
+    bsls::TimeInterval currentTime() const override
+    {
+        UNEXPECTED_CALL();
+        return bsls::TimeInterval();
+    }
+
+    // auxilary methods
+    void set_dataPool_WillAlwaysReturn(
+        const bsl::shared_ptr<ntci::DataPool>& dataPool)
+    {
+        d_dataPool = dataPool;
+    }
+
+    void set_outgoingBlobBufferFactory_WillAlwaysReturn(
+        bsl::shared_ptr<bdlbb::BlobBufferFactory> bufferFactory)
+    {
+        d_outgoingBlobBufferFactory = bufferFactory;
+    }
+
+    void set_incomingBlobBufferFactory_WillAlwaysReturn(
+        bsl::shared_ptr<bdlbb::BlobBufferFactory> bufferFactory)
+    {
+        d_incomingBlobBufferFactory = bufferFactory;
+    }
+
+    void set_oneShot_WillAlwaysReturn(bool flag)
+    {
+        d_oneShot = flag;
+    }
+
+    void set_maxThreads_WillAlwaysReturn(size_t val)
+    {
+        d_maxThreads = val;
+    }
+
+    void set_createTimer_WillOnceReturn(
+        const bsl::shared_ptr<ntci::Timer>& timer)
+    {
+        d_timer = timer;
+    }
+
+    void set_execute_expectedOnce()
+    {
+        d_executeExpected = true;
+    }
+
+    ntci::TimerCallback extract_timerCallback()
+    {
+        NTCCFG_TEST_TRUE(d_timerCallback.has_value());
+        const auto res = d_timerCallback.value();
+        d_timerCallback.reset();
+        return res;
+    }
+
+    ntci::Reactor::Functor extract_execute_functor()
+    {
+        ntci::Reactor::Functor res = d_execute_functor.value();
+        d_execute_functor.reset();
+        return res;
+    }
+
+  private:
+    bdlb::NullableValue<bsl::shared_ptr<bdlbb::BlobBufferFactory> >
+        d_incomingBlobBufferFactory;
+    bdlb::NullableValue<bsl::shared_ptr<bdlbb::BlobBufferFactory> >
+                                  d_outgoingBlobBufferFactory;
+    bsl::shared_ptr<ntci::Strand> dummyStrand;
+    bdlb::NullableValue<bsl::shared_ptr<ntci::DataPool> > d_dataPool;
+    bdlb::NullableValue<bool>                             d_oneShot;
+    bdlb::NullableValue<size_t>                           d_maxThreads;
+    bdlb::NullableValue<bsl::shared_ptr<ntci::Timer> >    d_timer;
+    bdlb::NullableValue<ntci::TimerCallback>              d_timerCallback;
+    bool                                                  d_executeExpected;
+    bdlb::NullableValue<ntci::Reactor::Functor>           d_execute_functor;
+};
+
+class TimerMock : public ntci::Timer
+{
+  public:
+    ntsa::Error schedule(const bsls::TimeInterval& deadline,
+                         const bsls::TimeInterval& period) override
+    {
+        if (d_scheduleReturn_error.isNull()) {
+            UNEXPECTED_CALL();
+        }
+        if (d_scheduleArg_deadline.has_value()) {
+            NTCCFG_TEST_EQ(deadline, d_scheduleArg_deadline.value());
+            d_scheduleArg_deadline.reset();
+        }
+        if (d_scheduleArg_period.has_value()) {
+            NTCCFG_TEST_EQ(period, d_scheduleArg_period.value());
+            d_scheduleArg_period.reset();
+        }
+        const auto error = d_scheduleReturn_error.value();
+        d_scheduleReturn_error.reset();
+
+        return error;
+    }
+    ntsa::Error cancel() override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error close() override
+    {
+        if (d_close_error.isNull()) {
+            UNEXPECTED_CALL();
+        }
+        const auto res = d_close_error.value();
+        d_close_error.reset();
+        return res;
+    }
+    void arrive(const bsl::shared_ptr<ntci::Timer>& self,
+                const bsls::TimeInterval&           now,
+                const bsls::TimeInterval&           deadline) override
+    {
+        UNEXPECTED_CALL();
+    }
+    void* handle() const override
+    {
+        UNEXPECTED_CALL();
+        return nullptr;
+    }
+    int id() const override
+    {
+        UNEXPECTED_CALL();
+        return 0;
+    }
+    bool oneShot() const override
+    {
+        UNEXPECTED_CALL();
+        return false;
+    }
+    bslmt::ThreadUtil::Handle threadHandle() const override
+    {
+        UNEXPECTED_CALL();
+        return BloombergLP::bslmt::ThreadUtil::Handle();
+    }
+    size_t threadIndex() const override
+    {
+        UNEXPECTED_CALL();
+        return 0;
+    }
+    const bsl::shared_ptr<ntci::Strand>& strand() const override
+    {
+        UNEXPECTED_CALL();
+        return dummyStrand;
+    }
+    bsls::TimeInterval currentTime() const override
+    {
+        UNEXPECTED_CALL();
+        return bsls::TimeInterval();
+    }
+
+    void set_schedule_willOnceReturn(
+        const bdlb::NullableValue<bsls::TimeInterval>& deadline,
+        const bdlb::NullableValue<bsls::TimeInterval>& period,
+        ntsa::Error                                    error)
+    {
+        d_scheduleArg_deadline = deadline;
+        d_scheduleArg_period   = period;
+        d_scheduleReturn_error = error;
+    }
+
+    void set_close_WillOnceReturn(const ntsa::Error& error)
+    {
+        d_close_error = error;
+    }
+
+  private:
+    bsl::shared_ptr<ntci::Strand> dummyStrand;
+
+    bdlb::NullableValue<bsls::TimeInterval> d_scheduleArg_deadline;
+    bdlb::NullableValue<bsls::TimeInterval> d_scheduleArg_period;
+    bdlb::NullableValue<ntsa::Error>        d_scheduleReturn_error;
+    bdlb::NullableValue<ntsa::Error>        d_close_error;
+};
+
+}  // close namespace mock
 
 }  // close namespace test
 
@@ -3347,6 +4255,114 @@ NTCCFG_TEST_CASE(21)
 #endif
 }
 
+NTCCFG_TEST_CASE(22)
+{
+    NTCI_LOG_CONTEXT();
+
+    ntccfg::TestAllocator ta;
+    {
+        NTCI_LOG_DEBUG("Fixture setup, socket creation...");
+
+        bdlb::NullableValue<ntca::ConnectEvent> connectResult;
+
+        bsl::shared_ptr<ntci::ReactorPool> nullPool;
+        bsl::shared_ptr<ntcs::Metrics>     nullMetrics;
+        bsl::shared_ptr<bdlbb::Blob>       nullBlob;
+        bsl::shared_ptr<ntci::Strand>      nullStrand;
+
+        bsl::shared_ptr<ntsa::Data> dummyData;
+        dummyData.createInplace(&ta);
+
+        bsl::shared_ptr<test::mock::ResolverMock> resolverMock;
+        resolverMock.createInplace(&ta);
+
+        bsl::shared_ptr<test::mock::ReactorMock> reactorMock;
+        reactorMock.createInplace(&ta);
+
+        bsl::shared_ptr<test::mock::StreamSocketMock> socketMock;
+        socketMock.createInplace(&ta);
+
+        bsl::shared_ptr<test::mock::DataPoolMock> dataPoolMock;
+        dataPoolMock.createInplace(&ta);
+        reactorMock->set_dataPool_WillAlwaysReturn(dataPoolMock);
+
+        bsl::shared_ptr<test::mock::BufferFactoryMock> bufferFactoryMock;
+        bufferFactoryMock.createInplace(&ta);
+        reactorMock->set_outgoingBlobBufferFactory_WillAlwaysReturn(
+            bufferFactoryMock);
+        reactorMock->set_incomingBlobBufferFactory_WillAlwaysReturn(
+            bufferFactoryMock);
+
+        reactorMock->set_oneShot_WillAlwaysReturn(false);
+        reactorMock->set_maxThreads_WillAlwaysReturn(1);
+
+        dataPoolMock->set_createIncomingBlobBuffer_WillAlwaysReturn(nullBlob);
+        dataPoolMock->set_createOutgoingBlobBuffer_WillAlwaysReturn(nullBlob);
+        dataPoolMock->set_createOutgoingData_WillAlwaysReturn(dummyData);
+
+        const ntca::StreamSocketOptions options;
+
+        ntcr::StreamSocket socket(options,
+                                  resolverMock,
+                                  reactorMock,
+                                  nullPool,
+                                  nullMetrics,
+                                  &ta);
+
+        NTCI_LOG_DEBUG("Connection initiation...");
+
+        bsl::shared_ptr<test::mock::TimerMock> connectRetryTimerMock;
+        connectRetryTimerMock.createInplace(&ta);
+        reactorMock->set_createTimer_WillOnceReturn(connectRetryTimerMock);
+
+        connectRetryTimerMock->set_schedule_willOnceReturn(
+            bdlb::NullOptType::makeInitialValue(),
+            bdlb::NullOptType::makeInitialValue(),
+            ntsa::Error());
+
+        const ntci::ConnectFunction connectCallback =
+            [&connectResult](const bsl::shared_ptr<ntci::Connector>& connector,
+                             const ntca::ConnectEvent&               event) {
+                NTCCFG_TEST_FALSE(connectResult.has_value());
+                connectResult = event;
+            };
+
+        const ntca::ConnectOptions connectOptions;
+
+        const bsl::string epName = "unreachable.bbg.com";
+
+        socket.connect(epName, connectOptions, connectCallback);
+
+        NTCI_LOG_DEBUG("Trigger internal timer to initiate connection...");
+
+        resolverMock->set_getEndpoint_WillOnceReturn(
+            epName,
+            bdlb::NullOptType::makeInitialValue(),
+            ntsa::Error());
+
+        const auto       timerCallback = reactorMock->extract_timerCallback();
+        ntca::TimerEvent timerEvent;
+        timerEvent.setType(ntca::TimerEventType::e_DEADLINE);
+        timerCallback(connectRetryTimerMock, timerEvent, nullStrand);
+
+        NTCI_LOG_DEBUG("Shutdown socket while it is waiting for remote "
+                       "endpoint resolution");
+
+        connectRetryTimerMock->set_close_WillOnceReturn(ntsa::Error());
+        reactorMock->set_execute_expectedOnce();
+
+        socket.shutdown(ntsa::ShutdownType::e_BOTH,
+                        ntsa::ShutdownMode::e_GRACEFUL);
+
+        const auto callback = reactorMock->extract_execute_functor();
+        callback();
+        NTCCFG_TEST_TRUE(connectResult.has_value());
+        NTCCFG_TEST_EQ(connectResult.value().type(),
+                       ntca::ConnectEventType::e_ERROR);
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
 NTCCFG_TEST_DRIVER
 {
     NTCCFG_TEST_REGISTER(1);
@@ -3376,5 +4392,7 @@ NTCCFG_TEST_DRIVER
 
     NTCCFG_TEST_REGISTER(20);
     NTCCFG_TEST_REGISTER(21);
+
+    NTCCFG_TEST_REGISTER(22);
 }
 NTCCFG_TEST_DRIVER_END;

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -2026,8 +2026,7 @@ class ReactorMock : public ntci::Reactor
     NTF_MOCK_METHOD_NEW(void, createIncomingBlobBuffer, bdlbb::BlobBuffer*)
     NTF_MOCK_METHOD_NEW(void, createOutgoingBlobBuffer, bdlbb::BlobBuffer*)
 
-public:
-
+  public:
     const bsl::shared_ptr<bdlbb::BlobBufferFactory>& incomingBlobBufferFactory()
         const override
     {
@@ -2045,7 +2044,9 @@ public:
         return d_outgoingBlobBufferFactory_result.value();
     }
 
-    NTF_MOCK_METHOD_NEW(ntci::Waiter, registerWaiter, const ntca::WaiterOptions&)
+    NTF_MOCK_METHOD_NEW(ntci::Waiter,
+                        registerWaiter,
+                        const ntca::WaiterOptions&)
     NTF_MOCK_METHOD_NEW(void, deregisterWaiter, ntci::Waiter)
     NTF_MOCK_METHOD_NEW(void, run, ntci::Waiter)
     NTF_MOCK_METHOD_NEW(void, poll, ntci::Waiter)
@@ -2054,8 +2055,7 @@ public:
     NTF_MOCK_METHOD_NEW(void, stop)
     NTF_MOCK_METHOD_NEW(void, restart)
 
-public:
-
+  public:
     void execute(const Functor& functor) override
     {
         if (!d_execute_expected) {
@@ -2092,7 +2092,7 @@ public:
         return res;
     }
     NTF_MOCK_METHOD_NEW(ntsa::Error, attachSocket, ntsa::Handle)
-public:
+  public:
     ntsa::Error showReadable(
         const bsl::shared_ptr<ntci::ReactorSocket>& socket,
         const ntca::ReactorEventOptions&            options) override
@@ -2146,47 +2146,24 @@ public:
         UNEXPECTED_CALL();
         return ntsa::Error();
     }
-    NTF_MOCK_METHOD_NEW(ntsa::Error, hideReadable, const bsl::shared_ptr<ntci::ReactorSocket>&)
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        hideReadable,
+                        const bsl::shared_ptr<ntci::ReactorSocket>&)
+    NTF_MOCK_METHOD_NEW(ntsa::Error, hideReadable, ntsa::Handle)
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        hideWritable,
+                        const bsl::shared_ptr<ntci::ReactorSocket>&)
+    NTF_MOCK_METHOD_NEW(ntsa::Error, hideWritable, ntsa::Handle)
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        hideError,
+                        const bsl::shared_ptr<ntci::ReactorSocket>&)
+    NTF_MOCK_METHOD_NEW(ntsa::Error, hideError, ntsa::Handle)
+    NTF_MOCK_METHOD_NEW(ntsa::Error,
+                        detachSocket,
+                        const bsl::shared_ptr<ntci::ReactorSocket>&)
+    NTF_MOCK_METHOD_NEW(ntsa::Error, detachSocket, ntsa::Handle)
 
-public:
-    ntsa::Error hideReadable(ntsa::Handle handle) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error hideWritable(
-        const bsl::shared_ptr<ntci::ReactorSocket>& socket) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error hideWritable(ntsa::Handle handle) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error hideError(
-        const bsl::shared_ptr<ntci::ReactorSocket>& socket) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error hideError(ntsa::Handle handle) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error detachSocket(
-        const bsl::shared_ptr<ntci::ReactorSocket>& socket) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    ntsa::Error detachSocket(ntsa::Handle handle) override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
+  public:
     ntsa::Error detachSocket(
         const bsl::shared_ptr<ntci::ReactorSocket>& socket,
         const ntci::SocketDetachedCallback&         callback) override
@@ -2222,101 +2199,29 @@ public:
         UNEXPECTED_CALL();
         return ntsa::Error();
     }
-    ntsa::Error closeAll() override
-    {
-        UNEXPECTED_CALL();
-        return ntsa::Error();
-    }
-    void incrementLoad(const ntca::LoadBalancingOptions& options) override
-    {
-        UNEXPECTED_CALL();
-    }
-    void decrementLoad(const ntca::LoadBalancingOptions& options) override
-    {
-        UNEXPECTED_CALL();
-    }
-    void drainFunctions() override
-    {
-        UNEXPECTED_CALL();
-    }
-    void clearFunctions() override
-    {
-        UNEXPECTED_CALL();
-    }
-    void clearTimers() override
-    {
-        UNEXPECTED_CALL();
-    }
-    void clearSockets() override
-    {
-        UNEXPECTED_CALL();
-    }
-    void clear() override
-    {
-        UNEXPECTED_CALL();
-    }
-    size_t numSockets() const override
-    {
-        UNEXPECTED_CALL();
-        return 0;
-    }
-    size_t maxSockets() const override
-    {
-        UNEXPECTED_CALL();
-        return 0;
-    }
-    size_t numTimers() const override
-    {
-        UNEXPECTED_CALL();
-        return 0;
-    }
-    size_t maxTimers() const override
-    {
-        UNEXPECTED_CALL();
-        return 0;
-    }
-    bool autoAttach() const override
-    {
-        UNEXPECTED_CALL();
-        return false;
-    }
-    bool autoDetach() const override
-    {
-        UNEXPECTED_CALL();
-        return false;
-    }
-    bool oneShot() const override
-    {
-        if (d_oneShot_result.isNull()) {
-            UNEXPECTED_CALL();
-        }
-        return d_oneShot_result.value();
-    }
-    ntca::ReactorEventTrigger::Value trigger() const override
-    {
-        UNEXPECTED_CALL();
-        return ntca::ReactorEventTrigger::e_LEVEL;
-    }
-    size_t load() const override
-    {
-        UNEXPECTED_CALL();
-        return 0;
-    }
-    bslmt::ThreadUtil::Handle threadHandle() const override
-    {
-        UNEXPECTED_CALL();
-        return BloombergLP::bslmt::ThreadUtil::Handle();
-    }
-    size_t threadIndex() const override
-    {
-        UNEXPECTED_CALL();
-        return 0;
-    }
-    bool empty() const override
-    {
-        UNEXPECTED_CALL();
-        return false;
-    }
+    NTF_MOCK_METHOD_NEW(ntsa::Error, closeAll)
+    NTF_MOCK_METHOD_NEW(void, incrementLoad, const ntca::LoadBalancingOptions&)
+    NTF_MOCK_METHOD_NEW(void, decrementLoad, const ntca::LoadBalancingOptions&)
+
+    NTF_MOCK_METHOD_NEW(void, drainFunctions)
+    NTF_MOCK_METHOD_NEW(void, clearFunctions)
+    NTF_MOCK_METHOD_NEW(void, clearTimers)
+    NTF_MOCK_METHOD_NEW(void, clearSockets)
+    NTF_MOCK_METHOD_NEW(void, clear)
+    NTF_MOCK_METHOD_CONST_NEW(size_t, numSockets)
+    NTF_MOCK_METHOD_CONST_NEW(size_t, maxSockets)
+    NTF_MOCK_METHOD_CONST_NEW(size_t, numTimers)
+    NTF_MOCK_METHOD_CONST_NEW(size_t, maxTimers)
+    NTF_MOCK_METHOD_CONST_NEW(bool, autoAttach)
+    NTF_MOCK_METHOD_CONST_NEW(bool, autoDetach)
+    NTF_MOCK_METHOD_CONST_NEW(bool, oneShot)
+    NTF_MOCK_METHOD_CONST_NEW(ntca::ReactorEventTrigger::Value, trigger)
+    NTF_MOCK_METHOD_CONST_NEW(size_t, load)
+    NTF_MOCK_METHOD_CONST_NEW(bslmt::ThreadUtil::Handle, threadHandle)
+    NTF_MOCK_METHOD_CONST_NEW(size_t, threadIndex)
+    NTF_MOCK_METHOD_CONST_NEW(bool, empty)
+
+  public:
     const bsl::shared_ptr<ntci::DataPool>& dataPool() const override
     {
         if (d_dataPool_result.isNull()) {
@@ -2324,69 +2229,33 @@ public:
         }
         return d_dataPool_result.value();
     }
-    bool supportsOneShot(bool oneShot) const override
-    {
-        UNEXPECTED_CALL();
-        return false;
-    }
-    bool supportsTrigger(
-        ntca::ReactorEventTrigger::Value trigger) const override
-    {
-        UNEXPECTED_CALL();
-        return false;
-    }
-    bsl::shared_ptr<ntci::Reactor> acquireReactor(
-        const ntca::LoadBalancingOptions& options) override
-    {
-        UNEXPECTED_CALL();
-        return bsl::shared_ptr<ntci::Reactor>();
-    }
+
+    NTF_MOCK_METHOD_CONST_NEW(bool, supportsOneShot, bool)
+    NTF_MOCK_METHOD_CONST_NEW(bool,
+                              supportsTrigger,
+                              ntca::ReactorEventTrigger::Value)
+
+    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Reactor>,
+                        acquireReactor,
+                        const ntca::LoadBalancingOptions&)
+  public:
     void releaseReactor(const bsl::shared_ptr<ntci::Reactor>& reactor,
                         const ntca::LoadBalancingOptions&     options) override
     {
         UNEXPECTED_CALL();
     }
-    bool acquireHandleReservation() override
-    {
-        if (d_acquireHandleReservation_result.isNull()) {
-            UNEXPECTED_CALL();
-        }
-        return d_acquireHandleReservation_result.value();
-    }
-    void releaseHandleReservation() override
-    {
-        if (!d_releaseHandleReservation) {
-            UNEXPECTED_CALL();
-        }
-    }
-    size_t numReactors() const override
-    {
-        UNEXPECTED_CALL();
-        return 0;
-    }
-    size_t numThreads() const override
-    {
-        UNEXPECTED_CALL();
-        return 0;
-    }
-    size_t minThreads() const override
-    {
-        UNEXPECTED_CALL();
-        return 0;
-    }
-    size_t maxThreads() const override
-    {
-        if (d_maxThreads_result.isNull()) {
-            UNEXPECTED_CALL();
-        }
-        return d_maxThreads_result.value();
-    }
-    bsl::shared_ptr<ntci::Strand> createStrand(
-        bslma::Allocator* basicAllocator) override
-    {
-        UNEXPECTED_CALL();
-        return bsl::shared_ptr<ntci::Strand>();
-    }
+    NTF_MOCK_METHOD_NEW(bool, acquireHandleReservation)
+    NTF_MOCK_METHOD_NEW(void, releaseHandleReservation)
+
+    NTF_MOCK_METHOD_CONST_NEW(size_t, numReactors)
+    NTF_MOCK_METHOD_CONST_NEW(size_t, numThreads)
+    NTF_MOCK_METHOD_CONST_NEW(size_t, minThreads)
+    NTF_MOCK_METHOD_CONST_NEW(size_t, maxThreads)
+
+    NTF_MOCK_METHOD_NEW(bsl::shared_ptr<ntci::Strand>,
+                        createStrand,
+                        bslma::Allocator*)
+  public:
     bsl::shared_ptr<ntci::StreamSocket> createStreamSocket(
         const ntca::StreamSocketOptions& options,
         bslma::Allocator*                basicAllocator) override
@@ -2417,11 +2286,7 @@ public:
         UNEXPECTED_CALL();
         return dummyStrand;
     }
-    bsls::TimeInterval currentTime() const override
-    {
-        UNEXPECTED_CALL();
-        return bsls::TimeInterval();
-    }
+    NTF_MOCK_METHOD_CONST_NEW(bsls::TimeInterval, currentTime)
 
   public:
     // Helper data structures
@@ -2592,22 +2457,6 @@ public:
         d_incomingBlobBufferFactory_result = bufferFactory;
     }
 
-    void expect_oneShot_WillAlwaysReturn(bool flag)
-    {
-        d_oneShot_result = flag;
-    }
-
-    void expect_maxThreads_WillAlwaysReturn(size_t val)
-    {
-        d_maxThreads_result = val;
-    }
-
-    //    void expect_createTimer_WillOnceReturn(
-    //        const bsl::shared_ptr<ntci::Timer>& timer)
-    //    {
-    //        d_timer_result = timer;
-    //    }
-
     Invocation_createTimer& expect_createTimer(
         const bdlb::NullableValue<ntca::TimerOptions>&  arg1,
         const bdlb::NullableValue<ntci::TimerCallback>& arg2,
@@ -2619,16 +2468,6 @@ public:
     void expect_execute_WillOnceReturn()
     {
         d_execute_expected = true;
-    }
-
-    void expect_acquireHandleReservation_WillAlwaysReturn(bool flag)
-    {
-        d_acquireHandleReservation_result = flag;
-    }
-
-    void expect_releaseHandleReservation_WillAlwaysReturn()
-    {
-        d_releaseHandleReservation = true;
     }
 
     void expect_attachSocket_WillOnceReturn(
@@ -2696,14 +2535,8 @@ public:
                                   d_outgoingBlobBufferFactory_result;
     bsl::shared_ptr<ntci::Strand> dummyStrand;
     bdlb::NullableValue<bsl::shared_ptr<ntci::DataPool> > d_dataPool_result;
-    bdlb::NullableValue<bool>                             d_oneShot_result;
-    bdlb::NullableValue<size_t>                           d_maxThreads_result;
-    //    bdlb::NullableValue<bsl::shared_ptr<ntci::Timer> >    d_timer_result;
-    //    bdlb::NullableValue<ntci::TimerCallback>              d_timerCallback;
-    bool                                        d_execute_expected;
-    bdlb::NullableValue<ntci::Reactor::Functor> d_execute_functor;
-    bdlb::NullableValue<bool> d_acquireHandleReservation_result;
-    bool                      d_releaseHandleReservation;
+    bool                                                  d_execute_expected;
+    bdlb::NullableValue<ntci::Reactor::Functor>           d_execute_functor;
 
     bdlb::NullableValue<bsl::shared_ptr<ntci::ReactorSocket> >
                                      d_attachSocket_arg1;
@@ -4914,8 +4747,8 @@ NTCCFG_TEST_CASE(22)
         reactorMock->expect_incomingBlobBufferFactory_WillAlwaysReturn(
             bufferFactoryMock);
 
-        reactorMock->expect_oneShot_WillAlwaysReturn(false);
-        reactorMock->expect_maxThreads_WillAlwaysReturn(1);
+        NTF_EXPECT_0(*reactorMock, oneShot).ALWAYS().RETURN(false);
+        NTF_EXPECT_0(*reactorMock, maxThreads).ALWAYS().RETURN(1);
 
         NTF_EXPECT_0(*dataPoolMock, createIncomingBlob)
             .ALWAYS()
@@ -4980,8 +4813,10 @@ NTCCFG_TEST_CASE(22)
         socketMock->expect_maxBuffersPerSend().willOnce().willReturn(22);
         socketMock->expect_maxBuffersPerReceive().willOnce().willReturn(22);
 
-        reactorMock->expect_acquireHandleReservation_WillAlwaysReturn(true);
-        reactorMock->expect_releaseHandleReservation_WillAlwaysReturn();
+        NTF_EXPECT_0(*reactorMock, acquireHandleReservation)
+            .ALWAYS()
+            .RETURN(true);
+        NTF_EXPECT_0(*reactorMock, releaseHandleReservation).ALWAYS();
 
         socket->open(ntsa::Transport::e_TCP_IPV4_STREAM, socketMock);
 
@@ -5091,8 +4926,8 @@ NTCCFG_TEST_CASE(23)
         reactorMock->expect_incomingBlobBufferFactory_WillAlwaysReturn(
             bufferFactoryMock);
 
-        reactorMock->expect_oneShot_WillAlwaysReturn(false);
-        reactorMock->expect_maxThreads_WillAlwaysReturn(1);
+        NTF_EXPECT_0(*reactorMock, oneShot).ALWAYS().RETURN(false);
+        NTF_EXPECT_0(*reactorMock, maxThreads).ALWAYS().RETURN(1);
 
         NTF_EXPECT_0(*dataPoolMock, createIncomingBlob)
             .ALWAYS()
@@ -5157,8 +4992,10 @@ NTCCFG_TEST_CASE(23)
         socketMock->expect_maxBuffersPerSend().willOnce().willReturn(22);
         socketMock->expect_maxBuffersPerReceive().willOnce().willReturn(22);
 
-        reactorMock->expect_acquireHandleReservation_WillAlwaysReturn(true);
-        reactorMock->expect_releaseHandleReservation_WillAlwaysReturn();
+        NTF_EXPECT_0(*reactorMock, acquireHandleReservation)
+            .ALWAYS()
+            .RETURN(true);
+        NTF_EXPECT_0(*reactorMock, releaseHandleReservation).ALWAYS();
 
         socket->open(ntsa::Transport::e_TCP_IPV4_STREAM, socketMock);
 
@@ -5280,8 +5117,8 @@ NTCCFG_TEST_CASE(24)
         reactorMock->expect_incomingBlobBufferFactory_WillAlwaysReturn(
             bufferFactoryMock);
 
-        reactorMock->expect_oneShot_WillAlwaysReturn(false);
-        reactorMock->expect_maxThreads_WillAlwaysReturn(1);
+        NTF_EXPECT_0(*reactorMock, oneShot).ALWAYS().RETURN(false);
+        NTF_EXPECT_0(*reactorMock, maxThreads).ALWAYS().RETURN(1);
 
         NTF_EXPECT_0(*dataPoolMock, createIncomingBlob)
             .ALWAYS()
@@ -5355,8 +5192,10 @@ NTCCFG_TEST_CASE(24)
 
         NTCI_LOG_DEBUG("Trigger internal timer to initiate connection...");
 
-        reactorMock->expect_acquireHandleReservation_WillAlwaysReturn(true);
-        reactorMock->expect_releaseHandleReservation_WillAlwaysReturn();
+        NTF_EXPECT_0(*reactorMock, acquireHandleReservation)
+            .ALWAYS()
+            .RETURN(true);
+        NTF_EXPECT_0(*reactorMock, releaseHandleReservation).ALWAYS();
         reactorMock->expect_attachSocket_WillOnceReturn(socket, ntsa::Error());
         reactorMock->expect_showWritable_WillOnceReturn(socket, ntsa::Error());
 

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -3842,6 +3842,10 @@ NTCCFG_TEST_CASE(21)
 
 NTCCFG_TEST_CASE(22)
 {
+    // Concern: shutdown socket while it is waiting for remote EP resolution
+    // 1) Create ntcr::StreamSocket
+    // 2) Initiate connection to remote name
+    // 3) Shutdown socket while waiting for remote EP resolution
     NTCI_LOG_CONTEXT();
 
     ntccfg::TestAllocator ta;
@@ -3959,6 +3963,13 @@ NTCCFG_TEST_CASE(22)
 
 NTCCFG_TEST_CASE(23)
 {
+    // Concern: shutdown socket while it is waiting for connection attempt
+    // result, no connection deadline timer
+    // 1) Create ntcr::StreamSocket
+    // 2) Initiate connection to some IP, no connection retries planned,
+    // no deadline time is set
+    // 3) Expect ntsi::StreamSocket::connect() to be called, then ->
+    // 4) Trigger socket shutdown
     NTCI_LOG_CONTEXT();
 
     ntccfg::TestAllocator ta;
@@ -4099,6 +4110,13 @@ NTCCFG_TEST_CASE(23)
 
 NTCCFG_TEST_CASE(24)
 {
+    // Concern: shutdown socket while it is waiting for connection attempt
+    // result, connection deadline timer is set
+    // 1) Create ntcr::StreamSocket
+    // 2) Initiate connection to some IP, no connection retries planned,
+    // deadline time is set
+    // 3) Expect ntsi::StreamSocket::connect() to be called, then ->
+    // 4) Trigger socket shutdown
     NTCI_LOG_CONTEXT();
 
     ntccfg::TestAllocator ta;
@@ -4267,6 +4285,14 @@ NTCCFG_TEST_CASE(24)
 
 NTCCFG_TEST_CASE(25)
 {
+    // Concern: shutdown socket while it is waiting for connection re-attempt
+    // 1) Create ntcr::StreamSocket
+    // 2) Initiate connection to some IP, some connection retries are planned
+    // 3) Expect ntsi::StreamSocket::connect() to be called, then ->
+    // 4) Indicate response from the reactor by calling processSocketWritable
+    // method, and then remoteEndpoint method should indicate an error
+    // 5) Shutdown socket
+
     NTCI_LOG_CONTEXT();
 
     ntccfg::TestAllocator ta;
@@ -4453,6 +4479,17 @@ NTCCFG_TEST_CASE(25)
 
 NTCCFG_TEST_CASE(26)
 {
+    // Concern: shutdown socket while it is being detached and conection
+    // retries are possible
+    // 1) Create ntcr::StreamSocket
+    // 2) Initiate connection to some IP, some connection retries are planned
+    // 3) Expect ntsi::StreamSocket::connect() to be called, then ->
+    // 4) Indicate response from the reactor by calling processSocketWritable
+    // method, and then remoteEndpoint method should indicate an error
+    // 5) Expect that reactor should detach socket ->
+    // 6) Shutdown socket (current implementation postpones the procedure)
+    // 7) Indicate that socket is detached
+
     NTCI_LOG_CONTEXT();
 
     ntccfg::TestAllocator ta;
@@ -4655,6 +4692,16 @@ NTCCFG_TEST_CASE(26)
 
 NTCCFG_TEST_CASE(27)
 {
+    // Concern: shutdown socket while it is being detached, no connection
+    // retries are possible
+    // 1) Create ntcr::StreamSocket
+    // 2) Initiate connection to some IP
+    // 3) Expect ntsi::StreamSocket::connect() to be called, then ->
+    // 4) Indicate response from the reactor by calling processSocketWritable
+    // method, and then remoteEndpoint method should indicate an error
+    // 5) Expect that reactor should detach socket ->
+    // 6) Shutdown socket (current implementation postpones the procedure)
+    // 7) Indicate that socket is detached
     NTCI_LOG_CONTEXT();
 
     ntccfg::TestAllocator ta;

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1593,8 +1593,7 @@ class StreamSocketMock : public ntsi::StreamSocket
   public:
     ntsa::Handle handle() const override
     {
-        UNEXPECTED_CALL();
-        return 0;
+        return d_invocation_handle.invoke();
     }
     ntsa::Error open(ntsa::Transport::Value transport) override
     {
@@ -1611,6 +1610,1007 @@ class StreamSocketMock : public ntsi::StreamSocket
         UNEXPECTED_CALL();
         return 0;
     }
+    ntsa::Error bind(const ntsa::Endpoint& endpoint,
+                     bool                  reuseAddress) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error bindAny(ntsa::Transport::Value transport,
+                        bool                   reuseAddress) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error connect(const ntsa::Endpoint& endpoint) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error send(ntsa::SendContext*       context,
+                     const bdlbb::Blob&       data,
+                     const ntsa::SendOptions& options) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error send(ntsa::SendContext*       context,
+                     const ntsa::Data&        data,
+                     const ntsa::SendOptions& options) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error receive(ntsa::ReceiveContext*       context,
+                        bdlbb::Blob*                data,
+                        const ntsa::ReceiveOptions& options) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error receive(ntsa::ReceiveContext*       context,
+                        ntsa::Data*                 data,
+                        const ntsa::ReceiveOptions& options) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error receiveNotifications(
+        ntsa::NotificationQueue* notifications) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error shutdown(ntsa::ShutdownType::Value direction) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error unlink() override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    ntsa::Error close() override
+    {
+        return d_invocation_close.invoke();
+    }
+    ntsa::Error sourceEndpoint(ntsa::Endpoint* result) const override
+    {
+        return d_invocation_sourceEndpoint.invoke(result);
+    }
+    ntsa::Error remoteEndpoint(ntsa::Endpoint* result) const override
+    {
+        return d_invocation_remoteEndpoint.invoke(result);
+    }
+    ntsa::Error setBlocking(bool blocking) override
+    {
+        return d_invocation_setBlocking.invoke(blocking);
+    }
+    ntsa::Error setOption(const ntsa::SocketOption& option) override
+    {
+        return d_invocation_setOption.invoke(option);
+    }
+    ntsa::Error getOption(ntsa::SocketOption*           option,
+                          ntsa::SocketOptionType::Value type) override
+    {
+        return d_invocation_getOption.invoke(option, type);
+    }
+    ntsa::Error getLastError(ntsa::Error* result) override
+    {
+        UNEXPECTED_CALL();
+        return ntsa::Error();
+    }
+    size_t maxBuffersPerSend() const override
+    {
+        return d_invocation_maxBuffersPerSend.invoke();
+    }
+    size_t maxBuffersPerReceive() const override
+    {
+        return d_invocation_maxBuffersPerReceive.invoke();
+    }
+
+    struct Invocation_handle {
+      private:
+        struct InvocationData {
+            int                               d_expectedCalls;
+            bdlb::NullableValue<ntsa::Handle> d_result;
+
+            InvocationData()
+            : d_expectedCalls(0)
+            , d_result()
+            {
+            }
+        };
+
+      public:
+        Invocation_handle& expect()
+        {
+            d_invocations.emplace_back();
+            InvocationData& invocation = d_invocations.back();
+            return *this;
+        }
+        Invocation_handle& willOnce()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = 1;
+            return *this;
+        }
+        Invocation_handle& willAlways()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = -1;
+            return *this;
+        }
+        //        Invocation_createTimer& times(int val){} //TODO: multiple calls
+
+        Invocation_handle& willReturn(ntsa::Handle result)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.back();
+            invocation.d_result        = result;
+            return *this;
+        }
+
+        ntsa::Handle invoke()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.front();
+
+            if (invocation.d_expectedCalls != -1) {
+                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
+            }
+
+            NTCCFG_TEST_TRUE(invocation.d_result.has_value());
+            const auto result = invocation.d_result.value();
+
+            if (invocation.d_expectedCalls != -1) {
+                --invocation.d_expectedCalls;
+                if (invocation.d_expectedCalls == 0) {
+                    d_invocations.pop_front();
+                }
+            }
+
+            return result;
+        }
+
+      private:
+        bsl::list<InvocationData> d_invocations;
+    };
+
+    Invocation_handle& expect_handle()
+    {
+        return d_invocation_handle.expect();
+    }
+
+    struct Invocation_close {
+      private:
+        struct InvocationData {
+            int                               d_expectedCalls;
+            bdlb::NullableValue<ntsa::Error> d_result;
+
+            InvocationData()
+            : d_expectedCalls(0)
+            , d_result()
+            {
+            }
+        };
+
+      public:
+        Invocation_close& expect()
+        {
+            d_invocations.emplace_back();
+            InvocationData& invocation = d_invocations.back();
+            return *this;
+        }
+        Invocation_close& willOnce()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = 1;
+            return *this;
+        }
+        Invocation_close& willAlways()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = -1;
+            return *this;
+        }
+        //        Invocation_createTimer& times(int val){} //TODO: multiple calls
+
+        Invocation_close& willReturn(ntsa::Error result)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.back();
+            invocation.d_result        = result;
+            return *this;
+        }
+
+        ntsa::Error invoke()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.front();
+
+            if (invocation.d_expectedCalls != -1) {
+                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
+            }
+
+            NTCCFG_TEST_TRUE(invocation.d_result.has_value());
+            const auto result = invocation.d_result.value();
+
+            if (invocation.d_expectedCalls != -1) {
+                --invocation.d_expectedCalls;
+                if (invocation.d_expectedCalls == 0) {
+                    d_invocations.pop_front();
+                }
+            }
+
+            return result;
+        }
+
+      private:
+        bsl::list<InvocationData> d_invocations;
+    };
+
+    Invocation_close& expect_close()
+    {
+        return d_invocation_close.expect();
+    }
+
+    struct Invocation_maxBuffersPerSend {
+      private:
+        struct InvocationData {
+            int                              d_expectedCalls;
+            bdlb::NullableValue<bsl::size_t> d_result;
+
+            InvocationData()
+            : d_expectedCalls(0)
+            , d_result()
+            {
+            }
+        };
+
+      public:
+        Invocation_maxBuffersPerSend& expect()
+        {
+            d_invocations.emplace_back();
+            InvocationData& invocation = d_invocations.back();
+            return *this;
+        }
+        Invocation_maxBuffersPerSend& willOnce()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = 1;
+            return *this;
+        }
+        Invocation_maxBuffersPerSend& willAlways()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = -1;
+            return *this;
+        }
+        //        Invocation_createTimer& times(int val){} //TODO: multiple calls
+
+        Invocation_maxBuffersPerSend& willReturn(bsl::size_t result)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.back();
+            invocation.d_result        = result;
+            return *this;
+        }
+
+        bsl::size_t invoke()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.front();
+
+            if (invocation.d_expectedCalls != -1) {
+                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
+            }
+
+            NTCCFG_TEST_TRUE(invocation.d_result.has_value());
+            const auto result = invocation.d_result.value();
+
+            if (invocation.d_expectedCalls != -1) {
+                --invocation.d_expectedCalls;
+                if (invocation.d_expectedCalls == 0) {
+                    d_invocations.pop_front();
+                }
+            }
+
+            return result;
+        }
+
+      private:
+        bsl::list<InvocationData> d_invocations;
+    };
+
+    Invocation_maxBuffersPerSend& expect_maxBuffersPerSend()
+    {
+        return d_invocation_maxBuffersPerSend.expect();
+    }
+
+    struct Invocation_maxBuffersPerReceive {
+      private:
+        struct InvocationData {
+            int                              d_expectedCalls;
+            bdlb::NullableValue<bsl::size_t> d_result;
+
+            InvocationData()
+            : d_expectedCalls(0)
+            , d_result()
+            {
+            }
+        };
+
+      public:
+        Invocation_maxBuffersPerReceive& expect()
+        {
+            d_invocations.emplace_back();
+            InvocationData& invocation = d_invocations.back();
+            return *this;
+        }
+        Invocation_maxBuffersPerReceive& willOnce()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = 1;
+            return *this;
+        }
+        Invocation_maxBuffersPerReceive& willAlways()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = -1;
+            return *this;
+        }
+        //        Invocation_createTimer& times(int val){} //TODO: multiple calls
+
+        Invocation_maxBuffersPerReceive& willReturn(bsl::size_t result)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.back();
+            invocation.d_result        = result;
+            return *this;
+        }
+
+        bsl::size_t invoke()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.front();
+
+            if (invocation.d_expectedCalls != -1) {
+                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
+            }
+
+            NTCCFG_TEST_TRUE(invocation.d_result.has_value());
+            const auto result = invocation.d_result.value();
+
+            if (invocation.d_expectedCalls != -1) {
+                --invocation.d_expectedCalls;
+                if (invocation.d_expectedCalls == 0) {
+                    d_invocations.pop_front();
+                }
+            }
+
+            return result;
+        }
+
+      private:
+        bsl::list<InvocationData> d_invocations;
+    };
+
+    Invocation_maxBuffersPerReceive& expect_maxBuffersPerReceive()
+    {
+        return d_invocation_maxBuffersPerReceive.expect();
+    }
+
+    struct Invocation_setBlocking {
+      private:
+        struct InvocationData {
+            int                              d_expectedCalls;
+            bdlb::NullableValue<bool>        d_arg1;
+            bdlb::NullableValue<ntsa::Error> d_result;
+            bool*                            d_arg1_out;
+
+            InvocationData()
+            : d_expectedCalls(0)
+            , d_arg1()
+            , d_result()
+            , d_arg1_out(0)
+            {
+            }
+        };
+
+      public:
+        Invocation_setBlocking& expect(const bdlb::NullableValue<bool>& arg1)
+        {
+            d_invocations.emplace_back();
+            InvocationData& invocation = d_invocations.back();
+
+            invocation.d_arg1 = arg1;
+
+            return *this;
+        }
+        Invocation_setBlocking& willOnce()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = 1;
+            return *this;
+        }
+        Invocation_setBlocking& willAlways()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = -1;
+            return *this;
+        }
+        //        Invocation_createTimer& times(int val){} //TODO: multiple calls
+
+        Invocation_setBlocking& willReturn(ntsa::Error result)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.back();
+            invocation.d_result        = result;
+            return *this;
+        }
+
+        Invocation_setBlocking& saveArg1(bool& arg1)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.back();
+            invocation.d_arg1_out      = &arg1;
+            return *this;
+        }
+
+        ntsa::Error invoke(bool arg1)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.front();
+
+            if (invocation.d_expectedCalls != -1) {
+                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
+            }
+
+            if (invocation.d_arg1.has_value()) {
+                NTCCFG_TEST_EQ(arg1, invocation.d_arg1.value());
+            }
+
+            if (invocation.d_arg1_out) {
+                *invocation.d_arg1_out = arg1;
+            }
+
+            NTCCFG_TEST_TRUE(invocation.d_result.has_value());
+            const auto result = invocation.d_result.value();
+
+            if (invocation.d_expectedCalls != -1) {
+                --invocation.d_expectedCalls;
+                if (invocation.d_expectedCalls == 0) {
+                    d_invocations.pop_front();
+                }
+            }
+
+            return result;
+        }
+
+      private:
+        bsl::list<InvocationData> d_invocations;
+    };
+
+    Invocation_setBlocking& expect_setBlocking(
+        const bdlb::NullableValue<bool>& arg1)
+    {
+        return d_invocation_setBlocking.expect(arg1);
+    }
+
+    struct Invocation_setOption {
+      private:
+        struct InvocationData {
+            int                                     d_expectedCalls;
+            bdlb::NullableValue<ntsa::SocketOption> d_arg1;
+            bdlb::NullableValue<ntsa::Error>        d_result;
+            ntsa::SocketOption*                     d_arg1_out;
+
+            InvocationData()
+            : d_expectedCalls(0)
+            , d_arg1()
+            , d_result()
+            , d_arg1_out(0)
+            {
+            }
+        };
+
+      public:
+        Invocation_setOption& expect(
+            const bdlb::NullableValue<ntsa::SocketOption>& arg1)
+        {
+            d_invocations.emplace_back();
+            InvocationData& invocation = d_invocations.back();
+
+            invocation.d_arg1 = arg1;
+
+            return *this;
+        }
+        Invocation_setOption& willOnce()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = 1;
+            return *this;
+        }
+        Invocation_setOption& willAlways()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = -1;
+            return *this;
+        }
+        //        Invocation_createTimer& times(int val){} //TODO: multiple calls
+
+        Invocation_setOption& willReturn(ntsa::Error result)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.back();
+            invocation.d_result        = result;
+            return *this;
+        }
+
+        Invocation_setOption& saveArg1(ntsa::SocketOption& arg1)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.back();
+            invocation.d_arg1_out      = &arg1;
+            return *this;
+        }
+
+        ntsa::Error invoke(const ntsa::SocketOption& arg1)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.front();
+
+            if (invocation.d_expectedCalls != -1) {
+                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
+            }
+
+            if (invocation.d_arg1.has_value()) {
+                NTCCFG_TEST_EQ(arg1, invocation.d_arg1.value());
+            }
+
+            if (invocation.d_arg1_out) {
+                *invocation.d_arg1_out = arg1;
+            }
+
+            NTCCFG_TEST_TRUE(invocation.d_result.has_value());
+            const auto result = invocation.d_result.value();
+
+            if (invocation.d_expectedCalls != -1) {
+                --invocation.d_expectedCalls;
+                if (invocation.d_expectedCalls == 0) {
+                    d_invocations.pop_front();
+                }
+            }
+
+            return result;
+        }
+
+      private:
+        bsl::list<InvocationData> d_invocations;
+    };
+
+    Invocation_setOption& expect_setOption(
+        const bdlb::NullableValue<ntsa::SocketOption>& arg1)
+    {
+        return d_invocation_setOption.expect(arg1);
+    }
+
+    struct Invocation_sourceEndpoint {
+      private:
+        struct InvocationData {
+            int                                  d_expectedCalls;
+            bdlb::NullableValue<ntsa::Endpoint*> d_arg1;
+            bdlb::NullableValue<ntsa::Error>     d_result;
+            ntsa::Endpoint**                     d_arg1_out;
+
+            InvocationData()
+            : d_expectedCalls(0)
+            , d_arg1()
+            , d_result()
+            , d_arg1_out(0)
+            {
+            }
+        };
+
+      public:
+        Invocation_sourceEndpoint& expect(
+            const bdlb::NullableValue<ntsa::Endpoint*>& arg1)
+        {
+            d_invocations.emplace_back();
+            InvocationData& invocation = d_invocations.back();
+
+            invocation.d_arg1 = arg1;
+
+            return *this;
+        }
+        Invocation_sourceEndpoint& willOnce()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = 1;
+            return *this;
+        }
+        Invocation_sourceEndpoint& willAlways()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = -1;
+            return *this;
+        }
+        //        Invocation_createTimer& times(int val){} //TODO: multiple calls
+
+        Invocation_sourceEndpoint& willReturn(ntsa::Error result)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.back();
+            invocation.d_result        = result;
+            return *this;
+        }
+
+        Invocation_sourceEndpoint& saveArg1(ntsa::Endpoint*& arg1)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.back();
+            invocation.d_arg1_out      = &arg1;
+            return *this;
+        }
+
+        ntsa::Error invoke(ntsa::Endpoint* arg1)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.front();
+
+            if (invocation.d_expectedCalls != -1) {
+                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
+            }
+
+            if (invocation.d_arg1.has_value()) {
+                NTCCFG_TEST_EQ(arg1, invocation.d_arg1.value());
+            }
+
+            if (invocation.d_arg1_out) {
+                *invocation.d_arg1_out = arg1;
+            }
+
+            NTCCFG_TEST_TRUE(invocation.d_result.has_value());
+            const auto result = invocation.d_result.value();
+
+            if (invocation.d_expectedCalls != -1) {
+                --invocation.d_expectedCalls;
+                if (invocation.d_expectedCalls == 0) {
+                    d_invocations.pop_front();
+                }
+            }
+
+            return result;
+        }
+
+      private:
+        bsl::list<InvocationData> d_invocations;
+    };
+
+    Invocation_sourceEndpoint& expect_sourceEndpoint(
+        const bdlb::NullableValue<ntsa::Endpoint*>& arg1)
+    {
+        return d_invocation_sourceEndpoint.expect(arg1);
+    }
+
+    struct Invocation_remoteEndpoint {
+      private:
+        struct InvocationData {
+            int                                  d_expectedCalls;
+            bdlb::NullableValue<ntsa::Endpoint*> d_arg1;
+            bdlb::NullableValue<ntsa::Error>     d_result;
+            ntsa::Endpoint**                     d_arg1_out;
+
+            InvocationData()
+            : d_expectedCalls(0)
+            , d_arg1()
+            , d_result()
+            , d_arg1_out(0)
+            {
+            }
+        };
+
+      public:
+        Invocation_remoteEndpoint& expect(
+            const bdlb::NullableValue<ntsa::Endpoint*>& arg1)
+        {
+            d_invocations.emplace_back();
+            InvocationData& invocation = d_invocations.back();
+
+            invocation.d_arg1 = arg1;
+
+            return *this;
+        }
+        Invocation_remoteEndpoint& willOnce()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = 1;
+            return *this;
+        }
+        Invocation_remoteEndpoint& willAlways()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = -1;
+            return *this;
+        }
+        //        Invocation_createTimer& times(int val){} //TODO: multiple calls
+
+        Invocation_remoteEndpoint& willReturn(ntsa::Error result)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.back();
+            invocation.d_result        = result;
+            return *this;
+        }
+
+        Invocation_remoteEndpoint& saveArg1(ntsa::Endpoint*& arg1)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.back();
+            invocation.d_arg1_out      = &arg1;
+            return *this;
+        }
+
+        ntsa::Error invoke(ntsa::Endpoint* arg1)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.front();
+
+            if (invocation.d_expectedCalls != -1) {
+                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
+            }
+
+            if (invocation.d_arg1.has_value()) {
+                NTCCFG_TEST_EQ(arg1, invocation.d_arg1.value());
+            }
+
+            if (invocation.d_arg1_out) {
+                *invocation.d_arg1_out = arg1;
+            }
+
+            NTCCFG_TEST_TRUE(invocation.d_result.has_value());
+            const auto result = invocation.d_result.value();
+
+            if (invocation.d_expectedCalls != -1) {
+                --invocation.d_expectedCalls;
+                if (invocation.d_expectedCalls == 0) {
+                    d_invocations.pop_front();
+                }
+            }
+
+            return result;
+        }
+
+      private:
+        bsl::list<InvocationData> d_invocations;
+    };
+
+    Invocation_remoteEndpoint& expect_remoteEndpoint(
+        const bdlb::NullableValue<ntsa::Endpoint*>& arg1)
+    {
+        return d_invocation_remoteEndpoint.expect(arg1);
+    }
+
+    struct Invocation_getOption {
+      private:
+        struct InvocationData {
+            int                                                d_expectedCalls;
+            bdlb::NullableValue<ntsa::SocketOption*>           d_arg1;
+            bdlb::NullableValue<ntsa::SocketOptionType::Value> d_arg2;
+            bdlb::NullableValue<ntsa::Error>                   d_result;
+            ntsa::SocketOption**                               d_arg1_out;
+            ntsa::SocketOptionType::Value*                     d_arg2_out;
+            bdlb::NullableValue<ntsa::SocketOption>            d_arg1_set;
+
+            InvocationData()
+            : d_expectedCalls(0)
+            , d_arg1()
+            , d_arg2()
+            , d_result()
+            , d_arg1_out(0)
+            , d_arg2_out(0)
+            , d_arg1_set()
+            {
+            }
+        };
+
+      public:
+        Invocation_getOption& expect(
+            const bdlb::NullableValue<ntsa::SocketOption*>&           arg1,
+            const bdlb::NullableValue<ntsa::SocketOptionType::Value>& arg2)
+        {
+            d_invocations.emplace_back();
+            InvocationData& invocation = d_invocations.back();
+
+            invocation.d_arg1 = arg1;
+            invocation.d_arg2 = arg2;
+
+            return *this;
+        }
+        Invocation_getOption& willOnce()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = 1;
+            return *this;
+        }
+        Invocation_getOption& willAlways()
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+
+            InvocationData& invocation = d_invocations.back();
+            NTCCFG_TEST_EQ(invocation.d_expectedCalls, 0);
+
+            invocation.d_expectedCalls = -1;
+            return *this;
+        }
+        //        Invocation_createTimer& times(int val){} //TODO: multiple calls
+
+        Invocation_getOption& willReturn(ntsa::Error result)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.back();
+            invocation.d_result        = result;
+            return *this;
+        }
+
+        Invocation_getOption& saveArg1(ntsa::SocketOption*& arg1)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.back();
+            invocation.d_arg1_out      = &arg1;
+            return *this;
+        }
+
+        Invocation_getOption& setArg1(const ntsa::SocketOption& arg1)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.back();
+            invocation.d_arg1_set      = arg1;
+            return *this;
+        }
+
+        Invocation_getOption& saveArg2(ntsa::SocketOptionType::Value& arg2)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.back();
+            invocation.d_arg2_out      = &arg2;
+            return *this;
+        }
+
+        ntsa::Error invoke(ntsa::SocketOption*           arg1,
+                           ntsa::SocketOptionType::Value arg2)
+        {
+            NTCCFG_TEST_FALSE(d_invocations.empty());
+            InvocationData& invocation = d_invocations.front();
+
+            if (invocation.d_expectedCalls != -1) {
+                NTCCFG_TEST_GE(invocation.d_expectedCalls, 1);
+            }
+
+            if (invocation.d_arg1.has_value()) {
+                NTCCFG_TEST_EQ(arg1, invocation.d_arg1.value());
+            }
+
+            if (invocation.d_arg2.has_value()) {
+                NTCCFG_TEST_EQ(arg2, invocation.d_arg2.value());
+            }
+
+            if (invocation.d_arg1_out) {
+                *invocation.d_arg1_out = arg1;
+            }
+
+            if (invocation.d_arg2_out) {
+                *invocation.d_arg2_out = arg2;
+            }
+
+            if (invocation.d_arg1_set.has_value()) {
+                *arg1 = invocation.d_arg1_set.value();
+            }
+
+            NTCCFG_TEST_TRUE(invocation.d_result.has_value());
+            const auto result = invocation.d_result.value();
+
+            if (invocation.d_expectedCalls != -1) {
+                --invocation.d_expectedCalls;
+                if (invocation.d_expectedCalls == 0) {
+                    d_invocations.pop_front();
+                }
+            }
+
+            return result;
+        }
+
+      private:
+        bsl::list<InvocationData> d_invocations;
+    };
+
+    Invocation_getOption& expect_getOption(
+        const bdlb::NullableValue<ntsa::SocketOption*>&           arg1,
+        const bdlb::NullableValue<ntsa::SocketOptionType::Value>& arg2)
+    {
+        return d_invocation_getOption.expect(arg1, arg2);
+    }
+
+  private:
+    mutable Invocation_handle               d_invocation_handle;
+    mutable Invocation_close                d_invocation_close;
+    mutable Invocation_maxBuffersPerSend    d_invocation_maxBuffersPerSend;
+    mutable Invocation_maxBuffersPerReceive d_invocation_maxBuffersPerReceive;
+    mutable Invocation_setBlocking          d_invocation_setBlocking;
+    mutable Invocation_setOption            d_invocation_setOption;
+    mutable Invocation_getOption            d_invocation_getOption;
+    mutable Invocation_sourceEndpoint       d_invocation_sourceEndpoint;
+    mutable Invocation_remoteEndpoint       d_invocation_remoteEndpoint;
 };
 
 class DataPoolMock : public ntci::DataPool
@@ -4647,7 +5647,8 @@ NTCCFG_TEST_CASE(22)
     {
         NTCI_LOG_DEBUG("Fixture setup, socket creation...");
 
-        const auto doNotCare = bdlb::NullOptType::makeInitialValue();
+        const auto         doNotCare = bdlb::NullOptType::makeInitialValue();
+        const ntsa::Handle handle    = 22;
 
         bdlb::NullableValue<ntca::ConnectEvent> connectResult;
 
@@ -4690,12 +5691,53 @@ NTCCFG_TEST_CASE(22)
 
         const ntca::StreamSocketOptions options;
 
-        ntcr::StreamSocket socket(options,
-                                  resolverMock,
-                                  reactorMock,
-                                  nullPool,
-                                  nullMetrics,
-                                  &ta);
+        bsl::shared_ptr<ntcr::StreamSocket> socket;
+        socket.createInplace(&ta,
+                             options,
+                             resolverMock,
+                             reactorMock,
+                             nullPool,
+                             nullMetrics,
+                             &ta);
+
+        socketMock->expect_handle().willAlways().willReturn(handle);
+        socketMock->expect_setBlocking(false).willOnce().willReturn(
+            ntsa::Error());
+        socketMock->expect_setBlocking(false).willOnce().willReturn(
+            ntsa::Error());  //TODO: for some reason it is called twice
+        socketMock->expect_setOption(doNotCare).willAlways().willReturn(
+            ntsa::Error());
+        socketMock->expect_sourceEndpoint(doNotCare).willOnce().willReturn(
+            ntsa::Error::invalid());
+        socketMock->expect_remoteEndpoint(doNotCare).willOnce().willReturn(
+            ntsa::Error::invalid());
+
+        ntsa::SocketOption sendBufferSizeOption;
+        sendBufferSizeOption.makeSendBufferSize(100500);
+        ntsa::SocketOption rcvBufferSizeOption;
+        rcvBufferSizeOption.makeReceiveBufferSize(100500);
+
+        socketMock
+            ->expect_getOption(doNotCare,
+                               ntsa::SocketOptionType::e_SEND_BUFFER_SIZE)
+            .willOnce()
+            .willReturn(ntsa::Error())
+            .setArg1(sendBufferSizeOption);
+
+        socketMock
+            ->expect_getOption(doNotCare,
+                               ntsa::SocketOptionType::e_RECEIVE_BUFFER_SIZE)
+            .willOnce()
+            .willReturn(ntsa::Error())
+            .setArg1(rcvBufferSizeOption);
+
+        socketMock->expect_maxBuffersPerSend().willOnce().willReturn(22);
+        socketMock->expect_maxBuffersPerReceive().willOnce().willReturn(22);
+
+        reactorMock->expect_acquireHandleReservation_WillAlwaysReturn(true);
+        reactorMock->expect_releaseHandleReservation_WillAlwaysReturn();
+
+        socket->open(ntsa::Transport::e_TCP_IPV4_STREAM, socketMock);
 
         NTCI_LOG_DEBUG("Connection initiation...");
 
@@ -4723,7 +5765,7 @@ NTCCFG_TEST_CASE(22)
 
         const bsl::string epName = "unreachable.bbg.com";
 
-        socket.connect(epName, connectOptions, connectCallback);
+        socket->connect(epName, connectOptions, connectCallback);
 
         NTCI_LOG_DEBUG("Trigger internal timer to initiate connection...");
 
@@ -4742,7 +5784,15 @@ NTCCFG_TEST_CASE(22)
         connectRetryTimerMock->expect_close_WillOnceReturn(ntsa::Error());
         reactorMock->expect_execute_WillOnceReturn();
 
-        socket.shutdown(ntsa::ShutdownType::e_BOTH,
+        reactorMock->expect_detachSocket_WillOnceReturn(
+            socket,
+            bdlb::NullOptType::makeInitialValue(),
+            ntsa::Error::invalid());
+        //TODO: is that ok to detach socket that has not been attached?
+
+        socketMock->expect_close().willOnce().willReturn(ntsa::Error());
+
+        socket->shutdown(ntsa::ShutdownType::e_BOTH,
                         ntsa::ShutdownMode::e_GRACEFUL);
 
         const auto callback = reactorMock->extract_execute_functor();

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -18,6 +18,7 @@
 #include <ntccfg_bind.h>
 #include <ntccfg_test.h>
 #include <ntcd_blobbufferfactory.h>
+#include <ntcd_datapool.h>
 #include <ntcd_datautil.h>
 #include <ntcd_encryption.h>
 #include <ntcd_reactor.h>
@@ -1376,70 +1377,6 @@ void variation(const test::Parameters& parameters)
 
 namespace mock {
 
-NTF_MOCK_CLASS(StreamSocketMock, ntsi::StreamSocket)
-
-NTF_MOCK_METHOD_CONST(ntsa::Handle, handle)
-NTF_MOCK_METHOD(ntsa::Error, open, ntsa::Transport::Value)
-NTF_MOCK_METHOD(ntsa::Error, acquire, ntsa::Handle)
-NTF_MOCK_METHOD(ntsa::Handle, release)
-
-NTF_MOCK_METHOD(ntsa::Error, bind, const ntsa::Endpoint&, bool)
-NTF_MOCK_METHOD(ntsa::Error, bindAny, ntsa::Transport::Value, bool)
-NTF_MOCK_METHOD(ntsa::Error, connect, const ntsa::Endpoint&)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                send,
-                ntsa::SendContext*,
-                const bdlbb::Blob&,
-                const ntsa::SendOptions&)
-NTF_MOCK_METHOD(ntsa::Error,
-                send,
-                ntsa::SendContext*,
-                const ntsa::Data&,
-                const ntsa::SendOptions&)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                receive,
-                ntsa::ReceiveContext*,
-                bdlbb::Blob*,
-                const ntsa::ReceiveOptions&)
-NTF_MOCK_METHOD(ntsa::Error,
-                receive,
-                ntsa::ReceiveContext*,
-                ntsa::Data*,
-                const ntsa::ReceiveOptions&)
-
-NTF_MOCK_METHOD(ntsa::Error, receiveNotifications, ntsa::NotificationQueue*)
-NTF_MOCK_METHOD(ntsa::Error, shutdown, ntsa::ShutdownType::Value)
-NTF_MOCK_METHOD(ntsa::Error, unlink)
-NTF_MOCK_METHOD(ntsa::Error, close)
-NTF_MOCK_METHOD_CONST(ntsa::Error, sourceEndpoint, ntsa::Endpoint*)
-NTF_MOCK_METHOD_CONST(ntsa::Error, remoteEndpoint, ntsa::Endpoint*)
-NTF_MOCK_METHOD(ntsa::Error, setBlocking, bool)
-NTF_MOCK_METHOD(ntsa::Error, setOption, const ntsa::SocketOption&)
-
-NTF_MOCK_METHOD(ntsa::Error,
-                getOption,
-                ntsa::SocketOption*,
-                ntsa::SocketOptionType::Value)
-NTF_MOCK_METHOD(ntsa::Error, getLastError, ntsa::Error*)
-NTF_MOCK_METHOD_CONST(bsl::size_t, maxBuffersPerSend)
-NTF_MOCK_METHOD_CONST(bsl::size_t, maxBuffersPerReceive)
-NTF_MOCK_CLASS_END;
-
-NTF_MOCK_CLASS(DataPoolMock, ntci::DataPool)
-NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createIncomingData)
-NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createOutgoingData)
-NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createIncomingBlob)
-NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createOutgoingBlob)
-NTF_MOCK_METHOD(void, createIncomingBlobBuffer, bdlbb::BlobBuffer*)
-NTF_MOCK_METHOD(void, createOutgoingBlobBuffer, bdlbb::BlobBuffer*)
-NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
-                      incomingBlobBufferFactory)
-NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
-                      outgoingBlobBufferFactory)
-NTF_MOCK_CLASS_END;
-
 NTF_MOCK_CLASS(ReactorMock, ntci::Reactor)
 
 NTF_MOCK_METHOD(bsl::shared_ptr<ntci::DatagramSocket>,
@@ -1631,11 +1568,11 @@ struct Fixture {
 
     bsl::shared_ptr<ntcd::BufferFactoryMock>  d_bufferFactoryMock;
     bsl::shared_ptr<bdlbb::BlobBufferFactory> d_bufferFactory;
-    bsl::shared_ptr<mock::DataPoolMock>       d_dataPoolMock;
+    bsl::shared_ptr<ntcd::DataPoolMock>       d_dataPoolMock;
     bsl::shared_ptr<ntci::DataPool>           d_dataPool;
     bsl::shared_ptr<mock::ReactorMock>        d_reactorMock;
     bsl::shared_ptr<ntcd::ResolverMock>       d_resolverMock;
-    bsl::shared_ptr<mock::StreamSocketMock>   d_streamSocketMock;
+    bsl::shared_ptr<ntcd::StreamSocketMock>   d_streamSocketMock;
     bsl::shared_ptr<mock::TimerMock>          d_connectRetryTimerMock;
     bsl::shared_ptr<mock::TimerMock>          d_connectDeadlineTimerMock;
 

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1583,11 +1583,22 @@ class BufferFactoryMock : public bdlbb::BlobBufferFactory
 {
   public:
         void allocate(bdlbb::BlobBuffer* buffer) override
-        {
-            UNEXPECTED_CALL();
-        }
+    {
+        UNEXPECTED_CALL();
+    }
 
-//    NTF_MOCK_METHOD(void, allocate, bdlbb::BlobBuffer*)
+    // NTF_MOCK_METHOD(void, allocate, bdlbb::BlobBuffer*)
+};
+
+struct MyClass
+{
+    virtual void doSmth(int) = 0;
+};
+
+class MyClassMock : public MyClass
+{
+public:
+    NTF_MOCK_METHOD_1(void, doSmth, int);
 };
 
 class StreamSocketMock : public ntsi::StreamSocket

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1496,22 +1496,22 @@ class ResolverMock : public ntci::Resolver
                             const ntca::GetEndpointOptions&  options,
                             const ntci::GetEndpointCallback& callback) override
     {
-        if (d_getEndpoint_error.isNull()) {
+        if (d_getEndpoint_result.isNull()) {
             UNEXPECTED_CALL();
         }
-        if (d_getEndpoint_text.has_value()) {
-            NTCCFG_TEST_EQ(text, d_getEndpoint_text.value());
-            d_getEndpoint_text.reset();
+        if (d_getEndpoint_arg1.has_value()) {
+            NTCCFG_TEST_EQ(text, d_getEndpoint_arg1.value());
+            d_getEndpoint_arg1.reset();
         }
-        if (d_getEndpoint_options.has_value()) {
-            NTCCFG_TEST_EQ(options, d_getEndpoint_options.value());
-            d_getEndpoint_options.reset();
+        if (d_getEndpoint_arg2.has_value()) {
+            NTCCFG_TEST_EQ(options, d_getEndpoint_arg2.value());
+            d_getEndpoint_arg2.reset();
         }
         NTCCFG_TEST_FALSE(d_getEndpoint_callback.has_value());
         d_getEndpoint_callback = callback;
 
-        const auto res = d_getEndpoint_error.value();
-        d_getEndpoint_error.reset();
+        const auto res = d_getEndpoint_result.value();
+        d_getEndpoint_result.reset();
         return res;
     }
     ntsa::Error getLocalIpAddress(
@@ -1559,24 +1559,24 @@ class ResolverMock : public ntci::Resolver
         return bsls::TimeInterval();
     }
 
-    // auxilary functions
-    void set_getEndpoint_WillOnceReturn(
+    // auxiliary functions
+    void expect_getEndpoint_WillOnceReturn(
         const bdlb::NullableValue<bslstl::StringRef>&        text,
         const bdlb::NullableValue<ntca::GetEndpointOptions>& options,
         ntsa::Error                                          error)
     {
-        d_getEndpoint_text    = text;
-        d_getEndpoint_options = options;
-        d_getEndpoint_error   = error;
+        d_getEndpoint_arg1   = text;
+        d_getEndpoint_arg2   = options;
+        d_getEndpoint_result = error;
     }
 
   private:
     bsl::shared_ptr<ntci::Strand> dummyStrand;
 
-    bdlb::NullableValue<bslstl::StringRef>         d_getEndpoint_text;
-    bdlb::NullableValue<ntca::GetEndpointOptions>  d_getEndpoint_options;
+    bdlb::NullableValue<bslstl::StringRef>         d_getEndpoint_arg1;
+    bdlb::NullableValue<ntca::GetEndpointOptions>  d_getEndpoint_arg2;
     bdlb::NullableValue<ntci::GetEndpointCallback> d_getEndpoint_callback;
-    bdlb::NullableValue<ntsa::Error>               d_getEndpoint_error;
+    bdlb::NullableValue<ntsa::Error>               d_getEndpoint_result;
 };
 
 class BufferFactoryMock : public bdlbb::BlobBufferFactory
@@ -1623,24 +1623,24 @@ class DataPoolMock : public ntci::DataPool
     }
     bsl::shared_ptr<ntsa::Data> createOutgoingData() override
     {
-        if (d_outgoingData.isNull()) {
+        if (d_createOutgoingData_result.isNull()) {
             UNEXPECTED_CALL();
         }
-        return d_outgoingData.value();
+        return d_createOutgoingData_result.value();
     }
     bsl::shared_ptr<bdlbb::Blob> createIncomingBlob() override
     {
-        if (d_incomingBlobBuffer.isNull()) {
+        if (d_createIncomingBlobBuffer_result.isNull()) {
             UNEXPECTED_CALL();
         }
-        return d_incomingBlobBuffer.value();
+        return d_createIncomingBlobBuffer_result.value();
     }
     bsl::shared_ptr<bdlbb::Blob> createOutgoingBlob() override
     {
-        if (d_outgoingBlobBuffer.isNull()) {
+        if (d_createOutgoingBlobBuffer_result.isNull()) {
             UNEXPECTED_CALL();
         }
-        return d_outgoingBlobBuffer.value();
+        return d_createOutgoingBlobBuffer_result.value();
     }
     void createIncomingBlobBuffer(bdlbb::BlobBuffer* blobBuffer) override
     {
@@ -1663,31 +1663,34 @@ class DataPoolMock : public ntci::DataPool
         return dummyBlobBufferFactory;
     }
 
-    // auxilary functions
+    // auxiliary functions
 
-    void set_createIncomingBlobBuffer_WillAlwaysReturn(
+    void expect_createIncomingBlobBuffer_WillAlwaysReturn(
         const bsl::shared_ptr<bdlbb::Blob>& blob)
     {
-        d_incomingBlobBuffer = blob;
+        d_createIncomingBlobBuffer_result = blob;
     }
 
-    void set_createOutgoingBlobBuffer_WillAlwaysReturn(
+    void expect_createOutgoingBlobBuffer_WillAlwaysReturn(
         const bsl::shared_ptr<bdlbb::Blob>& blob)
     {
-        d_outgoingBlobBuffer = blob;
+        d_createOutgoingBlobBuffer_result = blob;
     }
 
-    void set_createOutgoingData_WillAlwaysReturn(
-        bsl::shared_ptr<ntsa::Data> data)
+    void expect_createOutgoingData_WillAlwaysReturn(
+        const bsl::shared_ptr<ntsa::Data>& data)
     {
-        d_outgoingData = data;
+        d_createOutgoingData_result = data;
     }
 
   private:
-    bsl::shared_ptr<bdlbb::BlobBufferFactory>          dummyBlobBufferFactory;
-    bdlb::NullableValue<bsl::shared_ptr<bdlbb::Blob> > d_incomingBlobBuffer;
-    bdlb::NullableValue<bsl::shared_ptr<bdlbb::Blob> > d_outgoingBlobBuffer;
-    bdlb::NullableValue<bsl::shared_ptr<ntsa::Data> >  d_outgoingData;
+    bsl::shared_ptr<bdlbb::BlobBufferFactory> dummyBlobBufferFactory;
+    bdlb::NullableValue<bsl::shared_ptr<bdlbb::Blob> >
+        d_createIncomingBlobBuffer_result;
+    bdlb::NullableValue<bsl::shared_ptr<bdlbb::Blob> >
+        d_createOutgoingBlobBuffer_result;
+    bdlb::NullableValue<bsl::shared_ptr<ntsa::Data> >
+        d_createOutgoingData_result;
 };
 
 class ReactorMock : public ntci::Reactor
@@ -1731,18 +1734,18 @@ class ReactorMock : public ntci::Reactor
     const bsl::shared_ptr<bdlbb::BlobBufferFactory>& incomingBlobBufferFactory()
         const override
     {
-        if (d_incomingBlobBufferFactory.isNull()) {
+        if (d_incomingBlobBufferFactory_result.isNull()) {
             UNEXPECTED_CALL();
         }
-        return d_incomingBlobBufferFactory.value();
+        return d_incomingBlobBufferFactory_result.value();
     }
     const bsl::shared_ptr<bdlbb::BlobBufferFactory>& outgoingBlobBufferFactory()
         const override
     {
-        if (d_outgoingBlobBufferFactory.isNull()) {
+        if (d_outgoingBlobBufferFactory_result.isNull()) {
             UNEXPECTED_CALL();
         }
-        return d_outgoingBlobBufferFactory.value();
+        return d_outgoingBlobBufferFactory_result.value();
     }
     ntci::Waiter registerWaiter(
         const ntca::WaiterOptions& waiterOptions) override
@@ -1780,10 +1783,10 @@ class ReactorMock : public ntci::Reactor
     }
     void execute(const Functor& functor) override
     {
-        if (!d_executeExpected) {
+        if (!d_execute_expected) {
             UNEXPECTED_CALL();
         }
-        d_executeExpected = false;
+        d_execute_expected = false;
         NTCCFG_TEST_FALSE(d_execute_functor.has_value());
         d_execute_functor = functor;
     }
@@ -1805,9 +1808,9 @@ class ReactorMock : public ntci::Reactor
         if (d_attachSocket_result.isNull()) {
             UNEXPECTED_CALL();
         }
-        if (d_attachSocket_socket.has_value()) {
-            NTCCFG_TEST_EQ(socket, d_attachSocket_socket.value());
-            d_attachSocket_socket.reset();
+        if (d_attachSocket_arg1.has_value()) {
+            NTCCFG_TEST_EQ(socket, d_attachSocket_arg1.value());
+            d_attachSocket_arg1.reset();
         }
         const auto res = d_attachSocket_result.value();
         d_attachSocket_result.reset();
@@ -1841,9 +1844,9 @@ class ReactorMock : public ntci::Reactor
             UNEXPECTED_CALL();
         }
 
-        if (d_showWritable_socket.has_value()) {
-            NTCCFG_TEST_EQ(socket, d_showWritable_socket.value());
-            d_showWritable_socket.reset();
+        if (d_showWritable_arg1.has_value()) {
+            NTCCFG_TEST_EQ(socket, d_showWritable_arg1.value());
+            d_showWritable_arg1.reset();
         }
 
         const auto res = d_showWritable_result.value();
@@ -2015,10 +2018,10 @@ class ReactorMock : public ntci::Reactor
     }
     bool oneShot() const override
     {
-        if (d_oneShot.isNull()) {
+        if (d_oneShot_result.isNull()) {
             UNEXPECTED_CALL();
         }
-        return d_oneShot.value();
+        return d_oneShot_result.value();
     }
     ntca::ReactorEventTrigger::Value trigger() const override
     {
@@ -2047,10 +2050,10 @@ class ReactorMock : public ntci::Reactor
     }
     const bsl::shared_ptr<ntci::DataPool>& dataPool() const override
     {
-        if (d_dataPool.isNull()) {
+        if (d_dataPool_result.isNull()) {
             UNEXPECTED_CALL();
         }
-        return d_dataPool.value();
+        return d_dataPool_result.value();
     }
     bool supportsOneShot(bool oneShot) const override
     {
@@ -2076,10 +2079,10 @@ class ReactorMock : public ntci::Reactor
     }
     bool acquireHandleReservation() override
     {
-        if (d_aquireHandleReservation.isNull()) {
+        if (d_acquireHandleReservation_result.isNull()) {
             UNEXPECTED_CALL();
         }
-        return d_aquireHandleReservation.value();
+        return d_acquireHandleReservation_result.value();
     }
     void releaseHandleReservation() override
     {
@@ -2104,10 +2107,10 @@ class ReactorMock : public ntci::Reactor
     }
     size_t maxThreads() const override
     {
-        if (d_maxThreads.isNull()) {
+        if (d_maxThreads_result.isNull()) {
             UNEXPECTED_CALL();
         }
-        return d_maxThreads.value();
+        return d_maxThreads_result.value();
     }
     bsl::shared_ptr<ntci::Strand> createStrand(
         bslma::Allocator* basicAllocator) override
@@ -2127,11 +2130,11 @@ class ReactorMock : public ntci::Reactor
         const bsl::shared_ptr<ntci::TimerSession>& session,
         bslma::Allocator*                          basicAllocator) override
     {
-        if (d_timer.isNull()) {
+        if (d_timer_result.isNull()) {
             UNEXPECTED_CALL();
         }
-        const auto timer = d_timer.value();
-        d_timer->clear();
+        const auto timer = d_timer_result.value();
+        d_timer_result->clear();
         return timer;
     }
     bsl::shared_ptr<ntci::Timer> createTimer(
@@ -2139,15 +2142,15 @@ class ReactorMock : public ntci::Reactor
         const ntci::TimerCallback& callback,
         bslma::Allocator*          basicAllocator) override
     {
-        if (d_timer.isNull()) {
+        if (d_timer_result.isNull()) {
             UNEXPECTED_CALL();
         }
 
         NTCCFG_TEST_TRUE(d_timerCallback.isNull());
         d_timerCallback = callback;
 
-        const auto timer = d_timer.value();
-        d_timer.reset();
+        const auto timer = d_timer_result.value();
+        d_timer_result.reset();
         return timer;
     }
     const bsl::shared_ptr<ntci::Strand>& strand() const override
@@ -2161,81 +2164,81 @@ class ReactorMock : public ntci::Reactor
         return bsls::TimeInterval();
     }
 
-    // auxilary methods
-    void set_dataPool_WillAlwaysReturn(
+    // auxiliary methods
+    void expect_dataPool_WillAlwaysReturn(
         const bsl::shared_ptr<ntci::DataPool>& dataPool)
     {
-        d_dataPool = dataPool;
+        d_dataPool_result = dataPool;
     }
 
-    void set_outgoingBlobBufferFactory_WillAlwaysReturn(
-        bsl::shared_ptr<bdlbb::BlobBufferFactory> bufferFactory)
+    void expect_outgoingBlobBufferFactory_WillAlwaysReturn(
+        const bsl::shared_ptr<bdlbb::BlobBufferFactory>& bufferFactory)
     {
-        d_outgoingBlobBufferFactory = bufferFactory;
+        d_outgoingBlobBufferFactory_result = bufferFactory;
     }
 
-    void set_incomingBlobBufferFactory_WillAlwaysReturn(
-        bsl::shared_ptr<bdlbb::BlobBufferFactory> bufferFactory)
+    void expect_incomingBlobBufferFactory_WillAlwaysReturn(
+        const bsl::shared_ptr<bdlbb::BlobBufferFactory>& bufferFactory)
     {
-        d_incomingBlobBufferFactory = bufferFactory;
+        d_incomingBlobBufferFactory_result = bufferFactory;
     }
 
-    void set_oneShot_WillAlwaysReturn(bool flag)
+    void expect_oneShot_WillAlwaysReturn(bool flag)
     {
-        d_oneShot = flag;
+        d_oneShot_result = flag;
     }
 
-    void set_maxThreads_WillAlwaysReturn(size_t val)
+    void expect_maxThreads_WillAlwaysReturn(size_t val)
     {
-        d_maxThreads = val;
+        d_maxThreads_result = val;
     }
 
-    void set_createTimer_WillOnceReturn(
+    void expect_createTimer_WillOnceReturn(
         const bsl::shared_ptr<ntci::Timer>& timer)
     {
-        d_timer = timer;
+        d_timer_result = timer;
     }
 
-    void set_execute_expectedOnce()
+    void expect_execute_WillOnceReturn()
     {
-        d_executeExpected = true;
+        d_execute_expected = true;
     }
 
-    void set_aquireHandleReservation_WillAlwaysReturn(bool flag)
+    void expect_acquireHandleReservation_WillAlwaysReturn(bool flag)
     {
-        d_aquireHandleReservation = flag;
+        d_acquireHandleReservation_result = flag;
     }
 
-    void set_releaseHandleReservation_WillAlwaysReturn()
+    void expect_releaseHandleReservation_WillAlwaysReturn()
     {
         d_releaseHandleReservation = true;
     }
 
-    void set_attachSocket_WillOnceReturn(
+    void expect_attachSocket_WillOnceReturn(
         const bdlb::NullableValue<bsl::shared_ptr<ntci::ReactorSocket> >&
                            socket,
         const ntsa::Error& result)
     {
         NTCCFG_TEST_TRUE(d_attachSocket_result.isNull());
-        NTCCFG_TEST_TRUE(d_attachSocket_socket.isNull());
+        NTCCFG_TEST_TRUE(d_attachSocket_arg1.isNull());
 
         d_attachSocket_result = result;
-        d_attachSocket_socket = socket;
+        d_attachSocket_arg1   = socket;
     }
 
-    void set_showWritable_WillOnceReturn(
+    void expect_showWritable_WillOnceReturn(
         const bdlb::NullableValue<bsl::shared_ptr<ntci::ReactorSocket> >&
                            socket,
         const ntsa::Error& error)
     {
         NTCCFG_TEST_TRUE(d_showWritable_result.isNull());
-        NTCCFG_TEST_TRUE(d_showWritable_socket.isNull());
+        NTCCFG_TEST_TRUE(d_showWritable_arg1.isNull());
 
         d_showWritable_result = error;
-        d_showWritable_socket = socket;
+        d_showWritable_arg1   = socket;
     }
 
-    void set_detachSocket_WillOnceReturn(
+    void expect_detachSocket_WillOnceReturn(
         const bdlb::NullableValue<bsl::shared_ptr<ntci::ReactorSocket> >&
                                                                  socket,
         const bdlb::NullableValue<ntci::SocketDetachedCallback>& callback,
@@ -2271,26 +2274,26 @@ class ReactorMock : public ntci::Reactor
 
   private:
     bdlb::NullableValue<bsl::shared_ptr<bdlbb::BlobBufferFactory> >
-        d_incomingBlobBufferFactory;
+        d_incomingBlobBufferFactory_result;
     bdlb::NullableValue<bsl::shared_ptr<bdlbb::BlobBufferFactory> >
-                                  d_outgoingBlobBufferFactory;
+                                  d_outgoingBlobBufferFactory_result;
     bsl::shared_ptr<ntci::Strand> dummyStrand;
-    bdlb::NullableValue<bsl::shared_ptr<ntci::DataPool> > d_dataPool;
-    bdlb::NullableValue<bool>                             d_oneShot;
-    bdlb::NullableValue<size_t>                           d_maxThreads;
-    bdlb::NullableValue<bsl::shared_ptr<ntci::Timer> >    d_timer;
+    bdlb::NullableValue<bsl::shared_ptr<ntci::DataPool> > d_dataPool_result;
+    bdlb::NullableValue<bool>                             d_oneShot_result;
+    bdlb::NullableValue<size_t>                           d_maxThreads_result;
+    bdlb::NullableValue<bsl::shared_ptr<ntci::Timer> >    d_timer_result;
     bdlb::NullableValue<ntci::TimerCallback>              d_timerCallback;
-    bool                                                  d_executeExpected;
+    bool                                                  d_execute_expected;
     bdlb::NullableValue<ntci::Reactor::Functor>           d_execute_functor;
-    bdlb::NullableValue<bool> d_aquireHandleReservation;
+    bdlb::NullableValue<bool> d_acquireHandleReservation_result;
     bool                      d_releaseHandleReservation;
 
     bdlb::NullableValue<bsl::shared_ptr<ntci::ReactorSocket> >
-                                     d_attachSocket_socket;
+                                     d_attachSocket_arg1;
     bdlb::NullableValue<ntsa::Error> d_attachSocket_result;
 
     bdlb::NullableValue<bsl::shared_ptr<ntci::ReactorSocket> >
-                                     d_showWritable_socket;
+                                     d_showWritable_arg1;
     bdlb::NullableValue<ntsa::Error> d_showWritable_result;
 
     bdlb::NullableValue<ntsa::Error> d_detachSocket_result;
@@ -2305,19 +2308,19 @@ class TimerMock : public ntci::Timer
     ntsa::Error schedule(const bsls::TimeInterval& deadline,
                          const bsls::TimeInterval& period) override
     {
-        if (d_scheduleReturn_error.isNull()) {
+        if (d_schedule_result.isNull()) {
             UNEXPECTED_CALL();
         }
-        if (d_scheduleArg_deadline.has_value()) {
-            NTCCFG_TEST_EQ(deadline, d_scheduleArg_deadline.value());
-            d_scheduleArg_deadline.reset();
+        if (d_scheduleArg_arg1.has_value()) {
+            NTCCFG_TEST_EQ(deadline, d_scheduleArg_arg1.value());
+            d_scheduleArg_arg1.reset();
         }
-        if (d_scheduleArg_period.has_value()) {
-            NTCCFG_TEST_EQ(period, d_scheduleArg_period.value());
-            d_scheduleArg_period.reset();
+        if (d_scheduleArg_arg2.has_value()) {
+            NTCCFG_TEST_EQ(period, d_scheduleArg_arg2.value());
+            d_scheduleArg_arg2.reset();
         }
-        const auto error = d_scheduleReturn_error.value();
-        d_scheduleReturn_error.reset();
+        const auto error = d_schedule_result.value();
+        d_schedule_result.reset();
 
         return error;
     }
@@ -2328,11 +2331,11 @@ class TimerMock : public ntci::Timer
     }
     ntsa::Error close() override
     {
-        if (d_close_error.isNull()) {
+        if (d_close_result.isNull()) {
             UNEXPECTED_CALL();
         }
-        const auto res = d_close_error.value();
-        d_close_error.reset();
+        const auto res = d_close_result.value();
+        d_close_result.reset();
         return res;
     }
     void arrive(const bsl::shared_ptr<ntci::Timer>& self,
@@ -2377,28 +2380,28 @@ class TimerMock : public ntci::Timer
         return bsls::TimeInterval();
     }
 
-    void set_schedule_willOnceReturn(
+    void expect_schedule_willOnceReturn(
         const bdlb::NullableValue<bsls::TimeInterval>& deadline,
         const bdlb::NullableValue<bsls::TimeInterval>& period,
-        ntsa::Error                                    error)
+        const ntsa::Error&                             error)
     {
-        d_scheduleArg_deadline = deadline;
-        d_scheduleArg_period   = period;
-        d_scheduleReturn_error = error;
+        d_scheduleArg_arg1 = deadline;
+        d_scheduleArg_arg2 = period;
+        d_schedule_result  = error;
     }
 
-    void set_close_WillOnceReturn(const ntsa::Error& error)
+    void expect_close_WillOnceReturn(const ntsa::Error& error)
     {
-        d_close_error = error;
+        d_close_result = error;
     }
 
   private:
     bsl::shared_ptr<ntci::Strand> dummyStrand;
 
-    bdlb::NullableValue<bsls::TimeInterval> d_scheduleArg_deadline;
-    bdlb::NullableValue<bsls::TimeInterval> d_scheduleArg_period;
-    bdlb::NullableValue<ntsa::Error>        d_scheduleReturn_error;
-    bdlb::NullableValue<ntsa::Error>        d_close_error;
+    bdlb::NullableValue<bsls::TimeInterval> d_scheduleArg_arg1;
+    bdlb::NullableValue<bsls::TimeInterval> d_scheduleArg_arg2;
+    bdlb::NullableValue<ntsa::Error>        d_schedule_result;
+    bdlb::NullableValue<ntsa::Error>        d_close_result;
 };
 
 }  // close namespace mock
@@ -4409,21 +4412,23 @@ NTCCFG_TEST_CASE(22)
 
         bsl::shared_ptr<test::mock::DataPoolMock> dataPoolMock;
         dataPoolMock.createInplace(&ta);
-        reactorMock->set_dataPool_WillAlwaysReturn(dataPoolMock);
+        reactorMock->expect_dataPool_WillAlwaysReturn(dataPoolMock);
 
         bsl::shared_ptr<test::mock::BufferFactoryMock> bufferFactoryMock;
         bufferFactoryMock.createInplace(&ta);
-        reactorMock->set_outgoingBlobBufferFactory_WillAlwaysReturn(
+        reactorMock->expect_outgoingBlobBufferFactory_WillAlwaysReturn(
             bufferFactoryMock);
-        reactorMock->set_incomingBlobBufferFactory_WillAlwaysReturn(
+        reactorMock->expect_incomingBlobBufferFactory_WillAlwaysReturn(
             bufferFactoryMock);
 
-        reactorMock->set_oneShot_WillAlwaysReturn(false);
-        reactorMock->set_maxThreads_WillAlwaysReturn(1);
+        reactorMock->expect_oneShot_WillAlwaysReturn(false);
+        reactorMock->expect_maxThreads_WillAlwaysReturn(1);
 
-        dataPoolMock->set_createIncomingBlobBuffer_WillAlwaysReturn(nullBlob);
-        dataPoolMock->set_createOutgoingBlobBuffer_WillAlwaysReturn(nullBlob);
-        dataPoolMock->set_createOutgoingData_WillAlwaysReturn(dummyData);
+        dataPoolMock->expect_createIncomingBlobBuffer_WillAlwaysReturn(
+            nullBlob);
+        dataPoolMock->expect_createOutgoingBlobBuffer_WillAlwaysReturn(
+            nullBlob);
+        dataPoolMock->expect_createOutgoingData_WillAlwaysReturn(dummyData);
 
         const ntca::StreamSocketOptions options;
 
@@ -4438,9 +4443,9 @@ NTCCFG_TEST_CASE(22)
 
         bsl::shared_ptr<test::mock::TimerMock> connectRetryTimerMock;
         connectRetryTimerMock.createInplace(&ta);
-        reactorMock->set_createTimer_WillOnceReturn(connectRetryTimerMock);
+        reactorMock->expect_createTimer_WillOnceReturn(connectRetryTimerMock);
 
-        connectRetryTimerMock->set_schedule_willOnceReturn(
+        connectRetryTimerMock->expect_schedule_willOnceReturn(
             bdlb::NullOptType::makeInitialValue(),
             bdlb::NullOptType::makeInitialValue(),
             ntsa::Error());
@@ -4460,7 +4465,7 @@ NTCCFG_TEST_CASE(22)
 
         NTCI_LOG_DEBUG("Trigger internal timer to initiate connection...");
 
-        resolverMock->set_getEndpoint_WillOnceReturn(
+        resolverMock->expect_getEndpoint_WillOnceReturn(
             epName,
             bdlb::NullOptType::makeInitialValue(),
             ntsa::Error());
@@ -4473,8 +4478,8 @@ NTCCFG_TEST_CASE(22)
         NTCI_LOG_DEBUG("Shutdown socket while it is waiting for remote "
                        "endpoint resolution");
 
-        connectRetryTimerMock->set_close_WillOnceReturn(ntsa::Error());
-        reactorMock->set_execute_expectedOnce();
+        connectRetryTimerMock->expect_close_WillOnceReturn(ntsa::Error());
+        reactorMock->expect_execute_WillOnceReturn();
 
         socket.shutdown(ntsa::ShutdownType::e_BOTH,
                         ntsa::ShutdownMode::e_GRACEFUL);
@@ -4517,21 +4522,23 @@ NTCCFG_TEST_CASE(23)
 
         bsl::shared_ptr<test::mock::DataPoolMock> dataPoolMock;
         dataPoolMock.createInplace(&ta);
-        reactorMock->set_dataPool_WillAlwaysReturn(dataPoolMock);
+        reactorMock->expect_dataPool_WillAlwaysReturn(dataPoolMock);
 
         bsl::shared_ptr<test::mock::BufferFactoryMock> bufferFactoryMock;
         bufferFactoryMock.createInplace(&ta);
-        reactorMock->set_outgoingBlobBufferFactory_WillAlwaysReturn(
+        reactorMock->expect_outgoingBlobBufferFactory_WillAlwaysReturn(
             bufferFactoryMock);
-        reactorMock->set_incomingBlobBufferFactory_WillAlwaysReturn(
+        reactorMock->expect_incomingBlobBufferFactory_WillAlwaysReturn(
             bufferFactoryMock);
 
-        reactorMock->set_oneShot_WillAlwaysReturn(false);
-        reactorMock->set_maxThreads_WillAlwaysReturn(1);
+        reactorMock->expect_oneShot_WillAlwaysReturn(false);
+        reactorMock->expect_maxThreads_WillAlwaysReturn(1);
 
-        dataPoolMock->set_createIncomingBlobBuffer_WillAlwaysReturn(nullBlob);
-        dataPoolMock->set_createOutgoingBlobBuffer_WillAlwaysReturn(nullBlob);
-        dataPoolMock->set_createOutgoingData_WillAlwaysReturn(dummyData);
+        dataPoolMock->expect_createIncomingBlobBuffer_WillAlwaysReturn(
+            nullBlob);
+        dataPoolMock->expect_createOutgoingBlobBuffer_WillAlwaysReturn(
+            nullBlob);
+        dataPoolMock->expect_createOutgoingData_WillAlwaysReturn(dummyData);
 
         const ntca::StreamSocketOptions options;
 
@@ -4548,9 +4555,9 @@ NTCCFG_TEST_CASE(23)
 
         bsl::shared_ptr<test::mock::TimerMock> connectRetryTimerMock;
         connectRetryTimerMock.createInplace(&ta);
-        reactorMock->set_createTimer_WillOnceReturn(connectRetryTimerMock);
+        reactorMock->expect_createTimer_WillOnceReturn(connectRetryTimerMock);
 
-        connectRetryTimerMock->set_schedule_willOnceReturn(
+        connectRetryTimerMock->expect_schedule_willOnceReturn(
             bdlb::NullOptType::makeInitialValue(),
             bdlb::NullOptType::makeInitialValue(),
             ntsa::Error());
@@ -4570,10 +4577,10 @@ NTCCFG_TEST_CASE(23)
 
         NTCI_LOG_DEBUG("Trigger internal timer to initiate connection...");
 
-        reactorMock->set_aquireHandleReservation_WillAlwaysReturn(true);
-        reactorMock->set_releaseHandleReservation_WillAlwaysReturn();
-        reactorMock->set_attachSocket_WillOnceReturn(socket, ntsa::Error());
-        reactorMock->set_showWritable_WillOnceReturn(socket, ntsa::Error());
+        reactorMock->expect_acquireHandleReservation_WillAlwaysReturn(true);
+        reactorMock->expect_releaseHandleReservation_WillAlwaysReturn();
+        reactorMock->expect_attachSocket_WillOnceReturn(socket, ntsa::Error());
+        reactorMock->expect_showWritable_WillOnceReturn(socket, ntsa::Error());
 
         const auto       timerCallback = reactorMock->extract_timerCallback();
         ntca::TimerEvent timerEvent;
@@ -4583,9 +4590,9 @@ NTCCFG_TEST_CASE(23)
         NTCI_LOG_DEBUG(
             "Shutdown socket while it is waiting for connection result");
 
-        connectRetryTimerMock->set_close_WillOnceReturn(ntsa::Error());
+        connectRetryTimerMock->expect_close_WillOnceReturn(ntsa::Error());
 
-        reactorMock->set_detachSocket_WillOnceReturn(
+        reactorMock->expect_detachSocket_WillOnceReturn(
             socket,
             bdlb::NullOptType::makeInitialValue(),
             ntsa::Error());
@@ -4596,7 +4603,7 @@ NTCCFG_TEST_CASE(23)
         const auto detachCallback = reactorMock->extract_detachCallback();
         NTCCFG_TEST_TRUE(detachCallback);
 
-        reactorMock->set_execute_expectedOnce();
+        reactorMock->expect_execute_WillOnceReturn();
         detachCallback(nullStrand);
 
         const auto callback = reactorMock->extract_execute_functor();

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -1528,9 +1528,9 @@ NTF_MOCK_CLASS_END;
 
 NTF_MOCK_CLASS(DataPoolMock, ntci::DataPool)
 NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createIncomingData)
-NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createOutgoingData);
-NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createIncomingBlob);
-NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createOutgoingBlob);
+NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createOutgoingData)
+NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createIncomingBlob)
+NTF_MOCK_METHOD(bsl::shared_ptr<bdlbb::Blob>, createOutgoingBlob)
 NTF_MOCK_METHOD(void, createIncomingBlobBuffer, bdlbb::BlobBuffer*)
 NTF_MOCK_METHOD(void, createOutgoingBlobBuffer, bdlbb::BlobBuffer*)
 NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,

--- a/groups/ntc/ntcs/ntcs_proactordetachcontext.h
+++ b/groups/ntc/ntcs/ntcs_proactordetachcontext.h
@@ -332,6 +332,7 @@ ProactorDetachState::Value ProactorDetachContext::state() const
     }
 
     NTCCFG_UNREACHABLE();
+    return ProactorDetachState::e_ATTACHED;
 }
 
 NTCCFG_INLINE

--- a/targets.cmake
+++ b/targets.cmake
@@ -713,6 +713,7 @@ if (${NTF_BUILD_WITH_NTC})
         PRIVATE
     )
 
+    ntf_component(NAME ntcd_blobbufferfactory)
     ntf_component(NAME ntcd_datagramsocket)
     ntf_component(NAME ntcd_datautil)
     ntf_component(NAME ntcd_encryption)

--- a/targets.cmake
+++ b/targets.cmake
@@ -720,6 +720,7 @@ if (${NTF_BUILD_WITH_NTC})
     ntf_component(NAME ntcd_machine)
     ntf_component(NAME ntcd_proactor)
     ntf_component(NAME ntcd_reactor)
+    ntf_component(NAME ntcd_resolver)
     ntf_component(NAME ntcd_streamsocket)
     ntf_component(NAME ntcd_simulation)
 

--- a/targets.cmake
+++ b/targets.cmake
@@ -715,6 +715,7 @@ if (${NTF_BUILD_WITH_NTC})
 
     ntf_component(NAME ntcd_blobbufferfactory)
     ntf_component(NAME ntcd_datagramsocket)
+    ntf_component(NAME ntcd_datapool)
     ntf_component(NAME ntcd_datautil)
     ntf_component(NAME ntcd_encryption)
     ntf_component(NAME ntcd_listenersocket)

--- a/targets.cmake
+++ b/targets.cmake
@@ -724,6 +724,7 @@ if (${NTF_BUILD_WITH_NTC})
     ntf_component(NAME ntcd_resolver)
     ntf_component(NAME ntcd_streamsocket)
     ntf_component(NAME ntcd_simulation)
+    ntf_component(NAME ntcd_timer)
 
     ntf_package_end(NAME ntcd)
 


### PR DESCRIPTION
This PR brings an in-house lightweight framework to mock classes. The interface was inspired by existing mocking frameworks, though its current functionality is far behind from existing solutions. The main pro is that we do not introduce a dependancy to any new library.

This framework is used to test ntcr::StreamSocket shutdown sequence during connection phase.