### PR TITLE
Add tsan.supp file to ignore some tsan warnings

### DIFF
--- a/tsan.supp
+++ b/tsan.supp
@@ -1,0 +1,5 @@
+race:bsl::shared_ptr::shared_ptr
+race:bsl::shared_ptr<*>::get
+race:BloombergLP::bdlma::ConcurrentPool::allocate
+race:BloombergLP::bdlcc::ObjectPool<*>::getObject
+deadlock:ntcd::Session::step

--- a/tsan.supp
+++ b/tsan.supp
@@ -1,4 +1,4 @@
-race:bsl::shared_ptr::shared_ptr
+race:bsl::shared_ptr<*>::shared_ptr
 race:bsl::shared_ptr<*>::get
 race:BloombergLP::bdlma::ConcurrentPool::allocate
 race:BloombergLP::bdlcc::ObjectPool<*>::getObject


### PR DESCRIPTION
This file can be used to suppress know tsan errors/warnings in ntf-core tests.
`BDE` and `ntf-core` were built with thread sanitizer enabled.

To use this file do: 
`TSAN_OPTIONS=suppressions=tsan.supp ./executable`