### PR TITLE
Use weak_ptr when creating a callback for resolver in ntcr/ntcp::StreamSocket

### DIFF
--- a/groups/ntc/ntcp/ntcp_streamsocket.h
+++ b/groups/ntc/ntcp/ntcp_streamsocket.h
@@ -490,8 +490,7 @@ class StreamSocket : public ntci::StreamSocket,
     void privateRetryConnect(const bsl::shared_ptr<StreamSocket>& self);
 
     /// Retry connecting to the remote name. Return the error.
-    ntsa::Error privateRetryConnectToName(
-        const bsl::shared_ptr<StreamSocket>& self);
+    ntsa::Error privateRetryConnectToName();
 
     /// Retry connecting to the remote endpoint. Return the error.
     ntsa::Error privateRetryConnectToEndpoint(

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -3852,22 +3852,6 @@ void StreamSocket::processSourceEndpointResolution(
     }
 }
 
-void StreamSocket::processRemoteEndpointResolutionWeak(
-    const bsl::weak_ptr<StreamSocket>&     socket,
-    const bsl::shared_ptr<ntci::Resolver>& resolver,
-    const ntsa::Endpoint&                  endpoint,
-    const ntca::GetEndpointEvent&          getEndpointEvent,
-    bsl::size_t                            connectAttempts)
-{
-    const bsl::shared_ptr<StreamSocket> strongRef = socket.lock();
-    if (strongRef) {
-        strongRef->processRemoteEndpointResolution(resolver,
-                                                   endpoint,
-                                                   getEndpointEvent,
-                                                   connectAttempts);
-    }
-}
-
 void StreamSocket::processRemoteEndpointResolution(
     const bsl::shared_ptr<ntci::Resolver>& resolver,
     const ntsa::Endpoint&                  endpoint,
@@ -4008,8 +3992,8 @@ ntsa::Error StreamSocket::privateUpgrade(
         bdlf::MemFnUtil::memFn(&StreamSocket::privateEncryptionHandshake,
                                this);
 
-    error =
-        d_encryption_sp->initiateHandshake(upgradeOptions, handshakeCallback);
+    error = d_encryption_sp->initiateHandshake(
+        upgradeOptions, handshakeCallback);
     if (error) {
         return error;
     }
@@ -4142,7 +4126,7 @@ void StreamSocket::privateRetryConnect(
         error = this->privateRetryConnectToEndpoint(self);
     }
     else {
-        error = this->privateRetryConnectToName();
+        error = this->privateRetryConnectToName(self);
     }
 
     if (error) {
@@ -4150,7 +4134,8 @@ void StreamSocket::privateRetryConnect(
     }
 }
 
-ntsa::Error StreamSocket::privateRetryConnectToName()
+ntsa::Error StreamSocket::privateRetryConnectToName(
+    const bsl::shared_ptr<StreamSocket>& self)
 {
     ntsa::Error error;
 
@@ -4164,8 +4149,8 @@ ntsa::Error StreamSocket::privateRetryConnectToName()
 
     ntci::GetEndpointCallback getEndpointCallback =
         resolverRef->createGetEndpointCallback(
-            NTCCFG_BIND(&StreamSocket::processRemoteEndpointResolutionWeak,
-                        this->weak_from_this(),
+            NTCCFG_BIND(&StreamSocket::processRemoteEndpointResolution,
+                        self,
                         NTCCFG_BIND_PLACEHOLDER_1,
                         NTCCFG_BIND_PLACEHOLDER_2,
                         NTCCFG_BIND_PLACEHOLDER_3,
@@ -4292,9 +4277,9 @@ ntsa::Error StreamSocket::privateTimestampOutgoingData(
 
     {
         ntsa::SocketOption option(d_allocator_p);
-        error =
-            d_socket_sp->getOption(&option,
-                                   ntsa::SocketOptionType::e_TX_TIMESTAMPING);
+        error = d_socket_sp->getOption(
+            &option,
+            ntsa::SocketOptionType::e_TX_TIMESTAMPING);
         if (error) {
             if (error != ntsa::Error::e_NOT_IMPLEMENTED) {
                 NTCI_LOG_TRACE("Failed to get socket option: "
@@ -4372,9 +4357,9 @@ ntsa::Error StreamSocket::privateTimestampIncomingData(
 
     {
         ntsa::SocketOption option(d_allocator_p);
-        error =
-            d_socket_sp->getOption(&option,
-                                   ntsa::SocketOptionType::e_RX_TIMESTAMPING);
+        error = d_socket_sp->getOption(
+            &option,
+            ntsa::SocketOptionType::e_RX_TIMESTAMPING);
         if (error) {
             if (error != ntsa::Error::e_NOT_IMPLEMENTED) {
                 NTCI_LOG_TRACE("Failed to get socket option: "

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -3992,8 +3992,8 @@ ntsa::Error StreamSocket::privateUpgrade(
         bdlf::MemFnUtil::memFn(&StreamSocket::privateEncryptionHandshake,
                                this);
 
-    error = d_encryption_sp->initiateHandshake(
-        upgradeOptions, handshakeCallback);
+    error =
+        d_encryption_sp->initiateHandshake(upgradeOptions, handshakeCallback);
     if (error) {
         return error;
     }
@@ -4126,7 +4126,7 @@ void StreamSocket::privateRetryConnect(
         error = this->privateRetryConnectToEndpoint(self);
     }
     else {
-        error = this->privateRetryConnectToName(self);
+        error = this->privateRetryConnectToName();
     }
 
     if (error) {
@@ -4134,9 +4134,24 @@ void StreamSocket::privateRetryConnect(
     }
 }
 
-ntsa::Error StreamSocket::privateRetryConnectToName(
-    const bsl::shared_ptr<StreamSocket>& self)
+ntsa::Error StreamSocket::privateRetryConnectToName()
 {
+    struct WeakBinder {
+        static void invoke(const bsl::weak_ptr<StreamSocket>&     socket,
+                           const bsl::shared_ptr<ntci::Resolver>& resolver,
+                           const ntsa::Endpoint&                  endpoint,
+                           const ntca::GetEndpointEvent& getEndpointEvent,
+                           bsl::size_t                   connectAttempts)
+        {
+            const bsl::shared_ptr<StreamSocket> strongRef = socket.lock();
+            if (strongRef) {
+                strongRef->processRemoteEndpointResolution(resolver,
+                                                           endpoint,
+                                                           getEndpointEvent,
+                                                           connectAttempts);
+            }
+        }
+    };
     ntsa::Error error;
 
     ntcs::ObserverRef<ntci::Resolver> resolverRef(&d_resolver);
@@ -4149,8 +4164,8 @@ ntsa::Error StreamSocket::privateRetryConnectToName(
 
     ntci::GetEndpointCallback getEndpointCallback =
         resolverRef->createGetEndpointCallback(
-            NTCCFG_BIND(&StreamSocket::processRemoteEndpointResolution,
-                        self,
+            NTCCFG_BIND(&WeakBinder::invoke,
+                        this->weak_from_this(),
                         NTCCFG_BIND_PLACEHOLDER_1,
                         NTCCFG_BIND_PLACEHOLDER_2,
                         NTCCFG_BIND_PLACEHOLDER_3,
@@ -4277,9 +4292,9 @@ ntsa::Error StreamSocket::privateTimestampOutgoingData(
 
     {
         ntsa::SocketOption option(d_allocator_p);
-        error = d_socket_sp->getOption(
-            &option,
-            ntsa::SocketOptionType::e_TX_TIMESTAMPING);
+        error =
+            d_socket_sp->getOption(&option,
+                                   ntsa::SocketOptionType::e_TX_TIMESTAMPING);
         if (error) {
             if (error != ntsa::Error::e_NOT_IMPLEMENTED) {
                 NTCI_LOG_TRACE("Failed to get socket option: "
@@ -4357,9 +4372,9 @@ ntsa::Error StreamSocket::privateTimestampIncomingData(
 
     {
         ntsa::SocketOption option(d_allocator_p);
-        error = d_socket_sp->getOption(
-            &option,
-            ntsa::SocketOptionType::e_RX_TIMESTAMPING);
+        error =
+            d_socket_sp->getOption(&option,
+                                   ntsa::SocketOptionType::e_RX_TIMESTAMPING);
         if (error) {
             if (error != ntsa::Error::e_NOT_IMPLEMENTED) {
                 NTCI_LOG_TRACE("Failed to get socket option: "

--- a/groups/ntc/ntcr/ntcr_streamsocket.h
+++ b/groups/ntc/ntcr/ntcr_streamsocket.h
@@ -522,8 +522,7 @@ class StreamSocket : public ntci::StreamSocket,
     void privateRetryConnect(const bsl::shared_ptr<StreamSocket>& self);
 
     /// Retry connecting to the remote name. Return the error.
-    ntsa::Error privateRetryConnectToName(
-        const bsl::shared_ptr<StreamSocket>& self);
+    ntsa::Error privateRetryConnectToName();
 
     /// Retry connecting to the remote endpoint. Return the error.
     ntsa::Error privateRetryConnectToEndpoint(

--- a/groups/ntc/ntcr/ntcr_streamsocket.h
+++ b/groups/ntc/ntcr/ntcr_streamsocket.h
@@ -153,7 +153,7 @@ class StreamSocket : public ntci::StreamSocket,
     bslma::Allocator*                          d_allocator_p;
 
   private:
-    StreamSocket(const StreamSocket&) BSLS_KEYWORD_DELETED;
+                  StreamSocket(const StreamSocket&) BSLS_KEYWORD_DELETED;
     StreamSocket& operator=(const StreamSocket&) BSLS_KEYWORD_DELETED;
 
   private:
@@ -513,17 +513,22 @@ class StreamSocket : public ntci::StreamSocket,
         const ntca::GetEndpointEvent&          getEndpointEvent,
         bsl::size_t                            connectAttempts);
 
+    static void processRemoteEndpointResolutionWeak(
+        const bsl::weak_ptr<StreamSocket>&     socket,
+        const bsl::shared_ptr<ntci::Resolver>& resolver,
+        const ntsa::Endpoint&                  endpoint,
+        const ntca::GetEndpointEvent&          getEndpointEvent,
+        bsl::size_t                            connectAttempts);
+
     /// Initiate the upgrade. Return the error.
-    ntsa::Error privateUpgrade(
-        const bsl::shared_ptr<StreamSocket>& self,
-        const ntca::UpgradeOptions&          upgradeOptions);
+    ntsa::Error privateUpgrade(const bsl::shared_ptr<StreamSocket>& self,
+                               const ntca::UpgradeOptions& upgradeOptions);
 
     /// Retry connecting to the remote peer.
     void privateRetryConnect(const bsl::shared_ptr<StreamSocket>& self);
 
     /// Retry connecting to the remote name. Return the error.
-    ntsa::Error privateRetryConnectToName(
-        const bsl::shared_ptr<StreamSocket>& self);
+    ntsa::Error privateRetryConnectToName();
 
     /// Retry connecting to the remote endpoint. Return the error.
     ntsa::Error privateRetryConnectToEndpoint(

--- a/groups/ntc/ntcr/ntcr_streamsocket.h
+++ b/groups/ntc/ntcr/ntcr_streamsocket.h
@@ -153,7 +153,7 @@ class StreamSocket : public ntci::StreamSocket,
     bslma::Allocator*                          d_allocator_p;
 
   private:
-                  StreamSocket(const StreamSocket&) BSLS_KEYWORD_DELETED;
+    StreamSocket(const StreamSocket&) BSLS_KEYWORD_DELETED;
     StreamSocket& operator=(const StreamSocket&) BSLS_KEYWORD_DELETED;
 
   private:
@@ -513,22 +513,17 @@ class StreamSocket : public ntci::StreamSocket,
         const ntca::GetEndpointEvent&          getEndpointEvent,
         bsl::size_t                            connectAttempts);
 
-    static void processRemoteEndpointResolutionWeak(
-        const bsl::weak_ptr<StreamSocket>&     socket,
-        const bsl::shared_ptr<ntci::Resolver>& resolver,
-        const ntsa::Endpoint&                  endpoint,
-        const ntca::GetEndpointEvent&          getEndpointEvent,
-        bsl::size_t                            connectAttempts);
-
     /// Initiate the upgrade. Return the error.
-    ntsa::Error privateUpgrade(const bsl::shared_ptr<StreamSocket>& self,
-                               const ntca::UpgradeOptions& upgradeOptions);
+    ntsa::Error privateUpgrade(
+        const bsl::shared_ptr<StreamSocket>& self,
+        const ntca::UpgradeOptions&          upgradeOptions);
 
     /// Retry connecting to the remote peer.
     void privateRetryConnect(const bsl::shared_ptr<StreamSocket>& self);
 
     /// Retry connecting to the remote name. Return the error.
-    ntsa::Error privateRetryConnectToName();
+    ntsa::Error privateRetryConnectToName(
+        const bsl::shared_ptr<StreamSocket>& self);
 
     /// Retry connecting to the remote endpoint. Return the error.
     ntsa::Error privateRetryConnectToEndpoint(


### PR DESCRIPTION
This PR aims to resolve issue #63 

Please see the issue for the analysis.

Now resolver threads try to convert weak_ptr to shared_ptr before calling a callback with endpoint resolution results.