### PR TITLE
Disable mocking test framework and dependant tests unless built with C++20

### DIFF
--- a/groups/ntc/ntccfg/ntccfg_test.h
+++ b/groups/ntc/ntccfg/ntccfg_test.h
@@ -700,6 +700,14 @@ class TestAllocator : public bslma::Allocator
         runTestCase##number();                                                \
         return 0;
 
+#if defined(BDE_BUILD_TARGET_CPP20)
+#define NTCCFG_TEST_MOCK_ENABLED 1
+#else
+#define NTCCFG_TEST_MOCK_ENABLED 0
+#endif
+
+#if NTCCFG_TEST_MOCK_ENABLED
+
 #define NTF_CAT2_(A, B) A##B
 #define NTF_CAT2(A, B) NTF_CAT2_(A, B)
 
@@ -1854,7 +1862,7 @@ struct Invocation<METHOD_INFO, RESULT, NoArgs>
 #define SET_ARG_3(...) setArg<2>(__VA_ARGS__)
 #define SET_ARG_4(...) setArg<3>(__VA_ARGS__)
 
-#endif
+#endif // NTFCFG_TEST_MOCK_ENABLED
 
 /// @internal @brief
 /// Log at the fatal severity level.
@@ -1979,3 +1987,6 @@ struct Invocation<METHOD_INFO, RESULT, NoArgs>
 #else
 #error Not implemented
 #endif
+
+#endif
+

--- a/groups/ntc/ntccfg/ntccfg_test.t.cpp
+++ b/groups/ntc/ntccfg/ntccfg_test.t.cpp
@@ -31,6 +31,9 @@ using namespace BloombergLP;
 // [ 1]
 //-----------------------------------------------------------------------------
 
+
+#if NTCCFG_TEST_MOCK_ENABLED
+
 namespace mock_test {
 
 class Interface
@@ -66,8 +69,12 @@ NTF_MOCK_CLASS_END;
 
 }
 
+#endif
+
 NTCCFG_TEST_CASE(1)
 {
+#if NTCCFG_TEST_MOCK_ENABLED
+
     using namespace mock_test;
 
     MyMock mock;
@@ -79,10 +86,14 @@ NTCCFG_TEST_CASE(1)
 
     NTCCFG_TEST_EQ(mock.f1(), 22);
     NTCCFG_TEST_EQ(mock.f1(), 33);
+
+#endif
 }
 
 NTCCFG_TEST_CASE(2)
 {
+#if NTCCFG_TEST_MOCK_ENABLED
+
     using namespace mock_test;
 
     MyMock mock;
@@ -118,10 +129,14 @@ NTCCFG_TEST_CASE(2)
         NTF_EXPECT_1(mock, f4, NTF_EQ(value)).ONCE();
         mock.f4(ref);
     }
+
+#endif
 }
 
 NTCCFG_TEST_CASE(3)
 {
+#if NTCCFG_TEST_MOCK_ENABLED
+
     using namespace mock_test;
 
     MyMock mock;
@@ -146,10 +161,14 @@ NTCCFG_TEST_CASE(3)
         mock.f4(data_ref);
         NTCCFG_TEST_EQ(data, newValue);
     }
+
+#endif
 }
 
 NTCCFG_TEST_CASE(4)
 {
+#if NTCCFG_TEST_MOCK_ENABLED
+
     using namespace mock_test;
 
     MyMock mock;
@@ -191,10 +210,14 @@ NTCCFG_TEST_CASE(4)
         mock.f4(val);
         NTCCFG_TEST_EQ(storage, val);
     }
+
+#endif
 }
 
 NTCCFG_TEST_CASE(5)
 {
+#if NTCCFG_TEST_MOCK_ENABLED
+
     using namespace mock_test;
 
     MyMock mock;
@@ -218,10 +241,14 @@ NTCCFG_TEST_CASE(5)
 
         mock.f5(&val, d);
     }
+
+#endif
 }
 
 NTCCFG_TEST_CASE(6)
 {
+#if NTCCFG_TEST_MOCK_ENABLED
+
     using namespace mock_test;
 
     MyMock mock;
@@ -254,6 +281,8 @@ NTCCFG_TEST_CASE(6)
         NTCCFG_TEST_EQ(res, sptrRef);
         NTCCFG_TEST_EQ(&res, &sptrRef);
     }
+
+#endif
 }
 
 NTCCFG_TEST_DRIVER

--- a/groups/ntc/ntcd/ntcd_blobbufferfactory.h
+++ b/groups/ntc/ntcd/ntcd_blobbufferfactory.h
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #ifndef INCLUDED_NTCD_BLOBBUFFERFACTORY
 #define INCLUDED_NTCD_BLOBBUFFERFACTORY
 
@@ -24,9 +25,13 @@ BSLS_IDENT("$Id: $")
 namespace BloombergLP {
 namespace ntcd {
 
+#if NTCCFG_TEST_MOCK_ENABLED
+
 NTF_MOCK_CLASS(BufferFactoryMock, bdlbb::BlobBufferFactory)
 NTF_MOCK_METHOD(void, allocate, bdlbb::BlobBuffer*)
 NTF_MOCK_CLASS_END;
+
+#endif
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/groups/ntc/ntcd/ntcd_datapool.h
+++ b/groups/ntc/ntcd/ntcd_datapool.h
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #ifndef INCLUDED_NTCD_DATAPOOL
 #define INCLUDED_NTCD_DATAPOOL
 
@@ -23,6 +24,8 @@ BSLS_IDENT("$Id: $")
 
 namespace BloombergLP {
 namespace ntcd {
+
+#if NTCCFG_TEST_MOCK_ENABLED
 
 NTF_MOCK_CLASS(DataPoolMock, ntci::DataPool)
 NTF_MOCK_METHOD(bsl::shared_ptr<ntsa::Data>, createIncomingData)
@@ -36,6 +39,8 @@ NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
 NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<bdlbb::BlobBufferFactory>&,
                       outgoingBlobBufferFactory)
 NTF_MOCK_CLASS_END;
+
+#endif
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/groups/ntc/ntcd/ntcd_reactor.h
+++ b/groups/ntc/ntcd/ntcd_reactor.h
@@ -622,6 +622,8 @@ class ReactorFactory : public ntci::ReactorFactory
         bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
 };
 
+#if NTCCFG_TEST_MOCK_ENABLED
+
 NTF_MOCK_CLASS(ReactorMock, ntci::Reactor)
 
 NTF_MOCK_METHOD(bsl::shared_ptr<ntci::DatagramSocket>,
@@ -777,6 +779,8 @@ NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<ntci::Strand>&, strand)
 NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
 
 NTF_MOCK_CLASS_END;
+
+#endif
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/groups/ntc/ntcd/ntcd_resolver.h
+++ b/groups/ntc/ntcd/ntcd_resolver.h
@@ -24,6 +24,8 @@ BSLS_IDENT("$Id: $")
 namespace BloombergLP {
 namespace ntcd {
 
+#if NTCCFG_TEST_MOCK_ENABLED
+
 NTF_MOCK_CLASS(ResolverMock, ntci::Resolver)
 
 NTF_MOCK_METHOD(void, execute, const Functor&)
@@ -123,6 +125,7 @@ NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
 
 NTF_MOCK_CLASS_END;
 
+#endif
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/groups/ntc/ntcd/ntcd_streamsocket.h
+++ b/groups/ntc/ntcd/ntcd_streamsocket.h
@@ -249,6 +249,8 @@ class StreamSocketFactory : public ntci::StreamSocketFactory
         bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
 };
 
+#if NTCCFG_TEST_MOCK_ENABLED
+
 NTF_MOCK_CLASS(StreamSocketMock, ntsi::StreamSocket)
 
 NTF_MOCK_METHOD_CONST(ntsa::Handle, handle)
@@ -299,6 +301,8 @@ NTF_MOCK_METHOD(ntsa::Error, getLastError, ntsa::Error*)
 NTF_MOCK_METHOD_CONST(bsl::size_t, maxBuffersPerSend)
 NTF_MOCK_METHOD_CONST(bsl::size_t, maxBuffersPerReceive)
 NTF_MOCK_CLASS_END;
+
+#endif
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/groups/ntc/ntcd/ntcd_timer.h
+++ b/groups/ntc/ntcd/ntcd_timer.h
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #ifndef INCLUDED_NTCD_TIMER
 #define INCLUDED_NTCD_TIMER
 
@@ -23,6 +24,8 @@ BSLS_IDENT("$Id: $")
 
 namespace BloombergLP {
 namespace ntcd {
+
+#if NTCCFG_TEST_MOCK_ENABLED
 
 NTF_MOCK_CLASS(TimerMock, ntci::Timer)
 NTF_MOCK_METHOD(ntsa::Error,
@@ -44,6 +47,8 @@ NTF_MOCK_METHOD_CONST(size_t, threadIndex)
 NTF_MOCK_METHOD_CONST(const bsl::shared_ptr<ntci::Strand>&, strand)
 NTF_MOCK_METHOD_CONST(bsls::TimeInterval, currentTime)
 NTF_MOCK_CLASS_END;
+
+#endif
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -54,6 +54,8 @@
 #include <bslmt_threadutil.h>
 #include <bsl_unordered_map.h>
 
+#if NTCCFG_TEST_MOCK_ENABLED
+
 using namespace BloombergLP;
 
 // Uncomment to test a particular style of socket-to-thread load balancing,
@@ -4543,3 +4545,17 @@ NTCCFG_TEST_DRIVER
     NTCCFG_TEST_REGISTER(27);
 }
 NTCCFG_TEST_DRIVER_END;
+
+#else
+
+NTCCFG_TEST_CASE(1)
+{
+}
+
+NTCCFG_TEST_DRIVER
+{
+    NTCCFG_TEST_REGISTER(1);
+}
+NTCCFG_TEST_DRIVER_END;
+
+#endif


### PR DESCRIPTION
This PR disables the new mocking framework used in some test drivers unless the project is built for C++20. There are some compilation errors on older compilers, namely C++03-like Solaris Studio and IBMS's xlC that need to be fixed before we unconditionally enable these new tests.