### PR TITLE
Rename ntsi::{Datagram,Stream,Listener}Socket::isBlocking to getBlocking

### DIFF
--- a/groups/nts/ntsb/ntsb_datagramsocket.cpp
+++ b/groups/nts/ntsb/ntsb_datagramsocket.cpp
@@ -212,14 +212,14 @@ ntsa::Error DatagramSocket::setBlocking(bool blocking)
     return ntsu::SocketOptionUtil::setBlocking(d_handle, blocking);
 }
 
-ntsa::Error DatagramSocket::isBlocking(bool* blocking) const
-{
-    return ntsu::SocketOptionUtil::isBlocking(d_handle, blocking);
-}
-
 ntsa::Error DatagramSocket::setOption(const ntsa::SocketOption& option)
 {
     return ntsu::SocketOptionUtil::setOption(d_handle, option);
+}
+
+ntsa::Error DatagramSocket::getBlocking(bool* blocking) const
+{
+    return ntsu::SocketOptionUtil::getBlocking(d_handle, blocking);
 }
 
 ntsa::Error DatagramSocket::getOption(ntsa::SocketOption*           option,

--- a/groups/nts/ntsb/ntsb_datagramsocket.h
+++ b/groups/nts/ntsb/ntsb_datagramsocket.h
@@ -199,13 +199,13 @@ class DatagramSocket : public ntsi::DatagramSocket
     /// according to the specified 'blocking' flag. Return the error.
     ntsa::Error setBlocking(bool blocking) BSLS_KEYWORD_OVERRIDE;
 
-    /// Request the kernel if the socket is in a blocking mode and load the
-    /// result in the specified 'blocking' Return the error.
-    ntsa::Error isBlocking(bool* blocking) const BSLS_KEYWORD_OVERRIDE;
-
     /// Set the specified 'option' for this socket. Return the error.
     ntsa::Error setOption(const ntsa::SocketOption& option)
         BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'blocking' flag the blocking mode of the
+    /// specified 'socket'. Return the error.
+    ntsa::Error getBlocking(bool* blocking) const BSLS_KEYWORD_OVERRIDE;
 
     /// Load into the specified 'option' the socket option of the specified
     /// 'type' set for this socket. Return the error.

--- a/groups/nts/ntsb/ntsb_listenersocket.cpp
+++ b/groups/nts/ntsb/ntsb_listenersocket.cpp
@@ -188,14 +188,14 @@ ntsa::Error ListenerSocket::setBlocking(bool blocking)
     return ntsu::SocketOptionUtil::setBlocking(d_handle, blocking);
 }
 
-ntsa::Error ListenerSocket::isBlocking(bool* blocking) const
-{
-    return ntsu::SocketOptionUtil::isBlocking(d_handle, blocking);
-}
-
 ntsa::Error ListenerSocket::setOption(const ntsa::SocketOption& option)
 {
     return ntsu::SocketOptionUtil::setOption(d_handle, option);
+}
+
+ntsa::Error ListenerSocket::getBlocking(bool* blocking) const
+{
+    return ntsu::SocketOptionUtil::getBlocking(d_handle, blocking);
 }
 
 ntsa::Error ListenerSocket::getOption(ntsa::SocketOption*           option,

--- a/groups/nts/ntsb/ntsb_listenersocket.h
+++ b/groups/nts/ntsb/ntsb_listenersocket.h
@@ -146,13 +146,13 @@ class ListenerSocket : public ntsi::ListenerSocket
     /// according to the specified 'blocking' flag. Return the error.
     ntsa::Error setBlocking(bool blocking) BSLS_KEYWORD_OVERRIDE;
 
-    /// Request the kernel if the socket is in a blocking mode and load the
-    /// result in the specified 'blocking' Return the error.
-    ntsa::Error isBlocking(bool* blocking) const BSLS_KEYWORD_OVERRIDE;
-
     /// Set the specified 'option' for this socket. Return the error.
     ntsa::Error setOption(const ntsa::SocketOption& option)
         BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'blocking' flag the blocking mode of the
+    /// specified 'socket'. Return the error.
+    ntsa::Error getBlocking(bool* blocking) const BSLS_KEYWORD_OVERRIDE;
 
     /// Load into the specified 'option' the socket option of the specified
     /// 'type' set for this socket. Return the error.

--- a/groups/nts/ntsb/ntsb_streamsocket.cpp
+++ b/groups/nts/ntsb/ntsb_streamsocket.cpp
@@ -176,14 +176,14 @@ ntsa::Error StreamSocket::setBlocking(bool blocking)
     return ntsu::SocketOptionUtil::setBlocking(d_handle, blocking);
 }
 
-ntsa::Error StreamSocket::isBlocking(bool* blocking) const
-{
-    return ntsu::SocketOptionUtil::isBlocking(d_handle, blocking);
-}
-
 ntsa::Error StreamSocket::setOption(const ntsa::SocketOption& option)
 {
     return ntsu::SocketOptionUtil::setOption(d_handle, option);
+}
+
+ntsa::Error StreamSocket::getBlocking(bool* blocking) const
+{
+    return ntsu::SocketOptionUtil::getBlocking(d_handle, blocking);
 }
 
 ntsa::Error StreamSocket::getOption(ntsa::SocketOption*           option,

--- a/groups/nts/ntsb/ntsb_streamsocket.h
+++ b/groups/nts/ntsb/ntsb_streamsocket.h
@@ -165,13 +165,13 @@ class StreamSocket : public ntsi::StreamSocket
     /// according to the specified 'blocking' flag. Return the error.
     ntsa::Error setBlocking(bool blocking) BSLS_KEYWORD_OVERRIDE;
 
-    /// Request the kernel if the socket is in a blocking mode and load the
-    /// result in the specified 'blocking' Return the error.
-    ntsa::Error isBlocking(bool* blocking) const BSLS_KEYWORD_OVERRIDE;
-
     /// Set the specified 'option' for this socket. Return the error.
     ntsa::Error setOption(const ntsa::SocketOption& option)
         BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'blocking' flag the blocking mode of the
+    /// specified 'socket'. Return the error.
+    ntsa::Error getBlocking(bool* blocking) const BSLS_KEYWORD_OVERRIDE;
 
     /// Load into the specified 'option' the socket option of the specified
     /// 'type' set for this socket. Return the error.

--- a/groups/nts/ntsi/ntsi_datagramsocket.cpp
+++ b/groups/nts/ntsi/ntsi_datagramsocket.cpp
@@ -193,17 +193,16 @@ ntsa::Error DatagramSocket::setBlocking(bool blocking)
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 
-ntsa::Error DatagramSocket::isBlocking(bool* blocking) const
-{
-    NTSCFG_WARNING_UNUSED(blocking);
-
-    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
-}
-
 ntsa::Error DatagramSocket::setOption(const ntsa::SocketOption& option)
 {
     NTSCFG_WARNING_UNUSED(option);
 
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error DatagramSocket::getBlocking(bool* blocking) const
+{
+    *blocking = false;
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 

--- a/groups/nts/ntsi/ntsi_datagramsocket.h
+++ b/groups/nts/ntsi/ntsi_datagramsocket.h
@@ -571,12 +571,12 @@ class DatagramSocket : public ntsi::Channel
     /// according to the specified 'blocking' flag. Return the error.
     virtual ntsa::Error setBlocking(bool blocking);
 
-    /// If the socket is in a blocking mode then load true in the specified
-    /// 'blocking', otherwise load false. Return the error.
-    virtual ntsa::Error isBlocking(bool* blocking) const;
-
     /// Set the specified 'option' for this socket. Return the error.
     virtual ntsa::Error setOption(const ntsa::SocketOption& option);
+
+    /// Load into the specified 'blocking' flag the blocking mode of the
+    /// specified 'socket'. Return the error.
+    virtual ntsa::Error getBlocking(bool* blocking) const;
 
     /// Load into the specified 'option' the socket option of the specified
     /// 'type' set for this socket. Return the error.

--- a/groups/nts/ntsi/ntsi_listenersocket.cpp
+++ b/groups/nts/ntsi/ntsi_listenersocket.cpp
@@ -115,17 +115,16 @@ ntsa::Error ListenerSocket::setBlocking(bool blocking)
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 
-ntsa::Error ListenerSocket::isBlocking(bool* blocking) const
-{
-    NTSCFG_WARNING_UNUSED(blocking);
-
-    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
-}
-
 ntsa::Error ListenerSocket::setOption(const ntsa::SocketOption& option)
 {
     NTSCFG_WARNING_UNUSED(option);
 
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error ListenerSocket::getBlocking(bool* blocking) const
+{
+    *blocking = false;
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 

--- a/groups/nts/ntsi/ntsi_listenersocket.h
+++ b/groups/nts/ntsi/ntsi_listenersocket.h
@@ -176,12 +176,12 @@ class ListenerSocket : public ntsi::Descriptor
     /// according to the specified 'blocking' flag. Return the error.
     virtual ntsa::Error setBlocking(bool blocking);
 
-    /// If the socket is in a blocking mode then load true in the specified
-    /// 'blocking', otherwise load false. Return the error.
-    virtual ntsa::Error isBlocking(bool* blocking) const;
-
     /// Set the specified 'option' for this socket. Return the error.
     virtual ntsa::Error setOption(const ntsa::SocketOption& option);
+
+    /// Load into the specified 'blocking' flag the blocking mode of the
+    /// specified 'socket'. Return the error.
+    virtual ntsa::Error getBlocking(bool* blocking) const;
 
     /// Load into the specified 'option' the socket option of the specified
     /// 'type' set for this socket. Return the error.

--- a/groups/nts/ntsi/ntsi_streamsocket.cpp
+++ b/groups/nts/ntsi/ntsi_streamsocket.cpp
@@ -151,17 +151,16 @@ ntsa::Error StreamSocket::setBlocking(bool blocking)
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 
-ntsa::Error StreamSocket::isBlocking(bool* blocking) const
-{
-    NTSCFG_WARNING_UNUSED(blocking);
-
-    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
-}
-
 ntsa::Error StreamSocket::setOption(const ntsa::SocketOption& option)
 {
     NTSCFG_WARNING_UNUSED(option);
 
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error StreamSocket::getBlocking(bool* blocking) const
+{
+    *blocking = false;
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 

--- a/groups/nts/ntsi/ntsi_streamsocket.h
+++ b/groups/nts/ntsi/ntsi_streamsocket.h
@@ -341,12 +341,12 @@ class StreamSocket : public ntsi::Channel
     /// according to the specified 'blocking' flag. Return the error.
     virtual ntsa::Error setBlocking(bool blocking);
 
-    /// If the socket is in a blocking mode then load true in the specified
-    /// 'blocking', otherwise load false. Return the error.
-    virtual ntsa::Error isBlocking(bool* blocking) const;
-
     /// Set the specified 'option' for this socket. Return the error.
     virtual ntsa::Error setOption(const ntsa::SocketOption& option);
+
+    /// Load into the specified 'blocking' flag the blocking mode of the
+    /// specified 'socket'. Return the error.
+    virtual ntsa::Error getBlocking(bool* blocking) const;
 
     /// Load into the specified 'option' the socket option of the specified
     /// 'type' set for this socket. Return the error.

--- a/groups/nts/ntsu/ntsu_socketoptionutil.cpp
+++ b/groups/nts/ntsu/ntsu_socketoptionutil.cpp
@@ -348,18 +348,6 @@ ntsa::Error SocketOptionUtil::setBlocking(ntsa::Handle socket, bool blocking)
     return ntsa::Error();
 }
 
-ntsa::Error SocketOptionUtil::isBlocking(ntsa::Handle socket, bool* blocking)
-{
-    const int flags = fcntl(socket, F_GETFL, 0);
-    if (flags < 0) {
-        return ntsa::Error(errno);
-    }
-
-    *blocking = ((flags & O_NONBLOCK) == 0);
-
-    return ntsa::Error();
-}
-
 ntsa::Error SocketOptionUtil::setKeepAlive(ntsa::Handle socket, bool keepAlive)
 {
     int optionValue = static_cast<int>(keepAlive);
@@ -772,6 +760,20 @@ ntsa::Error SocketOptionUtil::setZeroCopy(ntsa::Handle socket, bool zeroCopy)
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 
 #endif
+}
+
+ntsa::Error SocketOptionUtil::getBlocking(ntsa::Handle socket, bool* blocking)
+{
+    *blocking = false;
+
+    const int flags = fcntl(socket, F_GETFL, 0);
+    if (flags < 0) {
+        return ntsa::Error(errno);
+    }
+
+    *blocking = ((flags & O_NONBLOCK) == 0);
+
+    return ntsa::Error();
 }
 
 ntsa::Error SocketOptionUtil::getKeepAlive(bool*        keepAlive,
@@ -1990,13 +1992,6 @@ ntsa::Error SocketOptionUtil::setBlocking(ntsa::Handle socket, bool blocking)
     return ntsa::Error();
 }
 
-ntsa::Error SocketOptionUtil::isBlocking(ntsa::Handle socket, bool* blocking)
-{
-    NTSCFG_WARNING_UNUSED(socket);
-    NTSCFG_WARNING_UNUSED(blocking);
-    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
-}
-
 ntsa::Error SocketOptionUtil::setKeepAlive(ntsa::Handle socket, bool keepAlive)
 {
     BOOL optionValue = static_cast<BOOL>(keepAlive);
@@ -2238,6 +2233,14 @@ ntsa::Error SocketOptionUtil::setInlineOutOfBandData(ntsa::Handle socket,
     }
 
     return ntsa::Error();
+}
+
+ntsa::Error SocketOptionUtil::getBlocking(ntsa::Handle socket, bool* blocking)
+{
+    NTSCFG_WARNING_UNUSED(socket);
+
+    *blocking = false;
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 
 ntsa::Error SocketOptionUtil::getKeepAlive(bool*        keepAlive,

--- a/groups/nts/ntsu/ntsu_socketoptionutil.h
+++ b/groups/nts/ntsu/ntsu_socketoptionutil.h
@@ -52,10 +52,6 @@ struct SocketOptionUtil {
     /// according to the specified 'blocking' flag. Return the error.
     static ntsa::Error setBlocking(ntsa::Handle socket, bool blocking);
 
-    /// If the specified 'socket' is in a blocking mode then load true in the
-    /// specified 'blocking', otherwise load false. Return the error.
-    static ntsa::Error isBlocking(ntsa::Handle handle, bool* blocking);
-
     /// Set the option for the specified 'socket' that controls automatic
     /// periodic transmission of TCP keep-alive packets according to the
     /// specified 'keepAlive' flag. Return the error.
@@ -151,6 +147,12 @@ struct SocketOptionUtil {
     static ntsa::Error getOption(ntsa::SocketOption*           option,
                                  ntsa::SocketOptionType::Value type,
                                  ntsa::Handle                  socket);
+
+    /// Load into the specified 'blocking' flag the blocking mode of the
+    /// specified 'socket'. Return the error. Note that this function always
+    /// returns an error on Windows, as determination of the blocking mode is
+    /// not supported on that platform.
+    static ntsa::Error getBlocking(ntsa::Handle handle, bool* blocking);
 
     /// Load into the specified 'keepAlive' flag the option for the
     /// specified 'socket' that controls automatic periodic transmission
@@ -298,15 +300,15 @@ struct SocketOptionUtil {
     static ntsa::Error isLocal(bool* result, ntsa::Handle socket);
 
     /// Return true if the specified 'socket' supports notifications, otherwise
-    /// return false. 
+    /// return false.
     static bool supportsNotifications(ntsa::Handle socket);
 
     /// Return true if the specified 'socket' supports timestamping, otherwise
-    /// return false. 
+    /// return false.
     static bool supportsTimestamping(ntsa::Handle socket);
 
     /// Return true if the specified 'socket' supports zero-copy, otherwise
-    /// return false. 
+    /// return false.
     static bool supportsZeroCopy(ntsa::Handle socket);
 
 };

--- a/groups/nts/ntsu/ntsu_socketoptionutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketoptionutil.t.cpp
@@ -1449,7 +1449,7 @@ NTSCFG_TEST_CASE(5)
         error = ntsu::SocketUtil::create(&socket, transport);
         NTSCFG_TEST_OK(error);
 
-        const bool isSupported = 
+        const bool isSupported =
             ntsu::SocketOptionUtil::supportsTimestamping(socket);
 
         if (isSupported) {
@@ -1485,8 +1485,8 @@ NTSCFG_TEST_CASE(5)
                     error = ntsu::SocketUtil::bind(
                         ntsa::Endpoint(
                             ntsa::IpEndpoint(
-                                ntsa::Ipv4Address::loopback(), 0)), 
-                        true, 
+                                ntsa::Ipv4Address::loopback(), 0)),
+                        true,
                         listener);
                     NTSCFG_TEST_OK(error);
                 }
@@ -1494,8 +1494,8 @@ NTSCFG_TEST_CASE(5)
                     error = ntsu::SocketUtil::bind(
                         ntsa::Endpoint(
                             ntsa::IpEndpoint(
-                                ntsa::Ipv6Address::loopback(), 0)), 
-                        true, 
+                                ntsa::Ipv6Address::loopback(), 0)),
+                        true,
                         listener);
                     NTSCFG_TEST_OK(error);
                 }
@@ -1756,7 +1756,7 @@ NTSCFG_TEST_CASE(6)
         error = ntsu::SocketUtil::create(&socket, transport);
         NTSCFG_TEST_OK(error);
 
-        const bool isSupported = 
+        const bool isSupported =
             ntsu::SocketOptionUtil::supportsZeroCopy(socket);
 
         if (isSupported) {
@@ -1775,7 +1775,7 @@ NTSCFG_TEST_CASE(6)
 
             error = ntsu::SocketOptionUtil::setZeroCopy(socket, true);
             NTSCFG_TEST_OK(error);
-            
+
             error = ntsu::SocketOptionUtil::getZeroCopy(&zeroCopy, socket);
             NTSCFG_TEST_OK(error);
             NTSCFG_TEST_TRUE(zeroCopy);
@@ -1873,7 +1873,7 @@ NTSCFG_TEST_CASE(7)
 
 NTSCFG_TEST_CASE(8)
 {
-    // Concern: test isLocal
+    // Concern: test setBlocking/getBlocking
 
     ntsa::Error error;
 
@@ -1916,17 +1916,20 @@ NTSCFG_TEST_CASE(8)
 
         ntsa::Handle socket;
         {
-            const ntsa::Error error = ntsu::SocketUtil::create(&socket, transport);
+            const ntsa::Error error =
+                ntsu::SocketUtil::create(&socket, transport);
             NTSCFG_TEST_OK(error);
         }
 
         {
-            const ntsa::Error error = ntsu::SocketOptionUtil::setBlocking(socket, false);
+            const ntsa::Error error =
+                ntsu::SocketOptionUtil::setBlocking(socket, false);
             NTSCFG_TEST_OK(error);
         }
         {
             bool blocking = true;
-            const ntsa::Error error = ntsu::SocketOptionUtil::isBlocking(socket, &blocking);
+            const ntsa::Error error =
+                ntsu::SocketOptionUtil::getBlocking(socket, &blocking);
 #if !defined(BSLS_PLATFORM_OS_WINDOWS)
             NTSCFG_TEST_OK(error);
             NTSCFG_TEST_FALSE(blocking);
@@ -1935,12 +1938,14 @@ NTSCFG_TEST_CASE(8)
 #endif
         }
         {
-            const ntsa::Error error = ntsu::SocketOptionUtil::setBlocking(socket, true);
+            const ntsa::Error error =
+                ntsu::SocketOptionUtil::setBlocking(socket, true);
             NTSCFG_TEST_OK(error);
         }
         {
             bool blocking = false;
-            const ntsa::Error error = ntsu::SocketOptionUtil::isBlocking(socket, &blocking);
+            const ntsa::Error error =
+                ntsu::SocketOptionUtil::getBlocking(socket, &blocking);
 #if !defined(BSLS_PLATFORM_OS_WINDOWS)
             NTSCFG_TEST_OK(error);
             NTSCFG_TEST_TRUE(blocking);
@@ -1949,12 +1954,14 @@ NTSCFG_TEST_CASE(8)
 #endif
         }
         {
-            const ntsa::Error error = ntsu::SocketOptionUtil::setBlocking(socket, false);
+            const ntsa::Error error =
+                ntsu::SocketOptionUtil::setBlocking(socket, false);
             NTSCFG_TEST_OK(error);
         }
         {
             bool blocking = true;
-            const ntsa::Error error = ntsu::SocketOptionUtil::isBlocking(socket, &blocking);
+            const ntsa::Error error =
+                ntsu::SocketOptionUtil::getBlocking(socket, &blocking);
 #if !defined(BSLS_PLATFORM_OS_WINDOWS)
             NTSCFG_TEST_OK(error);
             NTSCFG_TEST_FALSE(blocking);
@@ -1963,8 +1970,6 @@ NTSCFG_TEST_CASE(8)
 #endif
         }
     }
-
-
 }
 
 NTSCFG_TEST_DRIVER


### PR DESCRIPTION
This PR renames `ntsi::{Datagram,Stream,Listener}Socket::isBlocking` to `getBlocking` for consistency with `getOption`.