### PR TITLE
Make ntf-core build on C++03-only compilers

### DIFF
--- a/groups/ntc/ntco/ntco_kqueue.cpp
+++ b/groups/ntc/ntco/ntco_kqueue.cpp
@@ -1068,7 +1068,7 @@ Kqueue::Kqueue(const ntca::ReactorConfig&         configuration,
 })
 #else
 , d_detachFunctor(
-      NTCCFG_BIND(&Epoll::removeDetached, this, NTCCFG_BIND_PLACEHOLDER_1))
+      NTCCFG_BIND(&Kqueue::removeDetached, this, NTCCFG_BIND_PLACEHOLDER_1))
 #endif
 , d_registry(basicAllocator)
 , d_chronology(this, basicAllocator)


### PR DESCRIPTION
I tried to build ntf-core on Darwin using the `--ufid opt_64_cpp03` flag on clang, which exposed an issue in a seemingly unused code path in `ntco_kqueue`.  The issue appears to affect any C++03-only build of ntf-core, not just using clang.  Please see attached commit message for details.

There are numerous warnings, most of which having to do with variadic macro usage, which was only added in C++11, but which many earlier compilers supported as part of C99.

**Testing performed**
Built and tested as follows:

    ./configure --without-warnings-as-errors --ufid opt_64_cpp03
    make -j 16
    make test

All tests pass.
