### PR TITLE
Implement ntsu::SocketOptionUtil::get/setTcpCongestionControl on Windows, implement ntsf::System::getBlocking

### DIFF
--- a/groups/nts/ntsf/ntsf_system.cpp
+++ b/groups/nts/ntsf/ntsf_system.cpp
@@ -864,6 +864,11 @@ ntsa::Error System::getOption(ntsa::SocketOption*           option,
     return ntsu::SocketOptionUtil::getOption(option, type, socket);
 }
 
+ntsa::Error System::getBlocking(ntsa::Handle socket, bool* blocking)
+{
+    return ntsu::SocketOptionUtil::getBlocking(socket, blocking);
+}
+
 ntsa::Error System::getSourceEndpoint(ntsa::Endpoint* result,
                                       ntsa::Handle    socket)
 {

--- a/groups/nts/ntsf/ntsf_system.h
+++ b/groups/nts/ntsf/ntsf_system.h
@@ -1223,6 +1223,12 @@ struct System {
                                  ntsa::Handle                  socket,
                                  ntsa::SocketOptionType::Value type);
 
+    /// Load into the specified 'blocking' flag the blocking mode of the
+    /// specified 'socket'. Return the error. Note that this function always
+    /// returns an error on Windows, as determination of the blocking mode is
+    /// not supported on that platform.
+    static ntsa::Error getBlocking(ntsa::Handle socket, bool* blocking);
+
     /// Load into the specified 'result' the source (i.e. local) endpoint of
     /// the specified 'socket'. Return the error.
     static ntsa::Error getSourceEndpoint(ntsa::Endpoint* result,
@@ -1592,7 +1598,7 @@ struct System {
 class SystemGuard
 {
   private:
-    SystemGuard(const SystemGuard&) BSLS_KEYWORD_DELETED;
+                 SystemGuard(const SystemGuard&) BSLS_KEYWORD_DELETED;
     SystemGuard& operator=(const SystemGuard&) BSLS_KEYWORD_DELETED;
 
   public:
@@ -1622,7 +1628,7 @@ class HandleGuard
     ntsa::Handle d_handle;
 
   private:
-    HandleGuard(const HandleGuard&) BSLS_KEYWORD_DELETED;
+                 HandleGuard(const HandleGuard&) BSLS_KEYWORD_DELETED;
     HandleGuard& operator=(const HandleGuard&) BSLS_KEYWORD_DELETED;
 
   public:

--- a/groups/nts/ntsu/ntsu_socketoptionutil.cpp
+++ b/groups/nts/ntsu/ntsu_socketoptionutil.cpp
@@ -2163,6 +2163,16 @@ ntsa::Error SocketOptionUtil::setZeroCopy(ntsa::Handle socket, bool zeroCopy)
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 
+ntsa::Error SocketOptionUtil::setTcpCongestionControl(
+    ntsa::Handle                      socket,
+    const ntsa::TcpCongestionControl& algorithm)
+{
+    NTSCFG_WARNING_UNUSED(socket);
+    NTSCFG_WARNING_UNUSED(algorithm);
+
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
 ntsa::Error SocketOptionUtil::setLinger(ntsa::Handle              socket,
                                         bool                      linger,
                                         const bsls::TimeInterval& duration)
@@ -2661,6 +2671,15 @@ ntsa::Error SocketOptionUtil::getZeroCopy(bool*        zeroCopyFlag,
 
     *zeroCopyFlag = false;
 
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error SocketOptionUtil::getTcpCongestionControl(
+    ntsa::TcpCongestionControl* algorithm,
+    ntsa::Handle                socket)
+{
+    NTSCFG_WARNING_UNUSED(algorithm);
+    NTSCFG_WARNING_UNUSED(socket);
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 


### PR DESCRIPTION
The only change in ntccfg_test.h is that clang-format was applied + specialization of `InvocationResult<void>` was moved outside of `TestMock` definition. Otherwise it's a compilation error.