### PR TITLE
add test for `ntsa::Ipv4Address::less()`

### DIFF
--- a/groups/nts/ntsa/ntsa_ipv4address.t.cpp
+++ b/groups/nts/ntsa/ntsa_ipv4address.t.cpp
@@ -160,10 +160,23 @@ NTSCFG_TEST_CASE(3)
     NTSCFG_TEST_ASSERT(addressSet.size() == 2);
 }
 
+NTSCFG_TEST_CASE(4)
+{
+    // Concern: IPv4 address comparison must yield consistent result across
+    //          CPUs with varying endianness
+    // Plan:
+
+    ntsa::Ipv4Address address1("10.0.0.11");
+    ntsa::Ipv4Address address2("11.0.0.10");
+
+    NTSCFG_TEST_ASSERT(address1 < address2);
+}
+
 NTSCFG_TEST_DRIVER
 {
     NTSCFG_TEST_REGISTER(1);
     NTSCFG_TEST_REGISTER(2);
     NTSCFG_TEST_REGISTER(3);
+    NTSCFG_TEST_REGISTER(4);
 }
 NTSCFG_TEST_DRIVER_END;


### PR DESCRIPTION
Add test case comparing IPv4 addresses to alleviate concerns that result depends on CPU endianness. This test was confirmed passing on x86_64 and sparc

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
