### PR TITLE
ntsu::SocketUtil::pair: always set `reuseAddress` to false

### DIFF
--- a/groups/nts/ntsu/ntsu_socketutil.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.cpp
@@ -3984,14 +3984,6 @@ ntsa::Error SocketUtil::pair(ntsa::Handle*          client,
                              ntsa::Handle*          server,
                              ntsa::Transport::Value type)
 {
-    return pair(client, server, type, true);
-}
-
-ntsa::Error SocketUtil::pair(ntsa::Handle*          client,
-                             ntsa::Handle*          server,
-                             ntsa::Transport::Value type,
-                             bool                   reuseAddress)
-{
     ntsa::Error error;
 
     if (type == ntsa::Transport::e_TCP_IPV4_STREAM) {
@@ -4005,7 +3997,7 @@ ntsa::Error SocketUtil::pair(ntsa::Handle*          client,
 
         error = ntsu::SocketUtil::bind(
             ntsa::Endpoint(ntsa::IpEndpoint(ntsa::Ipv4Address::loopback(), 0)),
-            reuseAddress,
+            false,
             listener);
         if (error) {
             return error;
@@ -4052,7 +4044,7 @@ ntsa::Error SocketUtil::pair(ntsa::Handle*          client,
 
         error = ntsu::SocketUtil::bind(
             ntsa::Endpoint(ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0)),
-            reuseAddress,
+            false,
             listener);
         if (error) {
             return error;
@@ -4105,7 +4097,7 @@ ntsa::Error SocketUtil::pair(ntsa::Handle*          client,
 
         error = ntsu::SocketUtil::bind(
             ntsa::Endpoint(ntsa::IpEndpoint(ntsa::Ipv4Address::loopback(), 0)),
-            reuseAddress,
+            false,
             *client);
         if (error) {
             return error;
@@ -4113,7 +4105,7 @@ ntsa::Error SocketUtil::pair(ntsa::Handle*          client,
 
         error = ntsu::SocketUtil::bind(
             ntsa::Endpoint(ntsa::IpEndpoint(ntsa::Ipv4Address::loopback(), 0)),
-            reuseAddress,
+            false,
             *server);
         if (error) {
             return error;
@@ -4161,7 +4153,7 @@ ntsa::Error SocketUtil::pair(ntsa::Handle*          client,
 
         error = ntsu::SocketUtil::bind(
             ntsa::Endpoint(ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0)),
-            reuseAddress,
+            false,
             *client);
         if (error) {
             return error;
@@ -4169,7 +4161,7 @@ ntsa::Error SocketUtil::pair(ntsa::Handle*          client,
 
         error = ntsu::SocketUtil::bind(
             ntsa::Endpoint(ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0)),
-            reuseAddress,
+            false,
             *server);
         if (error) {
             return error;

--- a/groups/nts/ntsu/ntsu_socketutil.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.cpp
@@ -3984,6 +3984,14 @@ ntsa::Error SocketUtil::pair(ntsa::Handle*          client,
                              ntsa::Handle*          server,
                              ntsa::Transport::Value type)
 {
+    return pair(client, server, type, true);
+}
+
+ntsa::Error SocketUtil::pair(ntsa::Handle*          client,
+                             ntsa::Handle*          server,
+                             ntsa::Transport::Value type,
+                             bool                   reuseAddress)
+{
     ntsa::Error error;
 
     if (type == ntsa::Transport::e_TCP_IPV4_STREAM) {
@@ -3997,7 +4005,7 @@ ntsa::Error SocketUtil::pair(ntsa::Handle*          client,
 
         error = ntsu::SocketUtil::bind(
             ntsa::Endpoint(ntsa::IpEndpoint(ntsa::Ipv4Address::loopback(), 0)),
-            true,
+            reuseAddress,
             listener);
         if (error) {
             return error;
@@ -4044,7 +4052,7 @@ ntsa::Error SocketUtil::pair(ntsa::Handle*          client,
 
         error = ntsu::SocketUtil::bind(
             ntsa::Endpoint(ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0)),
-            true,
+            reuseAddress,
             listener);
         if (error) {
             return error;
@@ -4097,7 +4105,7 @@ ntsa::Error SocketUtil::pair(ntsa::Handle*          client,
 
         error = ntsu::SocketUtil::bind(
             ntsa::Endpoint(ntsa::IpEndpoint(ntsa::Ipv4Address::loopback(), 0)),
-            true,
+            reuseAddress,
             *client);
         if (error) {
             return error;
@@ -4105,7 +4113,7 @@ ntsa::Error SocketUtil::pair(ntsa::Handle*          client,
 
         error = ntsu::SocketUtil::bind(
             ntsa::Endpoint(ntsa::IpEndpoint(ntsa::Ipv4Address::loopback(), 0)),
-            true,
+            reuseAddress,
             *server);
         if (error) {
             return error;
@@ -4153,7 +4161,7 @@ ntsa::Error SocketUtil::pair(ntsa::Handle*          client,
 
         error = ntsu::SocketUtil::bind(
             ntsa::Endpoint(ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0)),
-            true,
+            reuseAddress,
             *client);
         if (error) {
             return error;
@@ -4161,7 +4169,7 @@ ntsa::Error SocketUtil::pair(ntsa::Handle*          client,
 
         error = ntsu::SocketUtil::bind(
             ntsa::Endpoint(ntsa::IpEndpoint(ntsa::Ipv6Address::loopback(), 0)),
-            true,
+            reuseAddress,
             *server);
         if (error) {
             return error;
@@ -5389,7 +5397,7 @@ ntsa::Error SocketUtil::bind(const ntsa::Endpoint& endpoint,
     ntsa::Error error;
 
 #if NTSCFG_BUILD_WITH_TRANSPORT_PROTOCOL_LOCAL
-    const bool  isLocal = endpoint.isLocal();
+    const bool isLocal = endpoint.isLocal();
 #else
     const bool isLocal = false;
 #endif
@@ -6854,7 +6862,7 @@ ntsa::Error SocketUtil::receive(bsl::size_t* numBytesReceived,
     DWORD wsaFlags            = 0;
 
     int wsaRecvResult =
-            WSARecv(socket, &wsaBuf, 1, &wsaNumBytesReceived, &wsaFlags, 0, 0);
+        WSARecv(socket, &wsaBuf, 1, &wsaNumBytesReceived, &wsaFlags, 0, 0);
 
     if (wsaRecvResult != 0) {
         return ntsa::Error(WSAGetLastError());

--- a/groups/nts/ntsu/ntsu_socketutil.h
+++ b/groups/nts/ntsu/ntsu_socketutil.h
@@ -707,6 +707,14 @@ struct SocketUtil {
                             ntsa::Handle*          server,
                             ntsa::Transport::Value type);
 
+    /// Load into the specified 'client' and 'server' a connected pair of
+    /// sockets of the specified 'type'. Additionally, use the specified
+    /// 'reuseAddress' flag when binding the sockets. Return the error.
+    static ntsa::Error pair(ntsa::Handle*          client,
+                            ntsa::Handle*          server,
+                            ntsa::Transport::Value type,
+                            bool                   reuseAddress);
+
     /// Load into the specified 'endpoint' the conversion of the specified
     /// 'socketAddress' having the specified 'socketAddressSize'. Return the
     /// error.

--- a/groups/nts/ntsu/ntsu_socketutil.h
+++ b/groups/nts/ntsu/ntsu_socketutil.h
@@ -707,14 +707,6 @@ struct SocketUtil {
                             ntsa::Handle*          server,
                             ntsa::Transport::Value type);
 
-    /// Load into the specified 'client' and 'server' a connected pair of
-    /// sockets of the specified 'type'. Additionally, use the specified
-    /// 'reuseAddress' flag when binding the sockets. Return the error.
-    static ntsa::Error pair(ntsa::Handle*          client,
-                            ntsa::Handle*          server,
-                            ntsa::Transport::Value type,
-                            bool                   reuseAddress);
-
     /// Load into the specified 'endpoint' the conversion of the specified
     /// 'socketAddress' having the specified 'socketAddressSize'. Return the
     /// error.

--- a/groups/nts/ntsu/ntsu_socketutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.t.cpp
@@ -7290,7 +7290,7 @@ NTSCFG_TEST_CASE(18)
 
         ntsa::Handle client;
         ntsa::Handle server;
-        error = ntsu::SocketUtil::pair(&client, &server, transport, false);
+        error = ntsu::SocketUtil::pair(&client, &server, transport);
         NTSCFG_TEST_ASSERT(!error);
 
         ntsa::Endpoint clientEndpoint;

--- a/groups/nts/ntsu/ntsu_socketutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.t.cpp
@@ -7290,7 +7290,7 @@ NTSCFG_TEST_CASE(18)
 
         ntsa::Handle client;
         ntsa::Handle server;
-        error = ntsu::SocketUtil::pair(&client, &server, transport);
+        error = ntsu::SocketUtil::pair(&client, &server, transport, false);
         NTSCFG_TEST_ASSERT(!error);
 
         ntsa::Endpoint clientEndpoint;
@@ -7330,6 +7330,8 @@ NTSCFG_TEST_CASE(18)
             error =
                 ntsu::SocketUtil::receive(&context, &data, options, server);
             NTSCFG_TEST_ASSERT(!error);
+            NTSCFG_TEST_EQ(context.bytesReceived(), 1);
+            NTSCFG_TEST_EQ(context.bytesReceivable(), 1);
 
             NTSCFG_TEST_ASSERT(!context.endpoint().isNull());
 


### PR DESCRIPTION
It appears that when creating a udp socket pair via 'ntsu::SocketUtil::pair()` sometimes both sockets are bound to the same address, which causes an issue when sending and receiving messages in a test driver. See issue: #36 
Allowing to reuse address when binding to a local address seems to be a mistake.