### PR TITLE
Allow the encryption certificate version to be omitted from the encoding if using X.509 v1

### DIFF
--- a/groups/ntc/ntca/ntca_encryptioncertificate.h
+++ b/groups/ntc/ntca/ntca_encryptioncertificate.h
@@ -5392,11 +5392,12 @@ void hashAppend(HASH_ALGORITHM&                           algorithm,
 /// @ingroup module_ntci_encryption
 class EncryptionCertificateEntity
 {
+    typedef ntca::EncryptionCertificateVersion       Version;
     typedef ntsa::AbstractBitString                  UniqueIdentifier;
     typedef ntca::EncryptionCertificateExtension     Extension;
     typedef ntca::EncryptionCertificateExtensionList ExtensionList;
 
-    ntca::EncryptionCertificateVersion            d_version;
+    bdlb::NullableValue<Version>                  d_version;
     ntsa::AbstractInteger                         d_serialNumber;
     ntca::EncryptionCertificateSignatureAlgorithm d_signatureAlgorithm;
     ntca::EncryptionCertificateIssuer             d_issuer;


### PR DESCRIPTION
The ASN.1 specification for a X.509 certificate requires the encoder to omit encoding the explicit version number if the version is the default version (1).
```
TBSCertificate ::= SEQUENCE {
       version          [ 0 ]  Version DEFAULT v1(0),
       <snip>
 ```
This PR enhances `ntca::EncryptionCertificate::decode()` to properly detected an omitted version field, and makes the corresponding changes to the encoder function.