### PR TITLE
Adopt ntccfg::Mutex or ntccfg::ConditionMutex instead of bslmt::Mutex

### DIFF
--- a/examples/m_ntcu10/ntcu10.m.cpp
+++ b/examples/m_ntcu10/ntcu10.m.cpp
@@ -373,18 +373,12 @@ ntsa::Error MessageParser::parse(
 // protocol over a stream socket.
 //
 
-                             
-                             
-                             
-
 // This class implements the 'ntci::StreamSocketSession' protocol to
 // provide client communication of the example wire protocol over an
 // asynchronous stream socket. This class is thread safe.
 class ClientSocket : public ntci::StreamSocketSession,
                      public ntccfg::Shared<ClientSocket> {
   public:
-    
-
     // Defines a type alias for a generic function callback.
     typedef bsl::function<void()> Callback;
 
@@ -394,15 +388,18 @@ class ClientSocket : public ntci::StreamSocketSession,
         ResponseCallback;
 
   private:
-    
-
     // Define a type alias for an associative data
     // structure mapping a transaction ID to the callback function
     // to be invoked when the response for that transaction ID is received.
     typedef bdlcc::ObjectCatalog<ResponseCallback> PendingCatalog;
 
-    
-    bslmt::Mutex                         d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    Mutex                                d_mutex;
     bsl::shared_ptr<ntci::StreamSocket>  d_streamSocket_sp;
     PendingCatalog                       d_pendingRequests;
     example::MessageParser               d_parser;
@@ -551,7 +548,7 @@ void ClientSocket::processDowngradeComplete(
     example::ClientSocket::Callback downgradeCallback(bsl::allocator_arg,
                                                       d_allocator_p);
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        LockGuard lockGuard(&d_mutex);
         d_downgradeCallback.swap(downgradeCallback);
     }
 
@@ -571,7 +568,7 @@ void ClientSocket::processUpgrade(
         example::ClientSocket::Callback upgradeCallback(bsl::allocator_arg,
                                                         d_allocator_p);
         {
-            bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+            LockGuard lockGuard(&d_mutex);
             d_upgradeCallback.swap(upgradeCallback);
         }
 
@@ -618,7 +615,7 @@ void ClientSocket::upgrade(
               const example::ClientSocket::Callback&         downgradeCallback)
 {
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        LockGuard lockGuard(&d_mutex);
         d_upgradeCallback   = upgradeCallback;
         d_downgradeCallback = downgradeCallback;
     }
@@ -703,14 +700,17 @@ ClientSocket::remoteCertificate() const
 class ServerSocket : public ntci::StreamSocketSession,
                      public ntccfg::Shared<ServerSocket> {
   public:
-    
-
     // Defines a type alias for a generic function callback.
     typedef bsl::function<void()> Callback;
 
   private:
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
     
-    bslmt::Mutex                         d_mutex;
+    Mutex                                d_mutex;
     bsl::shared_ptr<ntci::StreamSocket>  d_streamSocket_sp;
     example::MessageParser               d_parser;
     example::ServerSocket::Callback      d_upgradeCallback;
@@ -832,7 +832,7 @@ void ServerSocket::processDowngradeComplete(
     example::ServerSocket::Callback downgradeCallback(bsl::allocator_arg,
                                                       d_allocator_p);
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        LockGuard lockGuard(&d_mutex);
         d_downgradeCallback.swap(downgradeCallback);
     }
 
@@ -852,7 +852,7 @@ void ServerSocket::processUpgrade(
         example::ServerSocket::Callback upgradeCallback(bsl::allocator_arg,
                                                         d_allocator_p);
         {
-            bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+            LockGuard lockGuard(&d_mutex);
             d_upgradeCallback.swap(upgradeCallback);
         }
 
@@ -906,7 +906,7 @@ void ServerSocket::upgrade(
               const example::ServerSocket::Callback&         downgradeCallback)
 {
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        LockGuard lockGuard(&d_mutex);
         d_upgradeCallback   = upgradeCallback;
         d_downgradeCallback = downgradeCallback;
     }
@@ -972,8 +972,13 @@ class ListenerSocket : public ntci::ListenerSocketSession,
     typedef bsl::function<void()> Callback;
 
   private:
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
     
-    bslmt::Mutex                           d_mutex;
+    Mutex                                  d_mutex;
     bsl::shared_ptr<ntci::ListenerSocket>  d_listenerSocket_sp;
     bslma::Allocator                      *d_allocator_p;
 
@@ -1130,13 +1135,12 @@ class Client : public ntci::StreamSocketManager,
     typedef bsl::unordered_map<bsl::shared_ptr<ntci::StreamSocket>,
                                bsl::shared_ptr<example::ClientSocket> >
         StreamSocketMap;
-
     
-    bslmt::Mutex                      d_mutex;
+    ntccfg::ConditionMutex            d_mutex;
     bsl::shared_ptr<ntci::Interface>  d_interface_sp;
     PendingConnectionMap              d_pendingConnections;
     StreamSocketMap                   d_streamSockets;
-    bslmt::Condition                  d_linger;
+    ntccfg::Condition                 d_linger;
     bslma::Allocator                 *d_allocator_p;
 
   private:
@@ -1207,7 +1211,7 @@ void Client::processStreamSocketEstablished(
     example::Client::ClientSocketCallback  callback;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
 
         PendingConnectionMap::iterator it =
                                        d_pendingConnections.find(streamSocket);
@@ -1229,7 +1233,7 @@ void Client::processStreamSocketEstablished(
 void Client::processStreamSocketClosed(
                        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
 {
-    bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+    ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
 
     d_streamSockets.erase(streamSocket);
 
@@ -1282,7 +1286,7 @@ void Client::connect(
     streamSocket->registerManager(this->getSelf(this));
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
         d_pendingConnections[streamSocket] = callback;
     }
 
@@ -1303,7 +1307,7 @@ void Client::shutdown()
 {
     StreamSocketMap streamSockets;
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
         streamSockets = d_streamSockets;
     }
 
@@ -1316,7 +1320,7 @@ void Client::shutdown()
 
 void Client::linger()
 {
-    bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+    ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
 
     while (!d_streamSockets.empty()) {
         d_linger.wait(&d_mutex);
@@ -1369,13 +1373,18 @@ class Server : public ntci::ListenerSocketManager,
                                bsl::shared_ptr<example::ServerSocket> >
         StreamSocketMap;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
     
-    mutable bslmt::Mutex              d_mutex;
+    mutable ntccfg::ConditionMutex    d_mutex;
     bsl::shared_ptr<ntci::Interface>  d_interface_sp;
     PendingConnectionMap              d_pendingConnections;
     ListenerSocketMap                 d_listenerSockets;
     StreamSocketMap                   d_streamSockets;
-    bslmt::Condition                  d_linger;
+    ntccfg::Condition                 d_linger;
     bslma::Allocator                 *d_allocator_p;
 
   private:
@@ -1450,7 +1459,7 @@ void Server::processListenerSocketEstablished(
 {
     bsl::shared_ptr<example::ListenerSocket> listenerSocketSession;
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
 
         listenerSocketSession.createInplace(d_allocator_p,
                                             listenerSocket,
@@ -1467,7 +1476,7 @@ void Server::processListenerSocketEstablished(
 void Server::processListenerSocketClosed(
                    const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket)
 {
-    bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+    ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
 
     {
         std::size_t n = d_pendingConnections.erase(listenerSocket);
@@ -1496,7 +1505,7 @@ void Server::processStreamSocketEstablished(
 
     ServerSocketCallback callback;
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
 
         callback = d_pendingConnections[streamSocket->acceptor()];
         d_streamSockets[streamSocket] = serverSocket;
@@ -1508,7 +1517,7 @@ void Server::processStreamSocketEstablished(
 void Server::processStreamSocketClosed(
                        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
 {
-    bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+    ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
 
     std::size_t n = d_streamSockets.erase(streamSocket);
     BSLS_ASSERT_OPT(n == 1);
@@ -1553,7 +1562,7 @@ ntsa::Endpoint Server::listen(const ntsa::Endpoint&       sourceEndpoint,
     listenerSocket->registerSession(this->getSelf(this));
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
         d_pendingConnections[listenerSocket] = callback;
     }
 
@@ -1571,7 +1580,7 @@ void Server::shutdown()
     ListenerSocketMap listenerSockets;
     StreamSocketMap   streamSockets;
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
         listenerSockets = d_listenerSockets;
         streamSockets   = d_streamSockets;
     }
@@ -1591,7 +1600,7 @@ void Server::shutdown()
 
 void Server::linger()
 {
-    bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+    ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
     while (!d_pendingConnections.empty() || !d_listenerSockets.empty() ||
            !d_streamSockets.empty()) {
         d_linger.wait(&d_mutex);

--- a/examples/m_ntcu12/ntcu12.m.cpp
+++ b/examples/m_ntcu12/ntcu12.m.cpp
@@ -358,7 +358,13 @@ class ClientSocket : public ntci::StreamSocketSession,
     // to be invoked when the response for that transaction ID is received.
     typedef bdlcc::ObjectCatalog<ResponseCallback> PendingCatalog;
 
-    bslmt::Mutex                        d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    Mutex                               d_mutex;
     bsl::shared_ptr<ntci::StreamSocket> d_streamSocket_sp;
     PendingCatalog                      d_pendingRequests;
     example::MessageParser              d_parser;
@@ -489,7 +495,7 @@ void ClientSocket::processDowngradeComplete(
     example::ClientSocket::Callback downgradeCallback(bsl::allocator_arg,
                                                       d_allocator_p);
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        LockGuard lockGuard(&d_mutex);
         d_downgradeCallback.swap(downgradeCallback);
     }
 
@@ -508,7 +514,7 @@ void ClientSocket::processUpgrade(
         example::ClientSocket::Callback upgradeCallback(bsl::allocator_arg,
                                                         d_allocator_p);
         {
-            bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+            LockGuard lockGuard(&d_mutex);
             d_upgradeCallback.swap(upgradeCallback);
         }
 
@@ -553,7 +559,7 @@ void ClientSocket::upgrade(
     const example::ClientSocket::Callback&         downgradeCallback)
 {
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        LockGuard lockGuard(&d_mutex);
         d_upgradeCallback   = upgradeCallback;
         d_downgradeCallback = downgradeCallback;
     }
@@ -638,7 +644,13 @@ class ServerSocket : public ntci::StreamSocketSession,
     typedef bsl::function<void()> Callback;
 
   private:
-    bslmt::Mutex                        d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    Mutex                               d_mutex;
     bsl::shared_ptr<ntci::StreamSocket> d_streamSocket_sp;
     example::MessageParser              d_parser;
     example::ServerSocket::Callback     d_upgradeCallback;
@@ -742,7 +754,7 @@ void ServerSocket::processDowngradeComplete(
     example::ServerSocket::Callback downgradeCallback(bsl::allocator_arg,
                                                       d_allocator_p);
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        LockGuard lockGuard(&d_mutex);
         d_downgradeCallback.swap(downgradeCallback);
     }
 
@@ -761,7 +773,7 @@ void ServerSocket::processUpgrade(
         example::ServerSocket::Callback upgradeCallback(bsl::allocator_arg,
                                                         d_allocator_p);
         {
-            bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+            LockGuard lockGuard(&d_mutex);
             d_upgradeCallback.swap(upgradeCallback);
         }
 
@@ -812,7 +824,7 @@ void ServerSocket::upgrade(
     const example::ServerSocket::Callback&         downgradeCallback)
 {
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        LockGuard lockGuard(&d_mutex);
         d_upgradeCallback   = upgradeCallback;
         d_downgradeCallback = downgradeCallback;
     }
@@ -872,7 +884,13 @@ class ListenerSocket : public ntci::ListenerSocketSession,
     typedef bsl::function<void()> Callback;
 
   private:
-    bslmt::Mutex                          d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    Mutex                                 d_mutex;
     bsl::shared_ptr<ntci::ListenerSocket> d_listenerSocket_sp;
     bslma::Allocator*                     d_allocator_p;
 
@@ -1008,11 +1026,11 @@ class Client : public ntci::StreamSocketManager, public ntccfg::Shared<Client>
                                bsl::shared_ptr<example::ClientSocket> >
         StreamSocketMap;
 
-    bslmt::Mutex                     d_mutex;
+    ntccfg::ConditionMutex           d_mutex;
     bsl::shared_ptr<ntci::Interface> d_interface_sp;
     PendingConnectionMap             d_pendingConnections;
     StreamSocketMap                  d_streamSockets;
-    bslmt::Condition                 d_linger;
+    ntccfg::Condition                d_linger;
     bslma::Allocator*                d_allocator_p;
 
   private:
@@ -1071,7 +1089,7 @@ void Client::processStreamSocketEstablished(
     example::Client::ClientSocketCallback  callback;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
 
         PendingConnectionMap::iterator it =
             d_pendingConnections.find(streamSocket);
@@ -1093,7 +1111,7 @@ void Client::processStreamSocketEstablished(
 void Client::processStreamSocketClosed(
     const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
 {
-    bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+    ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
 
     d_streamSockets.erase(streamSocket);
 
@@ -1144,7 +1162,7 @@ void Client::connect(const ntsa::Endpoint& remoteEndpoint,
     streamSocket->registerManager(this->getSelf(this));
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
         d_pendingConnections[streamSocket] = callback;
     }
 
@@ -1165,7 +1183,7 @@ void Client::shutdown()
 {
     StreamSocketMap streamSockets;
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
         streamSockets = d_streamSockets;
     }
 
@@ -1179,7 +1197,7 @@ void Client::shutdown()
 
 void Client::linger()
 {
-    bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+    ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
 
     while (!d_streamSockets.empty()) {
         d_linger.wait(&d_mutex);
@@ -1225,12 +1243,12 @@ class Server : public ntci::ListenerSocketManager,
                                bsl::shared_ptr<example::ServerSocket> >
         StreamSocketMap;
 
-    mutable bslmt::Mutex             d_mutex;
+    mutable ntccfg::ConditionMutex   d_mutex;
     bsl::shared_ptr<ntci::Interface> d_interface_sp;
     PendingConnectionMap             d_pendingConnections;
     ListenerSocketMap                d_listenerSockets;
     StreamSocketMap                  d_streamSockets;
-    bslmt::Condition                 d_linger;
+    ntccfg::Condition                d_linger;
     bslma::Allocator*                d_allocator_p;
 
   private:
@@ -1292,7 +1310,7 @@ void Server::processListenerSocketEstablished(
 {
     bsl::shared_ptr<example::ListenerSocket> listenerSocketSession;
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
 
         listenerSocketSession.createInplace(d_allocator_p,
                                             listenerSocket,
@@ -1309,7 +1327,7 @@ void Server::processListenerSocketEstablished(
 void Server::processListenerSocketClosed(
     const bsl::shared_ptr<ntci::ListenerSocket>& listenerSocket)
 {
-    bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+    ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
 
     {
         std::size_t n = d_pendingConnections.erase(listenerSocket);
@@ -1338,7 +1356,7 @@ void Server::processStreamSocketEstablished(
 
     ServerSocketCallback callback;
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
 
         callback = d_pendingConnections[streamSocket->acceptor()];
         d_streamSockets[streamSocket] = serverSocket;
@@ -1350,7 +1368,7 @@ void Server::processStreamSocketEstablished(
 void Server::processStreamSocketClosed(
     const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
 {
-    bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+    ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
 
     std::size_t n = d_streamSockets.erase(streamSocket);
     BSLS_ASSERT_OPT(n == 1);
@@ -1394,7 +1412,7 @@ ntsa::Endpoint Server::listen(const ntsa::Endpoint&       sourceEndpoint,
     listenerSocket->registerSession(this->getSelf(this));
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
         d_pendingConnections[listenerSocket] = callback;
     }
 
@@ -1412,7 +1430,7 @@ void Server::shutdown()
     ListenerSocketMap listenerSockets;
     StreamSocketMap   streamSockets;
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
         listenerSockets = d_listenerSockets;
         streamSockets   = d_streamSockets;
     }
@@ -1434,7 +1452,7 @@ void Server::shutdown()
 
 void Server::linger()
 {
-    bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+    ntccfg::ConditionMutexGuard lockGuard(&d_mutex);
     while (!d_pendingConnections.empty() || !d_listenerSockets.empty() ||
            !d_streamSockets.empty())
     {

--- a/groups/ntc/ntccfg/ntccfg_mutex.h
+++ b/groups/ntc/ntccfg/ntccfg_mutex.h
@@ -22,6 +22,7 @@ BSLS_IDENT("$Id: $")
 #include <ntccfg_config.h>
 #include <ntccfg_inline.h>
 #include <ntcscm_version.h>
+#include <bslmt_condition.h>
 #include <bslmt_lockguard.h>
 #include <bslmt_mutex.h>
 #include <bslmt_recursivemutex.h>
@@ -371,6 +372,35 @@ typedef bslmt::UnLockGuard<ntccfg::Futex> UnLockGuard;
 #else
 #error Not implemented
 #endif
+
+#define NTCCFG_MUTEX_NULL ((ntccfg::Mutex*)(0))
+
+/// @internal @brief
+/// Define a type alias for a condition variable.
+///
+/// @ingroup module_ntccfg
+typedef bslmt::Condition Condition;
+
+/// @internal @brief
+/// Define a type alias for a mutex to lock the state associated with a 
+/// condition variable.
+///
+/// @ingroup module_ntccfg
+typedef bslmt::Mutex ConditionMutex;
+
+/// @internal @brief
+/// Define a type alias for a guard to lock and unlock a condition variable 
+/// mutex.
+///
+/// @ingroup module_ntccfg
+typedef bslmt::LockGuard<bslmt::Mutex> ConditionMutexGuard;
+
+/// @internal @brief
+/// Define a type alias for a guard to unlock and lock a condition variable 
+/// mutex.
+///
+/// @ingroup module_ntccfg
+typedef bslmt::UnLockGuard<bslmt::Mutex> ConditionMutexUnLockGuard;
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/groups/ntc/ntcd/ntcd_datagramsocket.cpp
+++ b/groups/ntc/ntcd/ntcd_datagramsocket.cpp
@@ -52,7 +52,7 @@ DatagramSocket::~DatagramSocket()
 
 ntsa::Error DatagramSocket::open(ntsa::Transport::Value transport)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -71,7 +71,7 @@ ntsa::Error DatagramSocket::open(ntsa::Transport::Value transport)
 
 ntsa::Error DatagramSocket::acquire(ntsa::Handle handle)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -90,7 +90,7 @@ ntsa::Error DatagramSocket::acquire(ntsa::Handle handle)
 
 ntsa::Handle DatagramSocket::release()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::k_INVALID_HANDLE;
@@ -105,7 +105,7 @@ ntsa::Handle DatagramSocket::release()
 ntsa::Error DatagramSocket::bind(const ntsa::Endpoint& endpoint,
                                  bool                  reuseAddress)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -117,7 +117,7 @@ ntsa::Error DatagramSocket::bind(const ntsa::Endpoint& endpoint,
 ntsa::Error DatagramSocket::bindAny(ntsa::Transport::Value transport,
                                     bool                   reuseAddress)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -128,7 +128,7 @@ ntsa::Error DatagramSocket::bindAny(ntsa::Transport::Value transport,
 
 ntsa::Error DatagramSocket::connect(const ntsa::Endpoint& endpoint)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -141,7 +141,7 @@ ntsa::Error DatagramSocket::send(ntsa::SendContext*       context,
                                  const bdlbb::Blob&       data,
                                  const ntsa::SendOptions& options)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -154,7 +154,7 @@ ntsa::Error DatagramSocket::send(ntsa::SendContext*       context,
                                  const ntsa::Data&        data,
                                  const ntsa::SendOptions& options)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -175,7 +175,7 @@ ntsa::Error DatagramSocket::receive(ntsa::ReceiveContext*       context,
                                     bdlbb::Blob*                data,
                                     const ntsa::ReceiveOptions& options)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -188,7 +188,7 @@ ntsa::Error DatagramSocket::receive(ntsa::ReceiveContext*       context,
                                     ntsa::Data*                 data,
                                     const ntsa::ReceiveOptions& options)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -199,7 +199,7 @@ ntsa::Error DatagramSocket::receive(ntsa::ReceiveContext*       context,
 
 ntsa::Error DatagramSocket::shutdown(ntsa::ShutdownType::Value direction)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -210,7 +210,7 @@ ntsa::Error DatagramSocket::shutdown(ntsa::ShutdownType::Value direction)
 
 ntsa::Error DatagramSocket::unlink()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -221,7 +221,7 @@ ntsa::Error DatagramSocket::unlink()
 
 ntsa::Error DatagramSocket::close()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -235,7 +235,7 @@ ntsa::Error DatagramSocket::close()
 
 ntsa::Error DatagramSocket::sourceEndpoint(ntsa::Endpoint* result) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -246,7 +246,7 @@ ntsa::Error DatagramSocket::sourceEndpoint(ntsa::Endpoint* result) const
 
 ntsa::Error DatagramSocket::remoteEndpoint(ntsa::Endpoint* result) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -257,7 +257,7 @@ ntsa::Error DatagramSocket::remoteEndpoint(ntsa::Endpoint* result) const
 
 ntsa::Handle DatagramSocket::handle() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::k_INVALID_HANDLE;
@@ -270,7 +270,7 @@ ntsa::Handle DatagramSocket::handle() const
 
 ntsa::Error DatagramSocket::setMulticastLoopback(bool enabled)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -282,7 +282,7 @@ ntsa::Error DatagramSocket::setMulticastLoopback(bool enabled)
 ntsa::Error DatagramSocket::setMulticastInterface(
     const ntsa::IpAddress& interface)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -293,7 +293,7 @@ ntsa::Error DatagramSocket::setMulticastInterface(
 
 ntsa::Error DatagramSocket::setMulticastTimeToLive(bsl::size_t maxHops)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -306,7 +306,7 @@ ntsa::Error DatagramSocket::joinMulticastGroup(
     const ntsa::IpAddress& interface,
     const ntsa::IpAddress& group)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -319,7 +319,7 @@ ntsa::Error DatagramSocket::leaveMulticastGroup(
     const ntsa::IpAddress& interface,
     const ntsa::IpAddress& group)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -332,7 +332,7 @@ ntsa::Error DatagramSocket::leaveMulticastGroup(
 
 ntsa::Error DatagramSocket::setBlocking(bool blocking)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -343,7 +343,7 @@ ntsa::Error DatagramSocket::setBlocking(bool blocking)
 
 ntsa::Error DatagramSocket::setOption(const ntsa::SocketOption& option)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -355,7 +355,7 @@ ntsa::Error DatagramSocket::setOption(const ntsa::SocketOption& option)
 ntsa::Error DatagramSocket::getOption(ntsa::SocketOption*           option,
                                       ntsa::SocketOptionType::Value type)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -366,7 +366,7 @@ ntsa::Error DatagramSocket::getOption(ntsa::SocketOption*           option,
 
 bsl::size_t DatagramSocket::maxBuffersPerSend() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return 1;
@@ -377,7 +377,7 @@ bsl::size_t DatagramSocket::maxBuffersPerSend() const
 
 bsl::size_t DatagramSocket::maxBuffersPerReceive() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return 1;

--- a/groups/ntc/ntcd/ntcd_datagramsocket.h
+++ b/groups/ntc/ntcd/ntcd_datagramsocket.h
@@ -45,7 +45,13 @@ namespace ntcd {
 /// @ingroup module_ntcd
 class DatagramSocket : public ntsi::DatagramSocket
 {
-    mutable bslmt::Mutex           d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex                  d_mutex;
     bsl::shared_ptr<ntcd::Machine> d_machine_sp;
     bsl::shared_ptr<ntcd::Session> d_session_sp;
     bslma::Allocator*              d_allocator_p;

--- a/groups/ntc/ntcd/ntcd_encryption.cpp
+++ b/groups/ntc/ntcd/ntcd_encryption.cpp
@@ -1188,7 +1188,7 @@ ntsa::Error Encryption::processIncomingHello()
         d_shutdownState.close();
         d_handshakeState = e_FAILED;
         {
-            bslmt::UnLockGuard<bslmt::Mutex> guard(&d_mutex);
+            ntccfg::UnLockGuard guard(&d_mutex);
             d_handshakeCallback(ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED),
                                 bsl::shared_ptr<ntci::EncryptionCertificate>(),
                                 "Not authorized");
@@ -1207,7 +1207,7 @@ ntsa::Error Encryption::processIncomingHello()
             BSLS_ASSERT(d_remoteCertificate_sp);
             d_handshakeState = e_ESTABLISHED;
             {
-                bslmt::UnLockGuard<bslmt::Mutex> guard(&d_mutex);
+                ntccfg::UnLockGuard guard(&d_mutex);
                 d_handshakeCallback(ntsa::Error(), d_remoteCertificate_sp, "");
             }
             d_handshakeCallback = ntci::Encryption::HandshakeCallback();
@@ -1260,7 +1260,7 @@ ntsa::Error Encryption::processIncomingAccept()
             BSLS_ASSERT(d_remoteCertificate_sp);
             d_handshakeState = e_ESTABLISHED;
             {
-                bslmt::UnLockGuard<bslmt::Mutex> guard(&d_mutex);
+                ntccfg::UnLockGuard guard(&d_mutex);
                 d_handshakeCallback(ntsa::Error(), d_remoteCertificate_sp, "");
             }
             d_handshakeCallback = ntci::Encryption::HandshakeCallback();
@@ -1270,7 +1270,7 @@ ntsa::Error Encryption::processIncomingAccept()
         d_shutdownState.close();
         d_handshakeState = e_FAILED;
         {
-            bslmt::UnLockGuard<bslmt::Mutex> guard(&d_mutex);
+            ntccfg::UnLockGuard guard(&d_mutex);
             d_handshakeCallback(ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED),
                                 bsl::shared_ptr<ntci::EncryptionCertificate>(),
                                 "Not authorized");
@@ -1423,13 +1423,13 @@ Encryption::~Encryption()
 
 void Encryption::authorizePeer(const bsl::string& name)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
     d_authorizationSet.insert(name);
 }
 
 ntsa::Error Encryption::initiateHandshake(const HandshakeCallback& callback)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     ntsa::Error error;
 
@@ -1453,7 +1453,7 @@ ntsa::Error Encryption::initiateHandshake(const HandshakeCallback& callback)
 
 ntsa::Error Encryption::pushIncomingCipherText(const bdlbb::Blob& input)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     if (!d_shutdownState.canReceive()) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -1466,7 +1466,7 @@ ntsa::Error Encryption::pushIncomingCipherText(const bdlbb::Blob& input)
 
 ntsa::Error Encryption::pushIncomingCipherText(const ntsa::Data& input)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     if (!d_shutdownState.canReceive()) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -1479,7 +1479,7 @@ ntsa::Error Encryption::pushIncomingCipherText(const ntsa::Data& input)
 
 ntsa::Error Encryption::pushOutgoingPlainText(const bdlbb::Blob& input)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     if (!d_shutdownState.canSend()) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -1492,7 +1492,7 @@ ntsa::Error Encryption::pushOutgoingPlainText(const bdlbb::Blob& input)
 
 ntsa::Error Encryption::pushOutgoingPlainText(const ntsa::Data& input)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     if (!d_shutdownState.canSend()) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -1505,7 +1505,7 @@ ntsa::Error Encryption::pushOutgoingPlainText(const ntsa::Data& input)
 
 ntsa::Error Encryption::popIncomingPlainText(bdlbb::Blob* output)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     if (d_incomingPlainText_sp->length() > 0) {
         bdlbb::BlobUtil::append(output, *d_incomingPlainText_sp);
@@ -1519,7 +1519,7 @@ ntsa::Error Encryption::popIncomingPlainText(bdlbb::Blob* output)
 
 ntsa::Error Encryption::popOutgoingCipherText(bdlbb::Blob* output)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     if (d_outgoingCipherText_sp->length() > 0) {
         bdlbb::BlobUtil::append(output, *d_outgoingCipherText_sp);
@@ -1533,7 +1533,7 @@ ntsa::Error Encryption::popOutgoingCipherText(bdlbb::Blob* output)
 
 ntsa::Error Encryption::shutdown()
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     ntsa::Error error;
 
@@ -1554,13 +1554,13 @@ ntsa::Error Encryption::shutdown()
 
 bool Encryption::hasIncomingPlainText() const
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
     return d_incomingPlainText_sp->length() > 0;
 }
 
 bool Encryption::hasOutgoingCipherText() const
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
     return d_outgoingCipherText_sp->length() > 0;
 }
 
@@ -1572,7 +1572,7 @@ bool Encryption::getCipher(bsl::string* result) const
 
 bool Encryption::isHandshakeFinished() const
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
     return d_handshakeState == e_ESTABLISHED || d_handshakeState == e_FAILED;
 }
 
@@ -1594,20 +1594,20 @@ bool Encryption::isShutdownFinished() const
 bsl::shared_ptr<ntci::EncryptionCertificate> Encryption::sourceCertificate()
     const
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
     return d_sourceCertificate_sp;
 }
 
 bsl::shared_ptr<ntci::EncryptionCertificate> Encryption::remoteCertificate()
     const
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
     return d_remoteCertificate_sp;
 }
 
 bsl::shared_ptr<ntci::EncryptionKey> Encryption::privateKey() const
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
     return d_sourceKey_sp;
 }
 

--- a/groups/ntc/ntcd/ntcd_encryption.h
+++ b/groups/ntc/ntcd/ntcd_encryption.h
@@ -473,7 +473,13 @@ class Encryption : public ntci::Encryption
     /// authorized to complete the handshake.
     typedef bsl::unordered_set<bsl::string> AuthorizationSet;
 
-    mutable bslmt::Mutex                             d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex                                    d_mutex;
     ntca::EncryptionRole::Value                      d_role;
     bdlb::NullableValue<ntcd::EncryptionFrameHeader> d_incomingHeader;
     bsl::shared_ptr<bdlbb::Blob>                     d_incomingPlainText_sp;

--- a/groups/ntc/ntcd/ntcd_listenersocket.cpp
+++ b/groups/ntc/ntcd/ntcd_listenersocket.cpp
@@ -52,7 +52,7 @@ ListenerSocket::~ListenerSocket()
 
 ntsa::Error ListenerSocket::open(ntsa::Transport::Value transport)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -71,7 +71,7 @@ ntsa::Error ListenerSocket::open(ntsa::Transport::Value transport)
 
 ntsa::Error ListenerSocket::acquire(ntsa::Handle handle)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -90,7 +90,7 @@ ntsa::Error ListenerSocket::acquire(ntsa::Handle handle)
 
 ntsa::Handle ListenerSocket::release()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::k_INVALID_HANDLE;
@@ -105,7 +105,7 @@ ntsa::Handle ListenerSocket::release()
 ntsa::Error ListenerSocket::bind(const ntsa::Endpoint& endpoint,
                                  bool                  reuseAddress)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -117,7 +117,7 @@ ntsa::Error ListenerSocket::bind(const ntsa::Endpoint& endpoint,
 ntsa::Error ListenerSocket::bindAny(ntsa::Transport::Value transport,
                                     bool                   reuseAddress)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -128,7 +128,7 @@ ntsa::Error ListenerSocket::bindAny(ntsa::Transport::Value transport,
 
 ntsa::Error ListenerSocket::listen(bsl::size_t backlog)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -139,7 +139,7 @@ ntsa::Error ListenerSocket::listen(bsl::size_t backlog)
 
 ntsa::Error ListenerSocket::accept(ntsa::Handle* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -152,7 +152,7 @@ ntsa::Error ListenerSocket::accept(
     bslma::ManagedPtr<ntsi::StreamSocket>* result,
     bslma::Allocator*                      basicAllocator)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -176,7 +176,7 @@ ntsa::Error ListenerSocket::accept(
 ntsa::Error ListenerSocket::accept(bsl::shared_ptr<ntsi::StreamSocket>* result,
                                    bslma::Allocator* basicAllocator)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -200,7 +200,7 @@ ntsa::Error ListenerSocket::accept(bsl::shared_ptr<ntsi::StreamSocket>* result,
 
 ntsa::Error ListenerSocket::shutdown(ntsa::ShutdownType::Value direction)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -211,7 +211,7 @@ ntsa::Error ListenerSocket::shutdown(ntsa::ShutdownType::Value direction)
 
 ntsa::Error ListenerSocket::unlink()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -222,7 +222,7 @@ ntsa::Error ListenerSocket::unlink()
 
 ntsa::Error ListenerSocket::close()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -236,7 +236,7 @@ ntsa::Error ListenerSocket::close()
 
 ntsa::Error ListenerSocket::sourceEndpoint(ntsa::Endpoint* result) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -247,7 +247,7 @@ ntsa::Error ListenerSocket::sourceEndpoint(ntsa::Endpoint* result) const
 
 ntsa::Handle ListenerSocket::handle() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::k_INVALID_HANDLE;
@@ -260,7 +260,7 @@ ntsa::Handle ListenerSocket::handle() const
 
 ntsa::Error ListenerSocket::setBlocking(bool blocking)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -271,7 +271,7 @@ ntsa::Error ListenerSocket::setBlocking(bool blocking)
 
 ntsa::Error ListenerSocket::setOption(const ntsa::SocketOption& option)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -283,7 +283,7 @@ ntsa::Error ListenerSocket::setOption(const ntsa::SocketOption& option)
 ntsa::Error ListenerSocket::getOption(ntsa::SocketOption*           option,
                                       ntsa::SocketOptionType::Value type)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);

--- a/groups/ntc/ntcd/ntcd_listenersocket.h
+++ b/groups/ntc/ntcd/ntcd_listenersocket.h
@@ -44,7 +44,13 @@ namespace ntcd {
 /// @ingroup module_ntcd
 class ListenerSocket : public ntsi::ListenerSocket
 {
-    mutable bslmt::Mutex           d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex                  d_mutex;
     bsl::shared_ptr<ntcd::Machine> d_machine_sp;
     bsl::shared_ptr<ntcd::Session> d_session_sp;
     bslma::Allocator*              d_allocator_p;

--- a/groups/ntc/ntcd/ntcd_machine.cpp
+++ b/groups/ntc/ntcd/ntcd_machine.cpp
@@ -1129,7 +1129,7 @@ ntsa::Error PacketQueue::setHighWatermark(bsl::size_t highWatermark)
     return ntsa::Error();
 }
 
-ntsa::Error PacketQueue::enqueue(bslmt::Mutex*                  mutex,
+ntsa::Error PacketQueue::enqueue(ntccfg::ConditionMutex*        mutex,
                                  bsl::shared_ptr<ntcd::Packet>& packet,
                                  bool                           block,
                                  PacketFunctor                  packetFunctor)
@@ -1221,7 +1221,7 @@ void PacketQueue::retry(const PacketVector& packetVector)
     }
 }
 
-ntsa::Error PacketQueue::dequeue(bslmt::Mutex*                  mutex,
+ntsa::Error PacketQueue::dequeue(ntccfg::ConditionMutex*        mutex,
                                  bsl::shared_ptr<ntcd::Packet>* result,
                                  bool                           block)
 {
@@ -1268,7 +1268,7 @@ ntsa::Error PacketQueue::dequeue(bslmt::Mutex*                  mutex,
     return ntsa::Error();
 }
 
-ntsa::Error PacketQueue::peek(bslmt::Mutex*                  mutex,
+ntsa::Error PacketQueue::peek(ntccfg::ConditionMutex*        mutex,
                               bsl::shared_ptr<ntcd::Packet>* result,
                               bool                           block)
 {
@@ -1301,7 +1301,7 @@ ntsa::Error PacketQueue::peek(bslmt::Mutex*                  mutex,
     return ntsa::Error();
 }
 
-ntsa::Error PacketQueue::pop(bslmt::Mutex* mutex, bool block)
+ntsa::Error PacketQueue::pop(ntccfg::ConditionMutex* mutex, bool block)
 {
     return this->dequeue(mutex, 0, block);
 }
@@ -1477,7 +1477,7 @@ PortMap::~PortMap()
 
 ntsa::Error PortMap::acquire(ntsa::Port* result, ntsa::Port requested)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     *result = 0;
 
@@ -1514,21 +1514,21 @@ ntsa::Error PortMap::acquire(ntsa::Port* result, ntsa::Port requested)
 
 void PortMap::release(ntsa::Port port)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     d_bitset.reset(port);
 }
 
 bool PortMap::isUsed(ntsa::Port port)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return d_bitset.test(port);
 }
 
 bool PortMap::isFree(ntsa::Port port)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return !d_bitset.test(port);
 }
@@ -1575,7 +1575,7 @@ ntsa::Error SessionQueue::setHighWatermark(bsl::size_t highWatermark)
 }
 
 ntsa::Error SessionQueue::enqueueSession(
-    bslmt::Mutex*                         mutex,
+    ntccfg::ConditionMutex*               mutex,
     const bsl::shared_ptr<ntcd::Session>& session,
     bool                                  block)
 {
@@ -1619,7 +1619,7 @@ ntsa::Error SessionQueue::enqueueSession(
 }
 
 ntsa::Error SessionQueue::dequeueSession(
-    bslmt::Mutex*                   mutex,
+    ntccfg::ConditionMutex*         mutex,
     bsl::shared_ptr<ntcd::Session>* result,
     bool                            block)
 {
@@ -2175,7 +2175,7 @@ ntsa::Error Session::open(ntsa::Transport::Value transport)
 {
     NTCCFG_WARNING_UNUSED(transport);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     bsl::shared_ptr<Session> self = this->getSelf(this);
 
@@ -2215,7 +2215,7 @@ ntsa::Error Session::acquire(ntsa::Handle handle)
 
 ntsa::Handle Session::release()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     ntsa::Handle handle = d_handle;
 
@@ -2232,7 +2232,7 @@ ntsa::Error Session::bind(const ntsa::Endpoint& endpoint, bool reuseAddress)
 {
     NTCCFG_WARNING_UNUSED(reuseAddress);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     bsl::shared_ptr<Session> self = this->getSelf(this);
 
@@ -2265,7 +2265,7 @@ ntsa::Error Session::bindAny(ntsa::Transport::Value transport,
 {
     NTCCFG_WARNING_UNUSED(reuseAddress);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     bsl::shared_ptr<Session> self = this->getSelf(this);
 
@@ -2320,7 +2320,7 @@ ntsa::Error Session::bindAny(ntsa::Transport::Value transport,
 
 ntsa::Error Session::listen(bsl::size_t backlog)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (d_handle == ntsa::k_INVALID_HANDLE) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -2352,7 +2352,7 @@ ntsa::Error Session::listen(bsl::size_t backlog)
 
 ntsa::Error Session::accept(ntsa::Handle* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     *result = ntsa::k_INVALID_HANDLE;
 
@@ -2411,7 +2411,7 @@ ntsa::Error Session::accept(bsl::shared_ptr<ntcd::Session>* result,
 {
     NTCCFG_WARNING_UNUSED(basicAllocator);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     UpdateGuard update(this);
 
@@ -2450,7 +2450,7 @@ ntsa::Error Session::accept(bsl::shared_ptr<ntcd::Session>* result,
 
 ntsa::Error Session::connect(const ntsa::Endpoint& endpoint)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     UpdateGuard update(this);
 
@@ -2544,7 +2544,7 @@ ntsa::Error Session::connect(const ntsa::Endpoint& endpoint)
             return this->privateError();
         }
 
-        bslmt::LockGuard<bslmt::Mutex> peerLock(&peer->d_mutex);
+        ntccfg::ConditionMutexGuard peerLock(&peer->d_mutex);
 
         UpdateGuard peerUpdate(peer.get());
 
@@ -2614,7 +2614,7 @@ ntsa::Error Session::send(ntsa::SendContext*       context,
                           const bdlbb::Blob&       data,
                           const ntsa::SendOptions& options)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     UpdateGuard update(this);
 
@@ -2847,7 +2847,7 @@ ntsa::Error Session::send(ntsa::SendContext*       context,
                           const ntsa::Data&        data,
                           const ntsa::SendOptions& options)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     UpdateGuard update(this);
 
@@ -3085,7 +3085,7 @@ ntsa::Error Session::receive(ntsa::ReceiveContext*       context,
                              bdlbb::Blob*                data,
                              const ntsa::ReceiveOptions& options)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     UpdateGuard update(this);
 
@@ -3225,7 +3225,7 @@ ntsa::Error Session::receive(ntsa::ReceiveContext*       context,
                              ntsa::Data*                 data,
                              const ntsa::ReceiveOptions& options)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     UpdateGuard update(this);
 
@@ -3364,7 +3364,7 @@ ntsa::Error Session::receive(ntsa::ReceiveContext*       context,
 ntsa::Error Session::receiveNotifications(
     ntsa::NotificationQueue* notifications)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     UpdateGuard update(this);
 
@@ -3385,7 +3385,7 @@ ntsa::Error Session::receiveNotifications(
 
 ntsa::Error Session::shutdown(ntsa::ShutdownType::Value direction)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     UpdateGuard update(this);
 
@@ -3470,7 +3470,7 @@ ntsa::Error Session::unlink()
 
 ntsa::Error Session::close()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -3505,7 +3505,7 @@ ntsa::Error Session::close()
 ntsa::Error Session::registerMonitor(
     const bsl::shared_ptr<ntcd::Monitor>& monitor)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (d_monitor_sp) {
         if (monitor != d_monitor_sp) {
@@ -3530,7 +3530,7 @@ ntsa::Error Session::registerMonitor(
 ntsa::Error Session::deregisterMonitor(
     const bsl::shared_ptr<ntcd::Monitor>& monitor)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (d_monitor_sp) {
         if (monitor != d_monitor_sp) {
@@ -3545,7 +3545,7 @@ ntsa::Error Session::deregisterMonitor(
 
 ntsa::Error Session::step(bool block)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     UpdateGuard update(this);
 
@@ -3633,7 +3633,7 @@ ntsa::Error Session::step(bool block)
             }
         }
 
-        bslmt::LockGuard<bslmt::Mutex> remoteLock(&remoteSession->d_mutex);
+        ntccfg::ConditionMutexGuard remoteLock(&remoteSession->d_mutex);
 
         if (!remoteSession->d_incomingPacketQueue_sp) {
             NTCD_SESSION_LOG_TRANSFERRING_PACKET_FAILED_PEER_DEAD(d_machine_sp,
@@ -3702,13 +3702,13 @@ ntsa::Error Session::step(bool block)
 
 ntsa::Handle Session::handle() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
     return d_handle;
 }
 
 ntsa::Error Session::sourceEndpoint(ntsa::Endpoint* result) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (d_sourceEndpoint.isUndefined()) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -3720,7 +3720,7 @@ ntsa::Error Session::sourceEndpoint(ntsa::Endpoint* result) const
 
 ntsa::Error Session::remoteEndpoint(ntsa::Endpoint* result) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (d_errorCode) {
         return this->privateError();
@@ -3738,7 +3738,7 @@ ntsa::Error Session::remoteEndpoint(ntsa::Endpoint* result) const
 
 ntsa::Error Session::setMulticastLoopback(bool enabled)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (d_handle == ntsa::k_INVALID_HANDLE) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -3751,7 +3751,7 @@ ntsa::Error Session::setMulticastLoopback(bool enabled)
 
 ntsa::Error Session::setMulticastInterface(const ntsa::IpAddress& interface)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (d_handle == ntsa::k_INVALID_HANDLE) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -3764,7 +3764,7 @@ ntsa::Error Session::setMulticastInterface(const ntsa::IpAddress& interface)
 
 ntsa::Error Session::setMulticastTimeToLive(bsl::size_t maxHops)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (d_handle == ntsa::k_INVALID_HANDLE) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -3778,7 +3778,7 @@ ntsa::Error Session::setMulticastTimeToLive(bsl::size_t maxHops)
 ntsa::Error Session::joinMulticastGroup(const ntsa::IpAddress& interface,
                                         const ntsa::IpAddress& group)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (d_handle == ntsa::k_INVALID_HANDLE) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -3793,7 +3793,7 @@ ntsa::Error Session::joinMulticastGroup(const ntsa::IpAddress& interface,
 ntsa::Error Session::leaveMulticastGroup(const ntsa::IpAddress& interface,
                                          const ntsa::IpAddress& group)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (d_handle == ntsa::k_INVALID_HANDLE) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -3809,7 +3809,7 @@ ntsa::Error Session::leaveMulticastGroup(const ntsa::IpAddress& interface,
 
 ntsa::Error Session::setBlocking(bool blocking)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (d_handle == ntsa::k_INVALID_HANDLE) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -3822,7 +3822,7 @@ ntsa::Error Session::setBlocking(bool blocking)
 
 ntsa::Error Session::setOption(const ntsa::SocketOption& option)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (d_handle == ntsa::k_INVALID_HANDLE) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -3864,7 +3864,7 @@ ntsa::Error Session::setOption(const ntsa::SocketOption& option)
 ntsa::Error Session::getOption(ntsa::SocketOption*           option,
                                ntsa::SocketOptionType::Value type)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (d_handle == ntsa::k_INVALID_HANDLE) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -4269,14 +4269,14 @@ void Monitor::setOneShot(bool oneShot)
 
 void Monitor::registerWaiter()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     d_waiters += 1;
 }
 
 void Monitor::deregisterWaiter()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     d_waiters -= 1;
 }
@@ -4303,7 +4303,7 @@ ntsa::Error Monitor::add(const bsl::shared_ptr<ntcd::Session>& session)
 {
     ntsa::Handle handle = session->handle();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     EntryMap::iterator it = d_map.find(handle);
     if (it != d_map.end()) {
@@ -4347,7 +4347,7 @@ ntsa::Error Monitor::remove(const bsl::shared_ptr<ntcd::Session>& session)
 {
     ntsa::Handle handle = session->handle();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     EntryMap::iterator it = d_map.find(handle);
     if (it == d_map.end()) {
@@ -4392,7 +4392,7 @@ ntsa::Error Monitor::update(ntsa::Handle handle, ntcs::Interest interest)
     const bool hasError        = session->hasError();
     const bool hasNotification = session->hasNotification();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     EntryMap::iterator it = d_map.find(handle);
     if (it == d_map.end()) {
@@ -4566,7 +4566,7 @@ ntsa::Error Monitor::update(const bsl::shared_ptr<ntcd::Session>& session,
     const bool hasError        = session->hasError();
     const bool hasNotification = session->hasNotification();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     EntryMap::iterator it = d_map.find(handle);
     if (it == d_map.end()) {
@@ -4749,7 +4749,7 @@ ntsa::Error Monitor::show(const bsl::shared_ptr<ntcd::Session>& session,
     const bool hasError   = session->hasError();
     // const bool hasNotification   = session->hasNotification();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     EntryMap::iterator it = d_map.find(handle);
     if (it == d_map.end()) {
@@ -4839,7 +4839,7 @@ ntsa::Error Monitor::hide(const bsl::shared_ptr<ntcd::Session>& session,
 
     ntsa::Handle handle = session->handle();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     EntryMap::iterator it = d_map.find(handle);
     if (it == d_map.end()) {
@@ -4882,7 +4882,7 @@ ntsa::Error Monitor::enable(ntsa::Handle                          handle,
 {
     NTCI_LOG_CONTEXT();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     EntryMap::iterator it = d_map.find(handle);
     if (it == d_map.end()) {
@@ -4929,7 +4929,7 @@ ntsa::Error Monitor::enableNotifications(
 {
     NTCI_LOG_CONTEXT();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     EntryMap::iterator it = d_map.find(handle);
     if (it == d_map.end()) {
@@ -4956,7 +4956,7 @@ ntsa::Error Monitor::disable(ntsa::Handle                          handle,
 {
     NTCI_LOG_CONTEXT();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     EntryMap::iterator it = d_map.find(handle);
     if (it == d_map.end()) {
@@ -5003,7 +5003,7 @@ ntsa::Error Monitor::disableNotifications(
 {
     NTCI_LOG_CONTEXT();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     EntryMap::iterator it = d_map.find(handle);
     if (it == d_map.end()) {
@@ -5025,7 +5025,7 @@ ntsa::Error Monitor::dequeue(bsl::vector<ntca::ReactorEvent>* result)
 {
     NTCI_LOG_CONTEXT();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (d_run && d_queue.empty() && d_interrupt == 0) {
         NTCD_MONITOR_LOG_WAITING(d_machine_sp, this);
@@ -5072,7 +5072,7 @@ ntsa::Error Monitor::dequeue(bsl::vector<ntca::ReactorEvent>* result,
 {
     NTCI_LOG_CONTEXT();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (d_run && d_queue.empty() && d_interrupt == 0) {
         NTCD_MONITOR_LOG_WAITING(d_machine_sp, this);
@@ -5119,7 +5119,7 @@ ntsa::Error Monitor::dequeue(bsl::vector<ntca::ReactorEvent>* result,
 
 void Monitor::interruptOne()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     bsl::uint64_t interrupt = d_interrupt.load();
     bsl::uint64_t waiters   = d_waiters.load();
@@ -5132,7 +5132,7 @@ void Monitor::interruptOne()
 
 void Monitor::interruptAll()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     bsl::uint64_t interrupt = d_interrupt.load();
     bsl::uint64_t waiters   = d_waiters.load();
@@ -5146,7 +5146,7 @@ void Monitor::interruptAll()
 
 void Monitor::stop()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     d_run = false;
 
@@ -5162,7 +5162,7 @@ void Monitor::stop()
 
 void Monitor::restart()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     d_run = true;
     d_condition.broadcast();
@@ -5219,7 +5219,7 @@ ntsa::Error Machine::acquireHandle(
 {
     NTCCFG_WARNING_UNUSED(transport);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     *result = ntsa::k_INVALID_HANDLE;
 
@@ -5280,7 +5280,7 @@ ntsa::Error Machine::releaseHandle(ntsa::Handle           handle,
 {
     NTCCFG_WARNING_UNUSED(transport);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -5343,7 +5343,7 @@ ntsa::Error Machine::acquireSourceEndpoint(
     ntsa::Transport::Value                transport,
     const bsl::shared_ptr<ntcd::Session>& session)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -5463,7 +5463,7 @@ ntsa::Error Machine::releaseSourceEndpoint(
     const ntsa::Endpoint&  sourceEndpoint,
     ntsa::Transport::Value transport)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -5520,7 +5520,7 @@ ntsa::Error Machine::acquireBinding(
     ntsa::Transport::Value                transport,
     const bsl::shared_ptr<ntcd::Session>& session)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -5669,7 +5669,7 @@ ntsa::Error Machine::acquireBinding(
 ntsa::Error Machine::releaseBinding(const ntcd::Binding&   binding,
                                     ntsa::Transport::Value transport)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     ntsa::TransportProtocol::Value protocol =
         ntsa::Transport::getProtocol(transport);
@@ -5748,7 +5748,7 @@ void Machine::update(const bsl::shared_ptr<ntcd::Session>& session)
 {
     NTCCFG_WARNING_UNUSED(session);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     bool d_alreadyNeedsUpdate = d_update.swap(true);
     if (!d_alreadyNeedsUpdate) {
@@ -5801,7 +5801,7 @@ ntsa::Error Machine::step(bool block)
 
     SessionVector sessions;
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (true) {
             bool needsUpdate = d_update.testAndSwap(true, false);
@@ -5862,7 +5862,7 @@ void Machine::stop()
 ntsa::Error Machine::lookupSession(bsl::weak_ptr<ntcd::Session>* result,
                                    ntsa::Handle                  handle) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     SessionByHandleMap::const_iterator it = d_sessionByHandleMap.find(handle);
     if (it == d_sessionByHandleMap.end()) {
@@ -5878,7 +5878,7 @@ ntsa::Error Machine::lookupSession(bsl::weak_ptr<ntcd::Session>* result,
                                    const ntsa::Endpoint&  sourceEndpoint,
                                    ntsa::Transport::Value transport) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     ntsa::TransportProtocol::Value protocol =
         ntsa::Transport::getProtocol(transport);
@@ -5934,7 +5934,7 @@ ntsa::Error Machine::lookupSession(bsl::weak_ptr<ntcd::Session>* result,
                                    const ntcd::Binding&          binding,
                                    ntsa::Transport::Value transport) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     result->reset();
 
@@ -6149,7 +6149,7 @@ bool Machine::discoverAdapter(ntsa::Adapter*             result,
 
 bool Machine::hasIpAddress(const ntsa::IpAddress& ipAddress) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     bsl::vector<ntsa::IpAddress>::const_iterator it =
         bsl::find(d_ipAddressList.begin(), d_ipAddressList.end(), ipAddress);

--- a/groups/ntc/ntcd/ntcd_machine.h
+++ b/groups/ntc/ntcd/ntcd_machine.h
@@ -375,7 +375,6 @@ class PacketQueue
     /// This typedef defines a queue of packets.
     typedef bsl::list<bsl::shared_ptr<ntcd::Packet> > Storage;
 
-    // MRM: mutable bslmt::Mutex  d_mutex;
     bslmt::Condition   d_allowDequeue;
     bslmt::Condition   d_allowEnqueue;
     Storage            d_storage;
@@ -414,7 +413,7 @@ class PacketQueue
     /// true, block until sufficient capacity is availble to store the
     /// 'packet'. If 'packetFunctor' is set then apply it to the packet in
     /// case of succesful enqueueing. Return the error.
-    ntsa::Error enqueue(bslmt::Mutex*                  mutex,
+    ntsa::Error enqueue(ntccfg::ConditionMutex*        mutex,
                         bsl::shared_ptr<ntcd::Packet>& packet,
                         bool                           block,
                         PacketFunctor packetFunctor = PacketFunctor());
@@ -429,7 +428,7 @@ class PacketQueue
     /// Dequeue a packet from the queue and load the dequeued packet into
     /// the specified 'result'. If the specified 'block' flag is true, block
     /// until a packet is available to dequeue. Return the error.
-    ntsa::Error dequeue(bslmt::Mutex*                  mutex,
+    ntsa::Error dequeue(ntccfg::ConditionMutex*        mutex,
                         bsl::shared_ptr<ntcd::Packet>* result,
                         bool                           block);
 
@@ -437,14 +436,14 @@ class PacketQueue
     /// 'result', but do not dequeue the packet If the specified 'block'
     /// flag is true, block until a packet is available to dequeue. Return
     /// the error.
-    ntsa::Error peek(bslmt::Mutex*                  mutex,
+    ntsa::Error peek(ntccfg::ConditionMutex*        mutex,
                      bsl::shared_ptr<ntcd::Packet>* result,
                      bool                           block);
 
     /// Dequeue a packet from the queue.  If the specified 'block'
     /// flag is true, block until a packet is available to dequeue. Return
     /// the error.
-    ntsa::Error pop(bslmt::Mutex* mutex, bool block);
+    ntsa::Error pop(ntccfg::ConditionMutex* mutex, bool block);
 
     /// Wake up any threads blocked on this queue. Return the error.
     ntsa::Error wakeup();
@@ -577,7 +576,13 @@ class PortMap
         k_MAX_PORT           = k_MAX_EPHEMERAL_PORT
     };
 
-    mutable bslmt::Mutex    d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex           d_mutex;
     bsl::bitset<k_MAX_PORT> d_bitset;
     bslma::Allocator*       d_allocator_p;
 
@@ -625,7 +630,6 @@ class SessionQueue
     /// This typedef defines a queue of contexts.
     typedef bsl::list<bsl::shared_ptr<ntcd::Session> > Storage;
 
-    // MRM: mutable bslmt::Mutex  d_mutex;
     bslmt::Condition   d_allowDequeue;
     bslmt::Condition   d_allowEnqueue;
     Storage            d_storage;
@@ -658,14 +662,14 @@ class SessionQueue
     /// Enqueue the specified 'session'. If the specified 'block' flag is
     /// true, block until sufficient capacity is availble to store the
     /// 'session'. Return the error.
-    ntsa::Error enqueueSession(bslmt::Mutex*                         mutex,
+    ntsa::Error enqueueSession(ntccfg::ConditionMutex*               mutex,
                                const bsl::shared_ptr<ntcd::Session>& session,
                                bool                                  block);
 
     /// Dequeue a context from the queue and load the dequeued context into
     /// the specified 'result'. If the specified 'block' flag is true, block
     /// until a context is available to dequeue. Return the error.
-    ntsa::Error dequeueSession(bslmt::Mutex*                   mutex,
+    ntsa::Error dequeueSession(ntccfg::ConditionMutex*         mutex,
                                bsl::shared_ptr<ntcd::Session>* result,
                                bool                            block);
 
@@ -704,7 +708,7 @@ class Session : public ntsi::DatagramSocket,
 
     typedef bsl::list<ntsa::Notification> SocketErrorQueue;
 
-    mutable bslmt::Mutex                        d_mutex;
+    mutable ntccfg::ConditionMutex              d_mutex;
     ntsa::Handle                                d_handle;
     ntsa::Transport::Value                      d_transport;
     ntsa::Endpoint                              d_sourceEndpoint;
@@ -1021,8 +1025,8 @@ class Monitor : public ntccfg::Shared<Monitor>
     /// readiness of events for the sessions identified by those handles.
     typedef bsl::unordered_map<ntsa::Handle, bsl::shared_ptr<Entry> > EntryMap;
 
-    bslmt::Mutex                     d_mutex;
-    bslmt::Condition                 d_condition;
+    ntccfg::ConditionMutex           d_mutex;
+    ntccfg::Condition                d_condition;
     bsls::AtomicBool                 d_run;
     bsls::AtomicUint64               d_interrupt;
     bsls::AtomicUint64               d_waiters;
@@ -1197,8 +1201,8 @@ class Machine : public ntccfg::Shared<Machine>
     typedef bsl::map<ntcd::Binding, bsl::weak_ptr<ntcd::Session> >
         SessionByBindingMap;
 
-    mutable bslmt::Mutex           d_mutex;
-    mutable bslmt::Condition       d_condition;
+    mutable ntccfg::ConditionMutex d_mutex;
+    mutable ntccfg::Condition      d_condition;
     bsl::string                    d_name;
     bsl::vector<ntsa::IpAddress>   d_ipAddressList;
     bdlbb::PooledBlobBufferFactory d_blobBufferFactory;

--- a/groups/ntc/ntcd/ntcd_proactor.cpp
+++ b/groups/ntc/ntcd/ntcd_proactor.cpp
@@ -196,7 +196,13 @@ struct Proactor::Work : public ntccfg::Shared<Proactor::Work> {
     /// This typedef defines a queue of pending receives.
     typedef bsl::list<Receive> ReceiveQueue;
 
-    bslmt::Mutex                          d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    Mutex                                 d_mutex;
     ntsa::Handle                          d_handle;
     bsl::shared_ptr<ntcd::Machine>        d_machine_sp;
     bsl::shared_ptr<ntcd::Monitor>        d_monitor_sp;
@@ -324,7 +330,7 @@ void Proactor::Work::processReadable(const ntca::ReactorEvent& event)
 
     bsl::shared_ptr<Work> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     UpdateGuard update(this);
 
@@ -356,7 +362,7 @@ void Proactor::Work::processReadable(const ntca::ReactorEvent& event)
                 NTCCFG_WARNING_UNUSED(accept);
                 d_acceptQueue.pop_front();
 
-                bslmt::UnLockGuard<bslmt::Mutex> unlock(&d_mutex);
+                ntccfg::UnLockGuard unlock(&d_mutex);
                 ntcs::Dispatch::announceAccepted(
                     d_socket_sp,
                     error,
@@ -376,7 +382,7 @@ void Proactor::Work::processReadable(const ntca::ReactorEvent& event)
             NTCCFG_WARNING_UNUSED(accept);
             d_acceptQueue.pop_front();
 
-            bslmt::UnLockGuard<bslmt::Mutex> unlock(&d_mutex);
+            ntccfg::UnLockGuard unlock(&d_mutex);
             ntcs::Dispatch::announceAccepted(d_socket_sp,
                                              ntsa::Error(),
                                              streamSocket,
@@ -388,7 +394,7 @@ void Proactor::Work::processReadable(const ntca::ReactorEvent& event)
                 NTCCFG_WARNING_UNUSED(accept);
                 d_acceptQueue.pop_front();
 
-                bslmt::UnLockGuard<bslmt::Mutex> unlock(&d_mutex);
+                ntccfg::UnLockGuard unlock(&d_mutex);
                 ntcs::Dispatch::announceAccepted(
                     d_socket_sp,
                     event.context().error(),
@@ -425,7 +431,7 @@ void Proactor::Work::processReadable(const ntca::ReactorEvent& event)
             if (error) {
                 d_receiveQueue.pop_front();
 
-                bslmt::UnLockGuard<bslmt::Mutex> unlock(&d_mutex);
+                ntccfg::UnLockGuard unlock(&d_mutex);
                 ntcs::Dispatch::announceReceived(d_socket_sp,
                                                  error,
                                                  context,
@@ -436,7 +442,7 @@ void Proactor::Work::processReadable(const ntca::ReactorEvent& event)
 
             d_receiveQueue.pop_front();
 
-            bslmt::UnLockGuard<bslmt::Mutex> unlock(&d_mutex);
+            ntccfg::UnLockGuard unlock(&d_mutex);
             ntcs::Dispatch::announceReceived(d_socket_sp,
                                              error,
                                              context,
@@ -448,7 +454,7 @@ void Proactor::Work::processReadable(const ntca::ReactorEvent& event)
                 NTCCFG_WARNING_UNUSED(receive);
                 d_receiveQueue.pop_front();
 
-                bslmt::UnLockGuard<bslmt::Mutex> unlock(&d_mutex);
+                ntccfg::UnLockGuard unlock(&d_mutex);
                 ntcs::Dispatch::announceReceived(d_socket_sp,
                                                  event.context().error(),
                                                  ntsa::ReceiveContext(),
@@ -464,7 +470,7 @@ void Proactor::Work::processWritable(const ntca::ReactorEvent& event)
 
     bsl::shared_ptr<Work> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     UpdateGuard update(this);
 
@@ -476,7 +482,7 @@ void Proactor::Work::processWritable(const ntca::ReactorEvent& event)
             NTCCFG_WARNING_UNUSED(connect);
             d_connectQueue.pop_front();
 
-            bslmt::UnLockGuard<bslmt::Mutex> unlock(&d_mutex);
+            ntccfg::UnLockGuard unlock(&d_mutex);
             ntcs::Dispatch::announceConnected(d_socket_sp,
                                               ntsa::Error(),
                                               d_socket_sp->strand());
@@ -487,7 +493,7 @@ void Proactor::Work::processWritable(const ntca::ReactorEvent& event)
                 NTCCFG_WARNING_UNUSED(connect);
                 d_connectQueue.pop_front();
 
-                bslmt::UnLockGuard<bslmt::Mutex> unlock(&d_mutex);
+                ntccfg::UnLockGuard unlock(&d_mutex);
                 ntcs::Dispatch::announceConnected(d_socket_sp,
                                                   event.context().error(),
                                                   d_socket_sp->strand());
@@ -529,7 +535,7 @@ void Proactor::Work::processWritable(const ntca::ReactorEvent& event)
             if (error) {
                 d_sendQueue.pop_front();
 
-                bslmt::UnLockGuard<bslmt::Mutex> unlock(&d_mutex);
+                ntccfg::UnLockGuard unlock(&d_mutex);
                 ntcs::Dispatch::announceSent(d_socket_sp,
                                              error,
                                              context,
@@ -540,7 +546,7 @@ void Proactor::Work::processWritable(const ntca::ReactorEvent& event)
 
             d_sendQueue.pop_front();
 
-            bslmt::UnLockGuard<bslmt::Mutex> unlock(&d_mutex);
+            ntccfg::UnLockGuard unlock(&d_mutex);
             ntcs::Dispatch::announceSent(d_socket_sp,
                                          error,
                                          context,
@@ -552,7 +558,7 @@ void Proactor::Work::processWritable(const ntca::ReactorEvent& event)
                 NTCCFG_WARNING_UNUSED(send);
                 d_sendQueue.pop_front();
 
-                bslmt::UnLockGuard<bslmt::Mutex> unlock(&d_mutex);
+                ntccfg::UnLockGuard unlock(&d_mutex);
                 ntcs::Dispatch::announceSent(d_socket_sp,
                                              event.context().error(),
                                              ntsa::SendContext(),
@@ -566,7 +572,7 @@ void Proactor::Work::processError(const ntca::ReactorEvent& event)
 {
     bsl::shared_ptr<Work> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     UpdateGuard update(this);
 
@@ -579,7 +585,7 @@ void Proactor::Work::processError(const ntca::ReactorEvent& event)
         NTCCFG_WARNING_UNUSED(accept);
         d_acceptQueue.pop_front();
 
-        bslmt::UnLockGuard<bslmt::Mutex> unlock(&d_mutex);
+        ntccfg::UnLockGuard unlock(&d_mutex);
         ntcs::Dispatch::announceAccepted(d_socket_sp,
                                          event.context().error(),
                                          bsl::shared_ptr<ntsi::StreamSocket>(),
@@ -591,7 +597,7 @@ void Proactor::Work::processError(const ntca::ReactorEvent& event)
         NTCCFG_WARNING_UNUSED(connect);
         d_connectQueue.pop_front();
 
-        bslmt::UnLockGuard<bslmt::Mutex> unlock(&d_mutex);
+        ntccfg::UnLockGuard unlock(&d_mutex);
         ntcs::Dispatch::announceConnected(d_socket_sp,
                                           event.context().error(),
                                           d_socket_sp->strand());
@@ -602,7 +608,7 @@ void Proactor::Work::processError(const ntca::ReactorEvent& event)
         NTCCFG_WARNING_UNUSED(send);
         d_sendQueue.pop_front();
 
-        bslmt::UnLockGuard<bslmt::Mutex> unlock(&d_mutex);
+        ntccfg::UnLockGuard unlock(&d_mutex);
         ntcs::Dispatch::announceSent(d_socket_sp,
                                      event.context().error(),
                                      ntsa::SendContext(),
@@ -614,7 +620,7 @@ void Proactor::Work::processError(const ntca::ReactorEvent& event)
         NTCCFG_WARNING_UNUSED(receive);
         d_receiveQueue.pop_front();
 
-        bslmt::UnLockGuard<bslmt::Mutex> unlock(&d_mutex);
+        ntccfg::UnLockGuard unlock(&d_mutex);
         ntcs::Dispatch::announceReceived(d_socket_sp,
                                          event.context().error(),
                                          ntsa::ReceiveContext(),
@@ -666,7 +672,7 @@ Proactor::Work::~Work()
 
 ntsa::Error Proactor::Work::showError()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntcs::Interest interest = d_entry_sp->showErrorCallback(
         ntca::ReactorEventOptions(),
@@ -679,7 +685,7 @@ ntsa::Error Proactor::Work::showError()
 
 ntsa::Error Proactor::Work::hideError()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntcs::Interest interest =
         d_entry_sp->hideErrorCallback(ntca::ReactorEventOptions());
@@ -689,7 +695,7 @@ ntsa::Error Proactor::Work::hideError()
 
 ntsa::Error Proactor::Work::initiateAccept()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_receiveQueue.empty()) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -716,7 +722,7 @@ ntsa::Error Proactor::Work::initiateAccept()
 
 ntsa::Error Proactor::Work::initiateConnect(const ntsa::Endpoint& endpoint)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -773,7 +779,7 @@ ntsa::Error Proactor::Work::initiateConnect(const ntsa::Endpoint& endpoint)
 ntsa::Error Proactor::Work::initiateSend(const bdlbb::Blob&       data,
                                          const ntsa::SendOptions& options)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -803,7 +809,7 @@ ntsa::Error Proactor::Work::initiateSend(const bdlbb::Blob&       data,
 ntsa::Error Proactor::Work::initiateSend(const ntsa::Data&        data,
                                          const ntsa::SendOptions& options)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -834,7 +840,7 @@ ntsa::Error Proactor::Work::initiateReceive(
     bdlbb::Blob*                data,
     const ntsa::ReceiveOptions& options)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -884,7 +890,7 @@ ntsa::Error Proactor::Work::shutdown(ntsa::ShutdownType::Value direction)
 
 ntsa::Error Proactor::Work::cancel()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     d_acceptQueue.clear();
     d_connectQueue.clear();
@@ -1222,7 +1228,7 @@ ntci::Waiter Proactor::registerWaiter(const ntca::WaiterOptions& waiterOptions)
     result->d_options = waiterOptions;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_waiterSetMutex);
+        LockGuard lockGuard(&d_waiterSetMutex);
 
         if (result->d_options.threadHandle() == bslmt::ThreadUtil::Handle()) {
             result->d_options.setThreadHandle(bslmt::ThreadUtil::self());
@@ -1278,7 +1284,7 @@ void Proactor::deregisterWaiter(ntci::Waiter waiter)
     bool flush = false;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_waiterSetMutex);
+        LockGuard lockGuard(&d_waiterSetMutex);
 
         bsl::size_t n = d_waiterSet.erase(result);
         BSLS_ASSERT_OPT(n == 1);
@@ -1347,7 +1353,7 @@ ntsa::Error Proactor::attachSocket(
 
     bsl::shared_ptr<Work> work;
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_workMapMutex);
+        LockGuard lock(&d_workMapMutex);
 
         WorkMap::iterator it = d_workMap.find(handle);
         if (it != d_workMap.end()) {
@@ -1476,7 +1482,7 @@ ntsa::Error Proactor::detachSocket(
     ntsa::Handle handle = socket->handle();
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_workMapMutex);
+        LockGuard lock(&d_workMapMutex);
 
         WorkMap::iterator it = d_workMap.find(handle);
         if (it == d_workMap.end()) {
@@ -1524,7 +1530,7 @@ ntsa::Error Proactor::removeDetached(
 ntsa::Error Proactor::closeAll()
 {
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_workMapMutex);
+        LockGuard lock(&d_workMapMutex);
         d_workMap.clear();
     }
 
@@ -1740,7 +1746,7 @@ void Proactor::clearSockets()
 
     entryList.clear();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_workMapMutex);
+    LockGuard lock(&d_workMapMutex);
 
     for (WorkMap::iterator it = d_workMap.begin(); it != d_workMap.end(); ++it)
     {
@@ -1769,7 +1775,7 @@ void Proactor::clear()
 
     entryList.clear();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_workMapMutex);
+    LockGuard lock(&d_workMapMutex);
 
     for (WorkMap::iterator it = d_workMap.begin(); it != d_workMap.end(); ++it)
     {
@@ -1890,19 +1896,19 @@ bsl::size_t Proactor::load() const
 
 bslmt::ThreadUtil::Handle Proactor::threadHandle() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_waiterSetMutex);
+    LockGuard lock(&d_waiterSetMutex);
     return d_threadHandle;
 }
 
 bsl::size_t Proactor::threadIndex() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_waiterSetMutex);
+    LockGuard lock(&d_waiterSetMutex);
     return d_threadIndex;
 }
 
 bsl::size_t Proactor::numWaiters() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_waiterSetMutex);
+    LockGuard lock(&d_waiterSetMutex);
     return d_waiterSet.size();
 }
 

--- a/groups/ntc/ntcd/ntcd_proactor.h
+++ b/groups/ntc/ntcd/ntcd_proactor.h
@@ -82,6 +82,12 @@ class Proactor : public ntci::Proactor,
     /// This typedef defines a map of work pending for the socket.
     typedef bsl::unordered_map<ntsa::Handle, bsl::shared_ptr<Work> > WorkMap;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     bsl::shared_ptr<ntcd::Machine>               d_machine_sp;
     bsl::shared_ptr<ntcd::Monitor>               d_monitor_sp;
     bsl::shared_ptr<ntci::User>                  d_user_sp;
@@ -96,9 +102,9 @@ class Proactor : public ntci::Proactor,
     bsl::shared_ptr<ntcs::RegistryEntryCatalog::EntryFunctor>
                                                 d_detachFunctor_sp;
     bsl::shared_ptr<ntcs::RegistryEntryCatalog> d_registry_sp;
-    mutable bslmt::Mutex                        d_waiterSetMutex;
+    mutable Mutex                               d_waiterSetMutex;
     WaiterSet                                   d_waiterSet;
-    mutable bslmt::Mutex                        d_workMapMutex;
+    mutable Mutex                               d_workMapMutex;
     WorkMap                                     d_workMap;
     bslmt::ThreadUtil::Handle                   d_threadHandle;
     bsl::size_t                                 d_threadIndex;

--- a/groups/ntc/ntcd/ntcd_reactor.cpp
+++ b/groups/ntc/ntcd/ntcd_reactor.cpp
@@ -495,7 +495,7 @@ ntci::Waiter Reactor::registerWaiter(const ntca::WaiterOptions& waiterOptions)
     result->d_options = waiterOptions;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_waiterSetMutex);
+        LockGuard lockGuard(&d_waiterSetMutex);
 
         if (result->d_options.threadHandle() == bslmt::ThreadUtil::Handle()) {
             result->d_options.setThreadHandle(bslmt::ThreadUtil::self());
@@ -551,7 +551,7 @@ void Reactor::deregisterWaiter(ntci::Waiter waiter)
     bool flush = false;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_waiterSetMutex);
+        LockGuard lockGuard(&d_waiterSetMutex);
 
         bsl::size_t n = d_waiterSet.erase(result);
         BSLS_ASSERT_OPT(n == 1);
@@ -1602,19 +1602,19 @@ bsl::size_t Reactor::load() const
 
 bslmt::ThreadUtil::Handle Reactor::threadHandle() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_waiterSetMutex);
+    LockGuard lock(&d_waiterSetMutex);
     return d_threadHandle;
 }
 
 bsl::size_t Reactor::threadIndex() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_waiterSetMutex);
+    LockGuard lock(&d_waiterSetMutex);
     return d_threadIndex;
 }
 
 bsl::size_t Reactor::numWaiters() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_waiterSetMutex);
+    LockGuard lock(&d_waiterSetMutex);
     return d_waiterSet.size();
 }
 

--- a/groups/ntc/ntcd/ntcd_reactor.h
+++ b/groups/ntc/ntcd/ntcd_reactor.h
@@ -62,6 +62,12 @@ class Reactor : public ntci::Reactor,
     /// This typedef defines a set of waiters.
     typedef bsl::unordered_set<ntci::Waiter> WaiterSet;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     struct Result;
     // This struct describes the context of a waiter.
 
@@ -91,7 +97,7 @@ class Reactor : public ntci::Reactor,
     bsl::shared_ptr<ntcs::RegistryEntryCatalog::EntryFunctor>
                                                 d_detachFunctor_sp;
     bsl::shared_ptr<ntcs::RegistryEntryCatalog> d_registry_sp;
-    mutable bslmt::Mutex                        d_waiterSetMutex;
+    mutable Mutex                               d_waiterSetMutex;
     WaiterSet                                   d_waiterSet;
     bslmt::ThreadUtil::Handle                   d_threadHandle;
     bsl::size_t                                 d_threadIndex;

--- a/groups/ntc/ntcd/ntcd_streamsocket.cpp
+++ b/groups/ntc/ntcd/ntcd_streamsocket.cpp
@@ -62,7 +62,7 @@ StreamSocket::~StreamSocket()
 
 ntsa::Error StreamSocket::open(ntsa::Transport::Value transport)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -81,7 +81,7 @@ ntsa::Error StreamSocket::open(ntsa::Transport::Value transport)
 
 ntsa::Error StreamSocket::acquire(ntsa::Handle handle)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -100,7 +100,7 @@ ntsa::Error StreamSocket::acquire(ntsa::Handle handle)
 
 ntsa::Handle StreamSocket::release()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::k_INVALID_HANDLE;
@@ -115,7 +115,7 @@ ntsa::Handle StreamSocket::release()
 ntsa::Error StreamSocket::bind(const ntsa::Endpoint& endpoint,
                                bool                  reuseAddress)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -127,7 +127,7 @@ ntsa::Error StreamSocket::bind(const ntsa::Endpoint& endpoint,
 ntsa::Error StreamSocket::bindAny(ntsa::Transport::Value transport,
                                   bool                   reuseAddress)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -138,7 +138,7 @@ ntsa::Error StreamSocket::bindAny(ntsa::Transport::Value transport,
 
 ntsa::Error StreamSocket::connect(const ntsa::Endpoint& endpoint)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -151,7 +151,7 @@ ntsa::Error StreamSocket::send(ntsa::SendContext*       context,
                                const bdlbb::Blob&       data,
                                const ntsa::SendOptions& options)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -164,7 +164,7 @@ ntsa::Error StreamSocket::send(ntsa::SendContext*       context,
                                const ntsa::Data&        data,
                                const ntsa::SendOptions& options)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -185,7 +185,7 @@ ntsa::Error StreamSocket::receive(ntsa::ReceiveContext*       context,
                                   bdlbb::Blob*                data,
                                   const ntsa::ReceiveOptions& options)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -198,7 +198,7 @@ ntsa::Error StreamSocket::receive(ntsa::ReceiveContext*       context,
                                   ntsa::Data*                 data,
                                   const ntsa::ReceiveOptions& options)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -209,7 +209,7 @@ ntsa::Error StreamSocket::receive(ntsa::ReceiveContext*       context,
 
 ntsa::Error StreamSocket::shutdown(ntsa::ShutdownType::Value direction)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -220,7 +220,7 @@ ntsa::Error StreamSocket::shutdown(ntsa::ShutdownType::Value direction)
 
 ntsa::Error StreamSocket::unlink()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -231,7 +231,7 @@ ntsa::Error StreamSocket::unlink()
 
 ntsa::Error StreamSocket::close()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -245,7 +245,7 @@ ntsa::Error StreamSocket::close()
 
 ntsa::Error StreamSocket::sourceEndpoint(ntsa::Endpoint* result) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -256,7 +256,7 @@ ntsa::Error StreamSocket::sourceEndpoint(ntsa::Endpoint* result) const
 
 ntsa::Error StreamSocket::remoteEndpoint(ntsa::Endpoint* result) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -267,7 +267,7 @@ ntsa::Error StreamSocket::remoteEndpoint(ntsa::Endpoint* result) const
 
 ntsa::Handle StreamSocket::handle() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::k_INVALID_HANDLE;
@@ -280,7 +280,7 @@ ntsa::Handle StreamSocket::handle() const
 
 ntsa::Error StreamSocket::setBlocking(bool blocking)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -291,7 +291,7 @@ ntsa::Error StreamSocket::setBlocking(bool blocking)
 
 ntsa::Error StreamSocket::setOption(const ntsa::SocketOption& option)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -303,7 +303,7 @@ ntsa::Error StreamSocket::setOption(const ntsa::SocketOption& option)
 ntsa::Error StreamSocket::getOption(ntsa::SocketOption*           option,
                                     ntsa::SocketOptionType::Value type)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -314,7 +314,7 @@ ntsa::Error StreamSocket::getOption(ntsa::SocketOption*           option,
 
 ntsa::Error StreamSocket::getLastError(ntsa::Error* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -325,7 +325,7 @@ ntsa::Error StreamSocket::getLastError(ntsa::Error* result)
 
 bsl::size_t StreamSocket::maxBuffersPerSend() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return 1;
@@ -336,7 +336,7 @@ bsl::size_t StreamSocket::maxBuffersPerSend() const
 
 bsl::size_t StreamSocket::maxBuffersPerReceive() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_session_sp) {
         return 1;

--- a/groups/ntc/ntcd/ntcd_streamsocket.h
+++ b/groups/ntc/ntcd/ntcd_streamsocket.h
@@ -46,7 +46,13 @@ namespace ntcd {
 /// @ingroup module_ntcd
 class StreamSocket : public ntsi::StreamSocket
 {
-    mutable bslmt::Mutex           d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex                  d_mutex;
     bsl::shared_ptr<ntcd::Machine> d_machine_sp;
     bsl::shared_ptr<ntcd::Session> d_session_sp;
     bslma::Allocator*              d_allocator_p;

--- a/groups/ntc/ntcdns/ntcdns_cache.cpp
+++ b/groups/ntc/ntcdns/ntcdns_cache.cpp
@@ -230,7 +230,7 @@ void Cache::setNegativeCacheMaxTimeToLive(bsl::size_t value)
 
 void Cache::clear()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     d_cacheEntryByDomainName.clear();
     d_cacheEntryByIpAddress.clear();
@@ -248,7 +248,7 @@ void Cache::updateHost(const bsl::string&        domainName,
     bsl::shared_ptr<ntcdns::CacheHostEntry> newCacheEntry;
     bool                                    oldCacheEntryUpdated = false;
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     {
         bool mustInsert = true;
@@ -464,7 +464,7 @@ ntsa::Error Cache::getIpAddress(ntca::GetIpAddressContext*       context,
         return error;
     }
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     bsl::string key = domainName;
 
@@ -605,7 +605,7 @@ ntsa::Error Cache::getDomainName(ntca::GetDomainNameContext*       context,
     bdlb::NullableValue<ntsa::Endpoint>     nameServer;
     bdlb::NullableValue<bsls::TimeInterval> timeToLive;
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntcdns::CacheHostEntryByIpAddressIterator it =
         d_cacheEntryByIpAddress.find(ipAddress);

--- a/groups/ntc/ntcdns/ntcdns_cache.h
+++ b/groups/ntc/ntcdns/ntcdns_cache.h
@@ -207,7 +207,13 @@ bsl::ostream& operator<<(bsl::ostream& stream, const CacheHostEntry& object);
 /// @ingroup module_ntcdns
 class Cache
 {
-    mutable bslmt::Mutex                       d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex                              d_mutex;
     mutable ntcdns::CacheHostEntryByDomainName d_cacheEntryByDomainName;
     mutable ntcdns::CacheHostEntryByIpAddress  d_cacheEntryByIpAddress;
     mutable bsl::size_t                        d_cacheEntryCount;

--- a/groups/ntc/ntcdns/ntcdns_client.cpp
+++ b/groups/ntc/ntcdns/ntcdns_client.cpp
@@ -577,7 +577,7 @@ void ClientGetIpAddressOperation::processError(const ntsa::Error& error)
 bsl::shared_ptr<ntcdns::ClientNameServer> ClientGetIpAddressOperation::
     tryNextServer()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     bsl::shared_ptr<ntcdns::ClientNameServer> result;
 
@@ -592,7 +592,7 @@ bsl::shared_ptr<ntcdns::ClientNameServer> ClientGetIpAddressOperation::
 
 bool ClientGetIpAddressOperation::tryNextSearch()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_searchIndex < d_searchList.size() - 1) {
         ++d_searchIndex;
@@ -614,13 +614,13 @@ const ntca::GetIpAddressOptions& ClientGetIpAddressOperation::options() const
 
 bsl::size_t ClientGetIpAddressOperation::serverIndex() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_serverIndex;
 }
 
 bsl::size_t ClientGetIpAddressOperation::searchIndex() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_searchIndex;
 }
 
@@ -869,7 +869,7 @@ void ClientGetDomainNameOperation::processError(const ntsa::Error& error)
 bsl::shared_ptr<ntcdns::ClientNameServer> ClientGetDomainNameOperation::
     tryNextServer()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     bsl::shared_ptr<ntcdns::ClientNameServer> result;
 
@@ -898,7 +898,7 @@ const ntca::GetDomainNameOptions& ClientGetDomainNameOperation::options() const
 
 bsl::size_t ClientGetDomainNameOperation::serverIndex() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_serverIndex;
 }
 
@@ -1094,11 +1094,11 @@ void ClientNameServer::processShutdownComplete(
 {
     NTCCFG_WARNING_UNUSED(event);
 
-    bslmt::LockGuard<bslmt::Mutex> stateSocketLock(&d_stateMutex);
+    ntccfg::ConditionMutexGuard stateSocketLock(&d_stateMutex);
 
-    bslmt::LockGuard<bslmt::Mutex> datagramSocketLock(&d_datagramSocketMutex);
+    LockGuard datagramSocketLock(&d_datagramSocketMutex);
 
-    bslmt::LockGuard<bslmt::Mutex> streamSocketLock(&d_streamSocketMutex);
+    LockGuard streamSocketLock(&d_streamSocketMutex);
 
     if (datagramSocket == d_datagramSocket_sp) {
         d_datagramSocket_sp->registerSession(
@@ -1186,11 +1186,11 @@ void ClientNameServer::processShutdownComplete(
 {
     NTCCFG_WARNING_UNUSED(event);
 
-    bslmt::LockGuard<bslmt::Mutex> stateSocketLock(&d_stateMutex);
+    ntccfg::ConditionMutexGuard stateSocketLock(&d_stateMutex);
 
-    bslmt::LockGuard<bslmt::Mutex> datagramSocketLock(&d_datagramSocketMutex);
+    LockGuard datagramSocketLock(&d_datagramSocketMutex);
 
-    bslmt::LockGuard<bslmt::Mutex> streamSocketLock(&d_streamSocketMutex);
+    LockGuard streamSocketLock(&d_streamSocketMutex);
 
     if (streamSocket == d_streamSocket_sp) {
         d_streamSocket_sp->registerSession(
@@ -1378,7 +1378,7 @@ void ClientNameServer::processDatagramSocketConnected(
         return;
     }
 
-    bslmt::LockGuard<bslmt::Mutex> datagramSocketLock(&d_datagramSocketMutex);
+    LockGuard datagramSocketLock(&d_datagramSocketMutex);
 
     d_datagramSocket_sp = datagramSocket;
 
@@ -1409,7 +1409,7 @@ void ClientNameServer::processStreamSocketConnected(
         return;
     }
 
-    bslmt::LockGuard<bslmt::Mutex> streamSocketLock(&d_streamSocketMutex);
+    LockGuard streamSocketLock(&d_streamSocketMutex);
 
     d_streamSocket_sp = streamSocket;
 
@@ -1505,7 +1505,7 @@ ntsa::Error ClientNameServer::start()
 
     bsl::shared_ptr<ClientNameServer> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> stateLock(&d_stateMutex);
+    ntccfg::ConditionMutexGuard stateLock(&d_stateMutex);
 
     if (d_state == e_STATE_STARTED) {
         return ntsa::Error();
@@ -1528,7 +1528,7 @@ ntsa::Error ClientNameServer::initiate(
 {
     ntsa::Error error;
 
-    bslmt::LockGuard<bslmt::Mutex> stateLock(&d_stateMutex);
+    ntccfg::ConditionMutexGuard stateLock(&d_stateMutex);
 
     if (d_state != e_STATE_STARTED) {
         return ntsa::Error(ntsa::Error::e_INVALID);
@@ -1539,7 +1539,7 @@ ntsa::Error ClientNameServer::initiate(
     d_operationQueue.push(operation);
 
     {
-        bslmt::LockGuard<bslmt::Mutex> datagramSocketLock(
+        LockGuard datagramSocketLock(
             &d_datagramSocketMutex);
 
         if (!d_datagramSocket_sp) {
@@ -1615,7 +1615,7 @@ void ClientNameServer::shutdown()
 {
     NTCI_LOG_CONTEXT();
 
-    bslmt::LockGuard<bslmt::Mutex> stateLock(&d_stateMutex);
+    ntccfg::ConditionMutexGuard stateLock(&d_stateMutex);
 
     if (d_state != e_STATE_STARTED) {
         return;
@@ -1627,9 +1627,9 @@ void ClientNameServer::shutdown()
 
     this->cancelAll();
 
-    bslmt::LockGuard<bslmt::Mutex> datagramSocketLock(&d_datagramSocketMutex);
+    LockGuard datagramSocketLock(&d_datagramSocketMutex);
 
-    bslmt::LockGuard<bslmt::Mutex> streamSocketLock(&d_streamSocketMutex);
+    LockGuard streamSocketLock(&d_streamSocketMutex);
 
     if (!d_datagramSocket_sp && !d_streamSocket_sp) {
         d_state = e_STATE_STOPPED;
@@ -1654,7 +1654,7 @@ void ClientNameServer::linger()
 {
     NTCI_LOG_CONTEXT();
 
-    bslmt::LockGuard<bslmt::Mutex> stateLock(&d_stateMutex);
+    ntccfg::ConditionMutexGuard stateLock(&d_stateMutex);
 
     while (d_state != e_STATE_STOPPED) {
         d_stateCondition.wait(&d_stateMutex);
@@ -1779,7 +1779,7 @@ ntsa::Error Client::start()
 
     ntsa::Error error;
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_state == e_STATE_STARTED) {
         return ntsa::Error();
@@ -1811,7 +1811,7 @@ void Client::shutdown()
 {
     NTCI_LOG_CONTEXT();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_state != e_STATE_STARTED) {
         return;
@@ -1836,7 +1836,7 @@ void Client::linger()
 {
     NTCI_LOG_CONTEXT();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_state == e_STATE_STOPPED) {
         return;
@@ -1872,7 +1872,7 @@ ntsa::Error Client::getIpAddress(
     const ntca::GetIpAddressOptions&       options,
     const ntci::GetIpAddressCallback&      callback)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -1964,7 +1964,7 @@ ntsa::Error Client::getDomainName(
     const ntca::GetDomainNameOptions&      options,
     const ntci::GetDomainNameCallback&     callback)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 

--- a/groups/ntc/ntcdns/ntcdns_client.h
+++ b/groups/ntc/ntcdns/ntcdns_client.h
@@ -143,8 +143,14 @@ class ClientGetIpAddressOperation
     typedef bsl::vector<bsl::shared_ptr<ntcdns::ClientNameServer> > ServerList;
 
   private:
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                  d_object;
-    mutable bslmt::Mutex            d_mutex;
+    mutable Mutex                   d_mutex;
     bsl::shared_ptr<ntci::Resolver> d_resolver_sp;
     const bsl::string               d_name;
     ServerList                      d_serverList;
@@ -256,8 +262,14 @@ class ClientGetDomainNameOperation
     typedef bsl::vector<bsl::shared_ptr<ntcdns::ClientNameServer> > ServerList;
 
   private:
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                   d_object;
-    mutable bslmt::Mutex             d_mutex;
+    mutable Mutex                    d_mutex;
     bsl::shared_ptr<ntci::Resolver>  d_resolver_sp;
     const ntsa::IpAddress            d_ipAddress;
     ServerList                       d_serverList;
@@ -372,6 +384,12 @@ class ClientNameServer : public ntci::DatagramSocketSession,
                         bsl::shared_ptr<ntcdns::ClientOperation> >
         OperationMap;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     enum State {
         // This enumeration enumerates the states of operation.
 
@@ -383,14 +401,14 @@ class ClientNameServer : public ntci::DatagramSocketSession,
     ntccfg::Object                               d_object;
     OperationQueue                               d_operationQueue;
     OperationMap                                 d_operationMap;
-    bslmt::Mutex                                 d_datagramSocketMutex;
+    Mutex                                        d_datagramSocketMutex;
     bsl::shared_ptr<ntci::DatagramSocket>        d_datagramSocket_sp;
     bsl::shared_ptr<ntci::DatagramSocketFactory> d_datagramSocketFactory_sp;
-    bslmt::Mutex                                 d_streamSocketMutex;
+    Mutex                                        d_streamSocketMutex;
     bsl::shared_ptr<ntci::StreamSocket>          d_streamSocket_sp;
     bsl::shared_ptr<ntci::StreamSocketFactory>   d_streamSocketFactory_sp;
-    bslmt::Mutex                                 d_stateMutex;
-    bslmt::Condition                             d_stateCondition;
+    ntccfg::ConditionMutex                       d_stateMutex;
+    ntccfg::Condition                            d_stateCondition;
     State                                        d_state;
     const ntsa::Endpoint                         d_endpoint;
     const bsl::size_t                            d_index;
@@ -605,6 +623,12 @@ class Client : public ntccfg::Shared<Client>
     /// try when performing the operation.
     typedef bsl::vector<bsl::shared_ptr<ntcdns::ClientNameServer> > ServerList;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     enum State {
         // This enumeraiton enumerates the states of operation.
 
@@ -614,7 +638,7 @@ class Client : public ntccfg::Shared<Client>
     };
 
     ntccfg::Object                               d_object;
-    bslmt::Mutex                                 d_mutex;
+    Mutex                                        d_mutex;
     bsl::shared_ptr<ntci::DatagramSocketFactory> d_datagramSocketFactory_sp;
     bsl::shared_ptr<ntci::StreamSocketFactory>   d_streamSocketFactory_sp;
     bsl::shared_ptr<ntcdns::Cache>               d_cache_sp;

--- a/groups/ntc/ntcdns/ntcdns_database.cpp
+++ b/groups/ntc/ntcdns/ntcdns_database.cpp
@@ -610,7 +610,7 @@ ntsa::Error HostDatabase::load(const bsl::shared_ptr<ntcdns::File>& file)
 #endif
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        LockGuard lock(&d_mutex);
 
         d_ipAddressByDomainName.swap(ipAddressByDomainName);
         d_domainNameByIpAddress.swap(domainNameByIpAddress);
@@ -636,7 +636,7 @@ HostDatabase::~HostDatabase()
 
 void HostDatabase::clear()
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     d_ipAddressByDomainName.clear();
     d_domainNameByIpAddress.clear();
@@ -726,7 +726,7 @@ ntsa::Error HostDatabase::getIpAddress(
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        LockGuard lock(&d_mutex);
 
         IpAddressByDomainName::const_iterator it =
             d_ipAddressByDomainName.find(domainName);
@@ -783,7 +783,7 @@ ntsa::Error HostDatabase::getDomainName(
 {
     NTCCFG_WARNING_UNUSED(options);
 
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     DomainNameByIpAddress::const_iterator it =
         d_domainNameByIpAddress.find(ipAddress);
@@ -1116,7 +1116,7 @@ ntsa::Error PortDatabase::load(const bsl::shared_ptr<ntcdns::File>& file)
 #endif
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        LockGuard lock(&d_mutex);
 
         d_tcpPortByServiceName.swap(tcpPortByServiceName);
         d_tcpServiceNameByPort.swap(tcpServiceNameByPort);
@@ -1146,7 +1146,7 @@ PortDatabase::~PortDatabase()
 
 void PortDatabase::clear()
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     d_tcpPortByServiceName.clear();
     d_tcpServiceNameByPort.clear();
@@ -1259,7 +1259,7 @@ ntsa::Error PortDatabase::getPort(ntca::GetPortContext*       context,
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        LockGuard lock(&d_mutex);
 
         if (examineTcpPortList) {
             PortByServiceName::const_iterator it =
@@ -1342,7 +1342,7 @@ ntsa::Error PortDatabase::getServiceName(
     const ntsa::Port&                  port,
     const ntca::GetServiceNameOptions& options) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     bool found = false;
 
@@ -1424,7 +1424,7 @@ void PortDatabase::dump(bsl::vector<ntcdns::PortEntry>* result) const
 {
     result->clear();
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     result->reserve(d_tcpServiceNameByPort.size() +
                     d_udpServiceNameByPort.size());

--- a/groups/ntc/ntcdns/ntcdns_database.h
+++ b/groups/ntc/ntcdns/ntcdns_database.h
@@ -123,7 +123,13 @@ class HostDatabase
         unordered_map<ntsa::IpAddress, bslstl::StringRef, IpAddressHash>
             DomainNameByIpAddress;
 
-    mutable bslmt::Mutex          d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex                 d_mutex;
     bdlma::MultipoolAllocator     d_pool;
     IpAddressByDomainName         d_ipAddressByDomainName;
     DomainNameByIpAddress         d_domainNameByIpAddress;
@@ -228,7 +234,13 @@ class PortDatabase
     typedef bsl::unordered_map<ntsa::Port, bslstl::StringRef>
         ServiceNameByPort;
 
-    mutable bslmt::Mutex          d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex                 d_mutex;
     PortByServiceName             d_tcpPortByServiceName;
     ServiceNameByPort             d_tcpServiceNameByPort;
     PortByServiceName             d_udpPortByServiceName;

--- a/groups/ntc/ntcdns/ntcdns_database.t.cpp
+++ b/groups/ntc/ntcdns/ntcdns_database.t.cpp
@@ -71,7 +71,13 @@ class HostDatabase
     typedef bsl::unordered_map<ntsa::IpAddress, bsl::string>
         DomainNameByIpAddress;
 
-    mutable bslmt::Mutex  d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex         d_mutex;
     IpAddressByDomainName d_ipAddressByDomainName;
     DomainNameByIpAddress d_domainNameByIpAddress;
     bslma::Allocator*     d_allocator_p;
@@ -145,12 +151,18 @@ class PortDatabase
     /// service names.
     typedef bsl::unordered_map<ntsa::Port, bsl::string> ServiceNameByPort;
 
-    mutable bslmt::Mutex d_mutex;
-    PortByServiceName    d_tcpPortByServiceName;
-    ServiceNameByPort    d_tcpServiceNameByPort;
-    PortByServiceName    d_udpPortByServiceName;
-    ServiceNameByPort    d_udpServiceNameByPort;
-    bslma::Allocator*    d_allocator_p;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex     d_mutex;
+    PortByServiceName d_tcpPortByServiceName;
+    ServiceNameByPort d_tcpServiceNameByPort;
+    PortByServiceName d_udpPortByServiceName;
+    ServiceNameByPort d_udpServiceNameByPort;
+    bslma::Allocator* d_allocator_p;
 
   private:
     PortDatabase(const PortDatabase&) BSLS_KEYWORD_DELETED;
@@ -216,7 +228,7 @@ HostDatabase::~HostDatabase()
 
 void HostDatabase::clear()
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     d_ipAddressByDomainName.clear();
     d_domainNameByIpAddress.clear();
@@ -246,7 +258,7 @@ ntsa::Error HostDatabase::addHostEntry(const ntcdns::HostEntry& entry)
 {
     NTCI_LOG_CONTEXT();
 
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     ntsa::Error error;
 
@@ -372,7 +384,7 @@ ntsa::Error HostDatabase::getIpAddress(
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        LockGuard lock(&d_mutex);
 
         IpAddressByDomainName::const_iterator it =
             d_ipAddressByDomainName.find(domainName);
@@ -422,7 +434,7 @@ ntsa::Error HostDatabase::getDomainName(
     const ntsa::IpAddress&            ipAddress,
     const ntca::GetDomainNameOptions& options) const
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     DomainNameByIpAddress::const_iterator it =
         d_domainNameByIpAddress.find(ipAddress);
@@ -459,7 +471,7 @@ PortDatabase::~PortDatabase()
 
 void PortDatabase::clear()
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     d_tcpPortByServiceName.clear();
     d_tcpServiceNameByPort.clear();
@@ -493,7 +505,7 @@ ntsa::Error PortDatabase::addPortEntry(const ntcdns::PortEntry& entry)
 
     ntsa::Error error;
 
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     if (entry.service().empty()) {
         NTCI_LOG_STREAM_WARN << "Failed to add port entry " << entry
@@ -595,7 +607,7 @@ ntsa::Error PortDatabase::getPort(ntca::GetPortContext*       context,
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        LockGuard lock(&d_mutex);
 
         if (examineTcpPortList) {
             PortByServiceName::const_iterator it =
@@ -677,7 +689,7 @@ ntsa::Error PortDatabase::getServiceName(
     const ntsa::Port&                  port,
     const ntca::GetServiceNameOptions& options) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     bool found = false;
 

--- a/groups/ntc/ntcdns/ntcdns_resolver.cpp
+++ b/groups/ntc/ntcdns/ntcdns_resolver.cpp
@@ -524,7 +524,7 @@ Resolver::~Resolver()
 
 ntsa::Error Resolver::start()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_state == e_STATE_STARTED) {
         return ntsa::Error();
@@ -549,7 +549,7 @@ void Resolver::shutdown()
     bsl::shared_ptr<ntcdns::System> system;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        LockGuard lock(&d_mutex);
 
         if (d_state != e_STATE_STARTED) {
             return;
@@ -578,7 +578,7 @@ void Resolver::linger()
     bsl::shared_ptr<ntci::Interface>   interface;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        LockGuard lock(&d_mutex);
 
         if (d_state == e_STATE_STOPPED) {
             return;
@@ -614,7 +614,7 @@ ntsa::Error Resolver::setIpAddress(
     const bslstl::StringRef&            domainName,
     const bsl::vector<ntsa::IpAddress>& ipAddressList)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -634,7 +634,7 @@ ntsa::Error Resolver::addIpAddress(
     const bslstl::StringRef&            domainName,
     const bsl::vector<ntsa::IpAddress>& ipAddressList)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -653,7 +653,7 @@ ntsa::Error Resolver::addIpAddress(
 ntsa::Error Resolver::addIpAddress(const bslstl::StringRef& domainName,
                                    const ntsa::IpAddress&   ipAddress)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -673,7 +673,7 @@ ntsa::Error Resolver::setPort(const bslstl::StringRef&       serviceName,
                               const bsl::vector<ntsa::Port>& portList,
                               ntsa::Transport::Value         transport)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -693,7 +693,7 @@ ntsa::Error Resolver::addPort(const bslstl::StringRef&       serviceName,
                               const bsl::vector<ntsa::Port>& portList,
                               ntsa::Transport::Value         transport)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -713,7 +713,7 @@ ntsa::Error Resolver::addPort(const bslstl::StringRef& serviceName,
                               ntsa::Port               port,
                               ntsa::Transport::Value   transport)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -732,7 +732,7 @@ ntsa::Error Resolver::addPort(const bslstl::StringRef& serviceName,
 ntsa::Error Resolver::setLocalIpAddress(
     const bsl::vector<ntsa::IpAddress>& ipAddressList)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -750,7 +750,7 @@ ntsa::Error Resolver::setLocalIpAddress(
 
 ntsa::Error Resolver::setHostname(const bsl::string& name)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -768,7 +768,7 @@ ntsa::Error Resolver::setHostname(const bsl::string& name)
 
 ntsa::Error Resolver::setHostnameFullyQualified(const bsl::string& name)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -788,7 +788,7 @@ ntsa::Error Resolver::getIpAddress(const bslstl::StringRef&         domainName,
                                    const ntca::GetIpAddressOptions& options,
                                    const ntci::GetIpAddressCallback& callback)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -838,7 +838,7 @@ ntsa::Error Resolver::getIpAddress(const bslstl::StringRef&         domainName,
                               d_strand_sp,
                               self,
                               true,
-                              (bslmt::Mutex*) NULL);
+                              NTCCFG_MUTEX_NULL);
 
             return ntsa::Error();
         }
@@ -871,7 +871,7 @@ ntsa::Error Resolver::getIpAddress(const bslstl::StringRef&         domainName,
                               d_strand_sp,
                               self,
                               true,
-                              (bslmt::Mutex*) NULL);
+                              NTCCFG_MUTEX_NULL);
 
             return ntsa::Error();
         }
@@ -905,7 +905,7 @@ ntsa::Error Resolver::getIpAddress(const bslstl::StringRef&         domainName,
                               d_strand_sp,
                               self,
                               true,
-                              (bslmt::Mutex*) NULL);
+                              NTCCFG_MUTEX_NULL);
 
             return ntsa::Error();
         }
@@ -951,7 +951,7 @@ ntsa::Error Resolver::getIpAddress(const bslstl::StringRef&         domainName,
                           d_strand_sp,
                           self,
                           true,
-                          (bslmt::Mutex*) NULL);
+                          NTCCFG_MUTEX_NULL);
     }
 
     return ntsa::Error();
@@ -962,7 +962,7 @@ ntsa::Error Resolver::getDomainName(
     const ntca::GetDomainNameOptions&  options,
     const ntci::GetDomainNameCallback& callback)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -1008,7 +1008,7 @@ ntsa::Error Resolver::getDomainName(
                               d_strand_sp,
                               self,
                               true,
-                              (bslmt::Mutex*) NULL);
+                              NTCCFG_MUTEX_NULL);
 
             return ntsa::Error();
         }
@@ -1042,7 +1042,7 @@ ntsa::Error Resolver::getDomainName(
                               d_strand_sp,
                               self,
                               true,
-                              (bslmt::Mutex*) NULL);
+                              NTCCFG_MUTEX_NULL);
 
             return ntsa::Error();
         }
@@ -1077,7 +1077,7 @@ ntsa::Error Resolver::getDomainName(
                               d_strand_sp,
                               self,
                               true,
-                              (bslmt::Mutex*) NULL);
+                              NTCCFG_MUTEX_NULL);
 
             return ntsa::Error();
         }
@@ -1123,7 +1123,7 @@ ntsa::Error Resolver::getDomainName(
                           d_strand_sp,
                           self,
                           true,
-                          (bslmt::Mutex*) NULL);
+                          NTCCFG_MUTEX_NULL);
     }
 
     return ntsa::Error();
@@ -1133,7 +1133,7 @@ ntsa::Error Resolver::getPort(const bslstl::StringRef&     serviceName,
                               const ntca::GetPortOptions&  options,
                               const ntci::GetPortCallback& callback)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -1182,7 +1182,7 @@ ntsa::Error Resolver::getPort(const bslstl::StringRef&     serviceName,
                               d_strand_sp,
                               self,
                               true,
-                              (bslmt::Mutex*) NULL);
+                              NTCCFG_MUTEX_NULL);
 
             return ntsa::Error();
         }
@@ -1214,7 +1214,7 @@ ntsa::Error Resolver::getPort(const bslstl::StringRef&     serviceName,
                               d_strand_sp,
                               self,
                               true,
-                              (bslmt::Mutex*) NULL);
+                              NTCCFG_MUTEX_NULL);
 
             return ntsa::Error();
         }
@@ -1246,7 +1246,7 @@ ntsa::Error Resolver::getPort(const bslstl::StringRef&     serviceName,
                               d_strand_sp,
                               self,
                               true,
-                              (bslmt::Mutex*) NULL);
+                              NTCCFG_MUTEX_NULL);
 
             return ntsa::Error();
         }
@@ -1275,7 +1275,7 @@ ntsa::Error Resolver::getPort(const bslstl::StringRef&     serviceName,
                               d_strand_sp,
                               self,
                               true,
-                              (bslmt::Mutex*) NULL);
+                              NTCCFG_MUTEX_NULL);
             return ntsa::Error();
         }
     }
@@ -1307,7 +1307,7 @@ ntsa::Error Resolver::getPort(const bslstl::StringRef&     serviceName,
                           d_strand_sp,
                           self,
                           true,
-                          (bslmt::Mutex*) NULL);
+                          NTCCFG_MUTEX_NULL);
     }
 
     return ntsa::Error();
@@ -1318,7 +1318,7 @@ ntsa::Error Resolver::getServiceName(
     const ntca::GetServiceNameOptions&  options,
     const ntci::GetServiceNameCallback& callback)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -1373,7 +1373,7 @@ ntsa::Error Resolver::getServiceName(
                               d_strand_sp,
                               self,
                               true,
-                              (bslmt::Mutex*) NULL);
+                              NTCCFG_MUTEX_NULL);
 
             return ntsa::Error();
         }
@@ -1407,7 +1407,7 @@ ntsa::Error Resolver::getServiceName(
                               d_strand_sp,
                               self,
                               true,
-                              (bslmt::Mutex*) NULL);
+                              NTCCFG_MUTEX_NULL);
 
             return ntsa::Error();
         }
@@ -1442,7 +1442,7 @@ ntsa::Error Resolver::getServiceName(
                               d_strand_sp,
                               self,
                               true,
-                              (bslmt::Mutex*) NULL);
+                              NTCCFG_MUTEX_NULL);
 
             return ntsa::Error();
         }
@@ -1465,7 +1465,7 @@ ntsa::Error Resolver::getServiceName(
                               d_strand_sp,
                               self,
                               true,
-                              (bslmt::Mutex*) NULL);
+                              NTCCFG_MUTEX_NULL);
 
             return ntsa::Error();
         }
@@ -1498,7 +1498,7 @@ ntsa::Error Resolver::getServiceName(
                           d_strand_sp,
                           self,
                           true,
-                          (bslmt::Mutex*) NULL);
+                          NTCCFG_MUTEX_NULL);
     }
 
     return ntsa::Error();
@@ -1565,7 +1565,7 @@ ntsa::Error Resolver::getEndpoint(const bslstl::StringRef&         text,
             getEndpointEvent.setContext(getEndpointContext);
 
             callback.dispatch(
-                self, endpoint, getEndpointEvent, d_strand_sp, self, true, (bslmt::Mutex*) NULL);
+                self, endpoint, getEndpointEvent, d_strand_sp, self, true, NTCCFG_MUTEX_NULL);
 
             return ntsa::Error();
         }
@@ -1742,7 +1742,7 @@ ntsa::Error Resolver::getEndpoint(const bslstl::StringRef&         text,
         bool needPort = true;
 
         {
-            bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+            LockGuard lock(&d_mutex);
 
             if (needPort && d_overrides_sp) {
                 error = d_overrides_sp->getPort(&portList,
@@ -1897,7 +1897,7 @@ ntsa::Error Resolver::getEndpoint(const bslstl::StringRef&         text,
                       d_strand_sp,
                       self,
                       true,
-                      (bslmt::Mutex*) NULL);
+                      NTCCFG_MUTEX_NULL);
 
     return ntsa::Error();
 }
@@ -1908,7 +1908,7 @@ ntsa::Error Resolver::getLocalIpAddress(bsl::vector<ntsa::IpAddress>* result,
     ntsa::Error error;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        LockGuard lock(&d_mutex);
 
         if (d_overrides_sp) {
             error = d_overrides_sp->getLocalIpAddress(result, options);
@@ -1926,7 +1926,7 @@ ntsa::Error Resolver::getHostname(bsl::string* result)
     ntsa::Error error;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        LockGuard lock(&d_mutex);
 
         if (d_overrides_sp) {
             error = d_overrides_sp->getHostname(result);
@@ -1944,7 +1944,7 @@ ntsa::Error Resolver::getHostnameFullyQualified(bsl::string* result)
     ntsa::Error error;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        LockGuard lock(&d_mutex);
 
         if (d_overrides_sp) {
             error = d_overrides_sp->getHostnameFullyQualified(result);
@@ -2054,7 +2054,7 @@ bsl::shared_ptr<ntci::Timer> Resolver::createTimer(
 
 ntsa::Error Resolver::loadHostDatabaseText(const char* data, bsl::size_t size)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -2079,7 +2079,7 @@ ntsa::Error Resolver::loadHostDatabaseText(const char* data, bsl::size_t size)
 
 ntsa::Error Resolver::loadPortDatabaseText(const char* data, bsl::size_t size)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -2108,7 +2108,7 @@ ntsa::Error Resolver::cacheHost(const bsl::string&        domainName,
                                 bsl::size_t               timeToLive,
                                 const bsls::TimeInterval& now)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 

--- a/groups/ntc/ntcdns/ntcdns_resolver.h
+++ b/groups/ntc/ntcdns/ntcdns_resolver.h
@@ -55,8 +55,14 @@ class Resolver : public ntci::Resolver, public ntccfg::Shared<Resolver>
 {
     enum State { e_STATE_STARTED, e_STATE_STOPPING, e_STATE_STOPPED };
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                               d_object;
-    mutable bslmt::Mutex                         d_mutex;
+    mutable Mutex                                d_mutex;
     bsl::shared_ptr<ntci::Interface>             d_interface_sp;
     bool                                         d_interfaceOwned;
     bsl::shared_ptr<ntci::DatagramSocketFactory> d_datagramSocketFactory_sp;

--- a/groups/ntc/ntcdns/ntcdns_system.cpp
+++ b/groups/ntc/ntcdns/ntcdns_system.cpp
@@ -330,7 +330,7 @@ System::~System()
 
 ntsa::Error System::start()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_state == e_STATE_STARTED) {
         return ntsa::Error();
@@ -353,7 +353,7 @@ void System::linger()
 {
     bsl::shared_ptr<bdlmt::ThreadPool> threadPool;
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        LockGuard lock(&d_mutex);
         threadPool = d_threadPool_sp;
     }
 
@@ -363,7 +363,7 @@ void System::linger()
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        LockGuard lock(&d_mutex);
         d_state = e_STATE_STOPPED;
         d_threadPool_sp.reset();
     }
@@ -376,7 +376,7 @@ ntsa::Error System::getIpAddress(
     const ntca::GetIpAddressOptions&       options,
     const ntci::GetIpAddressCallback&      callback)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
     int         rc;
@@ -414,7 +414,7 @@ ntsa::Error System::getDomainName(
     const ntca::GetDomainNameOptions&      options,
     const ntci::GetDomainNameCallback&     callback)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
     int         rc;
@@ -451,7 +451,7 @@ ntsa::Error System::getPort(const bsl::shared_ptr<ntci::Resolver>& resolver,
                             const ntca::GetPortOptions&            options,
                             const ntci::GetPortCallback&           callback)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
     int         rc;
@@ -489,7 +489,7 @@ ntsa::Error System::getServiceName(
     const ntca::GetServiceNameOptions&     options,
     const ntci::GetServiceNameCallback&    callback)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
     int         rc;
@@ -522,7 +522,7 @@ ntsa::Error System::getServiceName(
 
 void System::execute(const Functor& functor)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
     int         rc;
@@ -547,7 +547,7 @@ void System::execute(const Functor& functor)
 void System::moveAndExecute(FunctorSequence* functorSequence,
                             const Functor&   functor)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
     int         rc;

--- a/groups/ntc/ntcdns/ntcdns_system.h
+++ b/groups/ntc/ntcdns/ntcdns_system.h
@@ -74,7 +74,13 @@ class System : public ntci::Executor,
 {
     enum State { e_STATE_STARTED, e_STATE_STOPPING, e_STATE_STOPPED };
 
-    bslmt::Mutex                       d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    Mutex                              d_mutex;
     bsl::shared_ptr<bdlmt::ThreadPool> d_threadPool_sp;
     int                                d_minThreads;
     int                                d_maxThreads;

--- a/groups/ntc/ntcdns/ntcdns_utility.h
+++ b/groups/ntc/ntcdns/ntcdns_utility.h
@@ -164,10 +164,17 @@ struct Utility {
 template <typename KEY, typename VALUE>
 class Map
 {
+    /// Define a type alias for the container type.
     typedef bsl::unordered_map<KEY, VALUE> Container;
 
-    mutable bslmt::Mutex d_mutex;
-    Container            d_container;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex d_mutex;
+    Container     d_container;
 
   private:
     Map(const Map&) BSLS_KEYWORD_DELETED;
@@ -247,10 +254,17 @@ class Map
 template <typename TYPE>
 class Queue
 {
+    /// Define a type alias for the container type.
     typedef bsl::list<TYPE> Container;
 
-    mutable bslmt::Mutex d_mutex;
-    Container            d_container;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex d_mutex;
+    Container     d_container;
 
   private:
     Queue(const Queue&) BSLS_KEYWORD_DELETED;
@@ -315,7 +329,7 @@ Map<KEY, VALUE>::~Map()
 template <typename KEY, typename VALUE>
 bool Map<KEY, VALUE>::add(const KEY& key, const VALUE& value)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return d_container.insert(typename Container::value_type(key, value))
         .second;
@@ -324,7 +338,7 @@ bool Map<KEY, VALUE>::add(const KEY& key, const VALUE& value)
 template <typename KEY, typename VALUE>
 bool Map<KEY, VALUE>::replace(const KEY& key, const VALUE& value)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     typename Container::iterator it = d_container.find(key);
     if (it != d_container.end()) {
@@ -338,7 +352,7 @@ bool Map<KEY, VALUE>::replace(const KEY& key, const VALUE& value)
 template <typename KEY, typename VALUE>
 bool Map<KEY, VALUE>::find(VALUE* result, const KEY& key)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     typename Container::iterator it = d_container.find(key);
     if (it != d_container.end()) {
@@ -352,7 +366,7 @@ bool Map<KEY, VALUE>::find(VALUE* result, const KEY& key)
 template <typename KEY, typename VALUE>
 bool Map<KEY, VALUE>::remove(const KEY& key)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     bsl::size_t n = d_container.erase(key);
     return n == 1;
@@ -361,7 +375,7 @@ bool Map<KEY, VALUE>::remove(const KEY& key)
 template <typename KEY, typename VALUE>
 bool Map<KEY, VALUE>::remove(VALUE* result, const KEY& key)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     typename Container::iterator it = d_container.find(key);
     if (it != d_container.end()) {
@@ -376,7 +390,7 @@ bool Map<KEY, VALUE>::remove(VALUE* result, const KEY& key)
 template <typename KEY, typename VALUE>
 bsl::size_t Map<KEY, VALUE>::removeValue(const VALUE& value, bool all)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     bsl::size_t result = 0;
 
@@ -413,13 +427,13 @@ template <typename KEY, typename VALUE>
 void Map<KEY, VALUE>::swap(Map* other)
 {
     if (this < other) {
-        bslmt::LockGuard<bslmt::Mutex> lock1(&d_mutex);
-        bslmt::LockGuard<bslmt::Mutex> lock2(&other->d_mutex);
+        LockGuard lock1(&d_mutex);
+        LockGuard lock2(&other->d_mutex);
         d_container.swap(other->d_container);
     }
     else {
-        bslmt::LockGuard<bslmt::Mutex> lock1(&other->d_mutex);
-        bslmt::LockGuard<bslmt::Mutex> lock2(&d_mutex);
+        LockGuard lock1(&other->d_mutex);
+        LockGuard lock2(&d_mutex);
         d_container.swap(other->d_container);
     }
 }
@@ -427,14 +441,14 @@ void Map<KEY, VALUE>::swap(Map* other)
 template <typename KEY, typename VALUE>
 void Map<KEY, VALUE>::clear()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     d_container.clear();
 }
 
 template <typename KEY, typename VALUE>
 bool Map<KEY, VALUE>::contains(const KEY& key) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     typename Container::const_iterator it = d_container.find(key);
     if (it != d_container.end()) {
@@ -447,7 +461,7 @@ bool Map<KEY, VALUE>::contains(const KEY& key) const
 template <typename KEY, typename VALUE>
 void Map<KEY, VALUE>::keys(bsl::vector<VALUE>* result) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     result->reserve(result->size() + d_container.size());
 
@@ -462,7 +476,7 @@ void Map<KEY, VALUE>::keys(bsl::vector<VALUE>* result) const
 template <typename KEY, typename VALUE>
 void Map<KEY, VALUE>::values(bsl::vector<VALUE>* result) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     result->reserve(result->size() + d_container.size());
 
@@ -477,14 +491,14 @@ void Map<KEY, VALUE>::values(bsl::vector<VALUE>* result) const
 template <typename KEY, typename VALUE>
 bsl::size_t Map<KEY, VALUE>::size() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_container.size();
 }
 
 template <typename KEY, typename VALUE>
 bool Map<KEY, VALUE>::empty() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_container.empty();
 }
 
@@ -503,7 +517,7 @@ Queue<TYPE>::~Queue()
 template <typename TYPE>
 void Queue<TYPE>::push(const TYPE& value)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     d_container.push_back(value);
 }
 
@@ -511,15 +525,15 @@ template <typename TYPE>
 void Queue<TYPE>::push(const Queue& other)
 {
     if (this < &other) {
-        bslmt::LockGuard<bslmt::Mutex> lock1(&d_mutex);
-        bslmt::LockGuard<bslmt::Mutex> lock2(&other.d_mutex);
+        LockGuard lock1(&d_mutex);
+        LockGuard lock2(&other.d_mutex);
         d_container.insert(d_container.end(),
                            other.d_container.begin(),
                            other.d_container.end());
     }
     else {
-        bslmt::LockGuard<bslmt::Mutex> lock1(&other.d_mutex);
-        bslmt::LockGuard<bslmt::Mutex> lock2(&d_mutex);
+        LockGuard lock1(&other.d_mutex);
+        LockGuard lock2(&d_mutex);
         d_container.insert(d_container.end(),
                            other.d_container.begin(),
                            other.d_container.end());
@@ -529,7 +543,7 @@ void Queue<TYPE>::push(const Queue& other)
 template <typename TYPE>
 bool Queue<TYPE>::pop(TYPE* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (!d_container.empty()) {
         *result = d_container.front();
@@ -543,7 +557,7 @@ bool Queue<TYPE>::pop(TYPE* result)
 template <typename TYPE>
 bsl::size_t Queue<TYPE>::remove(const TYPE& value, bool all)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     bsl::size_t result = 0;
 
@@ -580,13 +594,13 @@ template <typename TYPE>
 void Queue<TYPE>::swap(Queue* other)
 {
     if (this < other) {
-        bslmt::LockGuard<bslmt::Mutex> lock1(&d_mutex);
-        bslmt::LockGuard<bslmt::Mutex> lock2(&other->d_mutex);
+        LockGuard lock1(&d_mutex);
+        LockGuard lock2(&other->d_mutex);
         d_container.swap(other->d_container);
     }
     else {
-        bslmt::LockGuard<bslmt::Mutex> lock1(&other->d_mutex);
-        bslmt::LockGuard<bslmt::Mutex> lock2(&d_mutex);
+        LockGuard lock1(&other->d_mutex);
+        LockGuard lock2(&d_mutex);
         d_container.swap(other->d_container);
     }
 }
@@ -594,14 +608,14 @@ void Queue<TYPE>::swap(Queue* other)
 template <typename TYPE>
 void Queue<TYPE>::clear()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     d_container.clear();
 }
 
 template <typename TYPE>
 void Queue<TYPE>::load(bsl::vector<TYPE>* result) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     result->reserve(result->size() + d_container.size());
 
@@ -616,14 +630,14 @@ void Queue<TYPE>::load(bsl::vector<TYPE>* result) const
 template <typename TYPE>
 bsl::size_t Queue<TYPE>::size() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_container.size();
 }
 
 template <typename TYPE>
 bool Queue<TYPE>::empty() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_container.empty();
 }
 

--- a/groups/ntc/ntcf/ntcf_system.t.cpp
+++ b/groups/ntc/ntcf/ntcf_system.t.cpp
@@ -292,9 +292,15 @@ class DatagramSocketManager : public ntci::DatagramSocketManager,
                                bsl::shared_ptr<DatagramSocketSession> >
         DatagramSocketApplicationMap;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                   d_object;
     bsl::shared_ptr<ntci::Interface> d_interface_sp;
-    bslmt::Mutex                     d_socketMapMutex;
+    Mutex                            d_socketMapMutex;
     DatagramSocketApplicationMap     d_socketMap;
     bslmt::Latch                     d_socketsEstablished;
     bslmt::Latch                     d_socketsClosed;
@@ -839,7 +845,7 @@ void DatagramSocketManager::processDatagramSocketEstablished(
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
         d_socketMap.insert(
             DatagramSocketApplicationMap::value_type(datagramSocket,
                                                      datagramSocketSession));
@@ -859,7 +865,7 @@ void DatagramSocketManager::processDatagramSocketClosed(
                    (int)(datagramSocket->handle()));
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
         bsl::size_t                    n = d_socketMap.erase(datagramSocket);
         NTCCFG_TEST_EQ(n, 1);
     }
@@ -939,7 +945,7 @@ void DatagramSocketManager::run()
     // Start the timers for each datagram socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
 
         for (DatagramSocketApplicationMap::const_iterator it =
                  d_socketMap.begin();
@@ -954,7 +960,7 @@ void DatagramSocketManager::run()
     // Send data between each datagram socket pair.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
 
         BSLS_ASSERT(d_socketMap.size() % 2 == 0);
 
@@ -992,7 +998,7 @@ void DatagramSocketManager::run()
     // datagram socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
 
         for (DatagramSocketApplicationMap::const_iterator it =
                  d_socketMap.begin();
@@ -1014,7 +1020,7 @@ void DatagramSocketManager::run()
         socketVector.reserve(d_socketMap.size());
 
         {
-            bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+            LockGuard guard(&d_socketMapMutex);
 
             for (DatagramSocketApplicationMap::const_iterator it =
                      d_socketMap.begin();
@@ -1256,13 +1262,19 @@ class StreamSocketManager : public ntci::ListenerSocketManager,
                                bsl::shared_ptr<StreamSocketSession> >
         StreamSocketApplicationMap;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                   d_object;
     bsl::shared_ptr<ntci::Interface> d_interface_sp;
-    bslmt::Mutex                     d_listenerSocketMapMutex;
+    Mutex                            d_listenerSocketMapMutex;
     ListenerSocketApplicationMap     d_listenerSocketMap;
     bslmt::Latch                     d_listenerSocketsEstablished;
     bslmt::Latch                     d_listenerSocketsClosed;
-    bslmt::Mutex                     d_streamSocketMapMutex;
+    Mutex                            d_streamSocketMapMutex;
     StreamSocketApplicationMap       d_streamSocketMap;
     bslmt::Latch                     d_streamSocketsConnected;
     bslmt::Latch                     d_streamSocketsEstablished;
@@ -2009,7 +2021,7 @@ void StreamSocketManager::processListenerSocketEstablished(
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+        LockGuard guard(&d_listenerSocketMapMutex);
         d_listenerSocketMap.insert(ListenerSocketApplicationMap::value_type(
             listenerSocket,
             listenerSocketApplication));
@@ -2029,7 +2041,7 @@ void StreamSocketManager::processListenerSocketClosed(
                    (int)(listenerSocket->handle()));
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+        LockGuard guard(&d_listenerSocketMapMutex);
         bsl::size_t n = d_listenerSocketMap.erase(listenerSocket);
         NTCCFG_TEST_EQ(n, 1);
     }
@@ -2084,7 +2096,7 @@ void StreamSocketManager::processStreamSocketEstablished(
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+        LockGuard guard(&d_streamSocketMapMutex);
         d_streamSocketMap.insert(
             StreamSocketApplicationMap::value_type(streamSocket,
                                                    streamSocketSession));
@@ -2103,7 +2115,7 @@ void StreamSocketManager::processStreamSocketClosed(
     NTCI_LOG_DEBUG("Stream socket %d closed", (int)(streamSocket->handle()));
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+        LockGuard guard(&d_streamSocketMapMutex);
         bsl::size_t n = d_streamSocketMap.erase(streamSocket);
         NTCCFG_TEST_EQ(n, 1);
     }
@@ -2205,7 +2217,7 @@ void StreamSocketManager::run()
     // Connect the configured number of sockets to each listener.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+        LockGuard guard(&d_listenerSocketMapMutex);
 
         for (ListenerSocketApplicationMap::const_iterator it =
                  d_listenerSocketMap.begin();
@@ -2277,7 +2289,7 @@ void StreamSocketManager::run()
     // Start the timers for each listener socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+        LockGuard guard(&d_listenerSocketMapMutex);
 
         for (ListenerSocketApplicationMap::const_iterator it =
                  d_listenerSocketMap.begin();
@@ -2293,7 +2305,7 @@ void StreamSocketManager::run()
     // Start the timers for each stream socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+        LockGuard guard(&d_streamSocketMapMutex);
 
         for (StreamSocketApplicationMap::const_iterator it =
                  d_streamSocketMap.begin();
@@ -2309,7 +2321,7 @@ void StreamSocketManager::run()
     // Send data from each connected socket pair.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+        LockGuard guard(&d_streamSocketMapMutex);
 
         for (StreamSocketApplicationMap::const_iterator it =
                  d_streamSocketMap.begin();
@@ -2326,7 +2338,7 @@ void StreamSocketManager::run()
     // stream socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+        LockGuard guard(&d_streamSocketMapMutex);
 
         for (StreamSocketApplicationMap::const_iterator it =
                  d_streamSocketMap.begin();
@@ -2343,7 +2355,7 @@ void StreamSocketManager::run()
     // listener socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+        LockGuard guard(&d_listenerSocketMapMutex);
 
         for (ListenerSocketApplicationMap::const_iterator it =
                  d_listenerSocketMap.begin();
@@ -2366,7 +2378,7 @@ void StreamSocketManager::run()
         streamSocketVector.reserve(d_streamSocketMap.size());
 
         {
-            bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+            LockGuard guard(&d_streamSocketMapMutex);
 
             for (StreamSocketApplicationMap::const_iterator it =
                      d_streamSocketMap.begin();
@@ -2404,7 +2416,7 @@ void StreamSocketManager::run()
         listenerSocketVector.reserve(d_listenerSocketMap.size());
 
         {
-            bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+            LockGuard guard(&d_listenerSocketMapMutex);
 
             for (ListenerSocketApplicationMap::const_iterator it =
                      d_listenerSocketMap.begin();
@@ -2495,7 +2507,13 @@ struct TransferParameters {
 /// Provide a connection used by a client.
 class TransferClientStreamSocketSession : public ntci::StreamSocketSession
 {
-    bslmt::Mutex                        d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    Mutex                               d_mutex;
     bsl::shared_ptr<ntci::StreamSocket> d_streamSocket_sp;
     bsls::AtomicInt                     d_numMessagesToSend;
     test::TransferParameters            d_parameters;
@@ -2632,7 +2650,13 @@ class TransferClient : public ntci::StreamSocketManager
     typedef bsl::vector<bsl::shared_ptr<ntci::StreamSocket> >
         StreamSocketVector;
 
-    bslmt::Mutex                            d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    Mutex                                   d_mutex;
     bsl::shared_ptr<ntci::Interface>        d_interface_sp;
     bsl::shared_ptr<ntci::EncryptionClient> d_encryptionClient_sp;
     StreamSocketMap                         d_streamSockets;
@@ -2687,7 +2711,13 @@ class TransferClient : public ntci::StreamSocketManager
 /// Provide a listener.
 class TransferServerListenerSocketSession : public ntci::ListenerSocketSession
 {
-    bslmt::Mutex                          d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    Mutex                                 d_mutex;
     bsl::shared_ptr<ntci::ListenerSocket> d_listenerSocket_sp;
     test::TransferParameters              d_parameters;
     bslma::Allocator*                     d_allocator_p;
@@ -2726,7 +2756,13 @@ class TransferServerListenerSocketSession : public ntci::ListenerSocketSession
 /// Provide a connection used by a server.
 class TransferServerStreamSocketSession : public ntci::StreamSocketSession
 {
-    bslmt::Mutex                        d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    Mutex                               d_mutex;
     bsl::shared_ptr<ntci::StreamSocket> d_streamSocket_sp;
     bdlbb::Blob                         d_receiveData;
     bsls::AtomicInt                     d_numMessagesToReceive;
@@ -2872,7 +2908,13 @@ class TransferServer : public ntci::ListenerSocketManager
     typedef bsl::vector<bsl::shared_ptr<ntci::StreamSocket> >
         StreamSocketVector;
 
-    mutable bslmt::Mutex                    d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex                           d_mutex;
     bsl::shared_ptr<ntci::Interface>        d_interface_sp;
     bsl::shared_ptr<ntci::EncryptionServer> d_encryptionServer_sp;
     ListenerSocketMap                       d_listenerSockets;
@@ -3262,7 +3304,7 @@ void TransferClient::processStreamSocketEstablished(
     streamSocket->registerSession(clientSession);
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        LockGuard lockGuard(&d_mutex);
         d_streamSockets[streamSocket] = clientSession;
     }
 
@@ -3288,7 +3330,7 @@ void TransferClient::processStreamSocketClosed(
                          << NTCCFG_TEST_LOG_END;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        LockGuard lockGuard(&d_mutex);
         bsl::size_t                    n = d_streamSockets.erase(streamSocket);
         NTCCFG_TEST_EQ(n, 1);
     }
@@ -3410,7 +3452,7 @@ void TransferClient::connect(const ntsa::Endpoint& remoteEndpoint)
         NTCCFG_TEST_TRUE(streamSocket);
 
         {
-            bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+            LockGuard lockGuard(&d_mutex);
             d_streamSockets[streamSocket] = bsl::nullptr_t();
         }
 
@@ -3863,7 +3905,7 @@ void TransferServer::processListenerSocketEstablished(
     listenerSocket->registerSession(serverListener);
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        LockGuard lockGuard(&d_mutex);
         d_listenerSockets[listenerSocket] = serverListener;
     }
 
@@ -3881,7 +3923,7 @@ void TransferServer::processListenerSocketClosed(
                          << NTCCFG_TEST_LOG_END;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        LockGuard lockGuard(&d_mutex);
         bsl::size_t n = d_listenerSockets.erase(listenerSocket);
         NTCCFG_TEST_EQ(n, 1);
     }
@@ -3907,7 +3949,7 @@ void TransferServer::processStreamSocketEstablished(
     streamSocket->registerSession(serverSession);
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        LockGuard lockGuard(&d_mutex);
         d_streamSockets[streamSocket] = serverSession;
     }
 
@@ -3932,7 +3974,7 @@ void TransferServer::processStreamSocketClosed(
                          << NTCCFG_TEST_LOG_END;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        LockGuard lockGuard(&d_mutex);
         bsl::size_t                    n = d_streamSockets.erase(streamSocket);
         NTCCFG_TEST_EQ(n, 1);
     }
@@ -4062,7 +4104,7 @@ void TransferServer::listen()
         NTCCFG_TEST_TRUE(listenerSocket);
 
         {
-            bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+            LockGuard lockGuard(&d_mutex);
             d_listenerSockets[listenerSocket] = bsl::nullptr_t();
         }
 
@@ -4086,7 +4128,7 @@ void TransferServer::wait()
 
     ListenerSocketVector listenerSockets;
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+        LockGuard lockGuard(&d_mutex);
 
         NTCCFG_FOREACH_ITERATOR(ListenerSocketMap::iterator,
                                 it,
@@ -4110,7 +4152,7 @@ void TransferServer::wait()
 void TransferServer::getListenerEndpoints(
     bsl::vector<ntsa::Endpoint>* result) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_mutex);
+    LockGuard lockGuard(&d_mutex);
 
     NTCCFG_FOREACH_ITERATOR(ListenerSocketMap::const_iterator,
                             it,

--- a/groups/ntc/ntci/ntci_acceptfuture.cpp
+++ b/groups/ntc/ntci/ntci_acceptfuture.cpp
@@ -38,7 +38,7 @@ void AcceptFuture::arrive(
 {
     NTCCFG_WARNING_UNUSED(acceptor);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     AcceptResult result;
     result.setAcceptor(acceptor);
@@ -65,7 +65,7 @@ AcceptFuture::~AcceptFuture()
 
 ntsa::Error AcceptFuture::wait(ntci::AcceptResult* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (d_resultQueue.empty()) {
         d_condition.wait(&d_mutex);
@@ -80,7 +80,7 @@ ntsa::Error AcceptFuture::wait(ntci::AcceptResult* result)
 ntsa::Error AcceptFuture::wait(ntci::AcceptResult*       result,
                                const bsls::TimeInterval& timeout)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (d_resultQueue.empty()) {
         int rc = d_condition.timedWait(&d_mutex, timeout);

--- a/groups/ntc/ntci/ntci_acceptfuture.h
+++ b/groups/ntc/ntci/ntci_acceptfuture.h
@@ -47,9 +47,9 @@ class AcceptFuture : public ntci::AcceptCallback
     /// Define a type alias for a queue of results.
     typedef bsl::list<ntci::AcceptResult> ResultQueue;
 
-    bslmt::Mutex     d_mutex;
-    bslmt::Condition d_condition;
-    ResultQueue      d_resultQueue;
+    ntccfg::ConditionMutex d_mutex;
+    ntccfg::Condition      d_condition;
+    ResultQueue            d_resultQueue;
 
   private:
     AcceptFuture(const AcceptFuture&) BSLS_KEYWORD_DELETED;

--- a/groups/ntc/ntci/ntci_bindfuture.cpp
+++ b/groups/ntc/ntci/ntci_bindfuture.cpp
@@ -36,7 +36,7 @@ void BindFuture::arrive(const bsl::shared_ptr<ntci::Bindable>& bindable,
 {
     NTCCFG_WARNING_UNUSED(bindable);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BindResult result;
     result.setBindable(bindable);
@@ -62,7 +62,7 @@ BindFuture::~BindFuture()
 
 ntsa::Error BindFuture::wait(ntci::BindResult* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (d_resultQueue.empty()) {
         d_condition.wait(&d_mutex);
@@ -77,7 +77,7 @@ ntsa::Error BindFuture::wait(ntci::BindResult* result)
 ntsa::Error BindFuture::wait(ntci::BindResult*         result,
                              const bsls::TimeInterval& timeout)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (d_resultQueue.empty()) {
         int rc = d_condition.timedWait(&d_mutex, timeout);

--- a/groups/ntc/ntci/ntci_bindfuture.h
+++ b/groups/ntc/ntci/ntci_bindfuture.h
@@ -47,9 +47,9 @@ class BindFuture : public ntci::BindCallback
     /// Define a type alias for a queue of results.
     typedef bsl::list<ntci::BindResult> ResultQueue;
 
-    bslmt::Mutex     d_mutex;
-    bslmt::Condition d_condition;
-    ResultQueue      d_resultQueue;
+    ntccfg::ConditionMutex d_mutex;
+    ntccfg::Condition      d_condition;
+    ResultQueue            d_resultQueue;
 
   private:
     BindFuture(const BindFuture&) BSLS_KEYWORD_DELETED;

--- a/groups/ntc/ntci/ntci_callback.t.cpp
+++ b/groups/ntc/ntci/ntci_callback.t.cpp
@@ -1586,8 +1586,8 @@ NTCCFG_TEST_CASE(6)
     {
         ntsa::Error error;
 
-        bslmt::Mutex                   mutex;
-        bslmt::LockGuard<bslmt::Mutex> mutexGuard(&mutex);
+        ntccfg::Mutex     mutex;
+        ntccfg::LockGuard mutexGuard(&mutex);
 
         {
             CallbackArg0 callback(&ta);

--- a/groups/ntc/ntci/ntci_closefuture.cpp
+++ b/groups/ntc/ntci/ntci_closefuture.cpp
@@ -33,7 +33,7 @@ namespace ntci {
 
 void CloseFuture::arrive()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     CloseResult result;
 
@@ -57,7 +57,7 @@ CloseFuture::~CloseFuture()
 
 ntsa::Error CloseFuture::wait(ntci::CloseResult* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (d_resultQueue.empty()) {
         d_condition.wait(&d_mutex);
@@ -72,7 +72,7 @@ ntsa::Error CloseFuture::wait(ntci::CloseResult* result)
 ntsa::Error CloseFuture::wait(ntci::CloseResult*        result,
                               const bsls::TimeInterval& timeout)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (d_resultQueue.empty()) {
         int rc = d_condition.timedWait(&d_mutex, timeout);

--- a/groups/ntc/ntci/ntci_closefuture.h
+++ b/groups/ntc/ntci/ntci_closefuture.h
@@ -47,9 +47,9 @@ class CloseFuture : public ntci::CloseCallback
     /// Define a type alias for a queue of results.
     typedef bsl::list<ntci::CloseResult> ResultQueue;
 
-    bslmt::Mutex     d_mutex;
-    bslmt::Condition d_condition;
-    ResultQueue      d_resultQueue;
+    ntccfg::ConditionMutex d_mutex;
+    ntccfg::Condition      d_condition;
+    ResultQueue            d_resultQueue;
 
   private:
     CloseFuture(const CloseFuture&) BSLS_KEYWORD_DELETED;

--- a/groups/ntc/ntci/ntci_connectfuture.cpp
+++ b/groups/ntc/ntci/ntci_connectfuture.cpp
@@ -36,7 +36,7 @@ void ConnectFuture::arrive(const bsl::shared_ptr<ntci::Connector>& connector,
 {
     NTCCFG_WARNING_UNUSED(connector);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     ConnectResult result;
     result.setConnector(connector);
@@ -62,7 +62,7 @@ ConnectFuture::~ConnectFuture()
 
 ntsa::Error ConnectFuture::wait(ntci::ConnectResult* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (d_resultQueue.empty()) {
         d_condition.wait(&d_mutex);
@@ -77,7 +77,7 @@ ntsa::Error ConnectFuture::wait(ntci::ConnectResult* result)
 ntsa::Error ConnectFuture::wait(ntci::ConnectResult*      result,
                                 const bsls::TimeInterval& timeout)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (d_resultQueue.empty()) {
         int rc = d_condition.timedWait(&d_mutex, timeout);

--- a/groups/ntc/ntci/ntci_connectfuture.h
+++ b/groups/ntc/ntci/ntci_connectfuture.h
@@ -47,9 +47,9 @@ class ConnectFuture : public ntci::ConnectCallback
     /// Define a type alias for a queue of results.
     typedef bsl::list<ntci::ConnectResult> ResultQueue;
 
-    bslmt::Mutex     d_mutex;
-    bslmt::Condition d_condition;
-    ResultQueue      d_resultQueue;
+    ntccfg::ConditionMutex d_mutex;
+    ntccfg::Condition      d_condition;
+    ResultQueue            d_resultQueue;
 
   private:
     ConnectFuture(const ConnectFuture&) BSLS_KEYWORD_DELETED;

--- a/groups/ntc/ntci/ntci_log.cpp
+++ b/groups/ntc/ntci/ntci_log.cpp
@@ -76,7 +76,13 @@ struct LogJournal {
         d_records.resize(k_MAX_LOG_RECORDS);
     }
 
-    bslmt::Mutex           d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    Mutex                  d_mutex;
     bsl::vector<LogRecord> d_records;
     int                    d_position;
     bslma::Allocator*      d_allocator_p;

--- a/groups/ntc/ntci/ntci_monitorable.t.cpp
+++ b/groups/ntc/ntci/ntci_monitorable.t.cpp
@@ -153,7 +153,13 @@ class ObjectStatistic
 /// test driver.
 class Object : public ntci::Monitorable
 {
-    mutable bslmt::Mutex d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex        d_mutex;
     bsls::TimeInterval   d_currentTime;
     int                  d_seed;
     ObjectStatistic      d_statistic;
@@ -251,8 +257,14 @@ class ObjectRegistry : public ntci::MonitorableRegistry
     /// so identified.
     typedef bsl::map<int, bsl::shared_ptr<ntci::Monitorable> > ObjectMap;
 
-    mutable bslmt::Mutex d_mutex;
-    ObjectMap            d_objects;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex d_mutex;
+    ObjectMap     d_objects;
 
   private:
     ObjectRegistry(const ObjectRegistry&) BSLS_KEYWORD_DELETED;
@@ -403,7 +415,7 @@ void Object::execute()
 
 void Object::getStats(bdld::ManagedDatum* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     bsl::int64_t count, total, min, max;
 
@@ -504,7 +516,7 @@ ObjectRegistry::~ObjectRegistry()
 void ObjectRegistry::registerMonitorable(
     const bsl::shared_ptr<ntci::Monitorable>& object)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     d_objects[static_cast<int>(object->objectId())] = object;
 }
@@ -512,7 +524,7 @@ void ObjectRegistry::registerMonitorable(
 void ObjectRegistry::deregisterMonitorable(
     const bsl::shared_ptr<ntci::Monitorable>& object)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     d_objects.erase(static_cast<int>(object->objectId()));
 }
@@ -520,7 +532,7 @@ void ObjectRegistry::deregisterMonitorable(
 void ObjectRegistry::loadRegisteredObjects(
     bsl::vector<bsl::shared_ptr<ntci::Monitorable> >* result) const
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     result->reserve(result->size() + d_objects.size());
 

--- a/groups/ntc/ntci/ntci_receivefuture.cpp
+++ b/groups/ntc/ntci/ntci_receivefuture.cpp
@@ -37,7 +37,7 @@ void ReceiveFuture::arrive(const bsl::shared_ptr<ntci::Receiver>& receiver,
 {
     NTCCFG_WARNING_UNUSED(receiver);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     ReceiveResult result;
     result.setReceiver(receiver);
@@ -64,7 +64,7 @@ ReceiveFuture::~ReceiveFuture()
 
 ntsa::Error ReceiveFuture::wait(ntci::ReceiveResult* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (d_resultQueue.empty()) {
         d_condition.wait(&d_mutex);
@@ -79,7 +79,7 @@ ntsa::Error ReceiveFuture::wait(ntci::ReceiveResult* result)
 ntsa::Error ReceiveFuture::wait(ntci::ReceiveResult*      result,
                                 const bsls::TimeInterval& timeout)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (d_resultQueue.empty()) {
         int rc = d_condition.timedWait(&d_mutex, timeout);

--- a/groups/ntc/ntci/ntci_receivefuture.h
+++ b/groups/ntc/ntci/ntci_receivefuture.h
@@ -48,9 +48,9 @@ class ReceiveFuture : public ntci::ReceiveCallback
     /// Define a type alias for a queue of results.
     typedef bsl::list<ntci::ReceiveResult> ResultQueue;
 
-    bslmt::Mutex     d_mutex;
-    bslmt::Condition d_condition;
-    ResultQueue      d_resultQueue;
+    ntccfg::ConditionMutex d_mutex;
+    ntccfg::Condition      d_condition;
+    ResultQueue            d_resultQueue;
 
   private:
     ReceiveFuture(const ReceiveFuture&) BSLS_KEYWORD_DELETED;

--- a/groups/ntc/ntci/ntci_sendfuture.cpp
+++ b/groups/ntc/ntci/ntci_sendfuture.cpp
@@ -36,7 +36,7 @@ void SendFuture::arrive(const bsl::shared_ptr<ntci::Sender>& sender,
 {
     NTCCFG_WARNING_UNUSED(sender);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     SendResult result;
     result.setSender(sender);
@@ -62,7 +62,7 @@ SendFuture::~SendFuture()
 
 ntsa::Error SendFuture::wait(ntci::SendResult* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (d_resultQueue.empty()) {
         d_condition.wait(&d_mutex);
@@ -77,7 +77,7 @@ ntsa::Error SendFuture::wait(ntci::SendResult* result)
 ntsa::Error SendFuture::wait(ntci::SendResult*         result,
                              const bsls::TimeInterval& timeout)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (d_resultQueue.empty()) {
         int rc = d_condition.timedWait(&d_mutex, timeout);

--- a/groups/ntc/ntci/ntci_sendfuture.h
+++ b/groups/ntc/ntci/ntci_sendfuture.h
@@ -47,9 +47,9 @@ class SendFuture : public ntci::SendCallback
     /// Define a type alias for a queue of results.
     typedef bsl::list<ntci::SendResult> ResultQueue;
 
-    bslmt::Mutex     d_mutex;
-    bslmt::Condition d_condition;
-    ResultQueue      d_resultQueue;
+    ntccfg::ConditionMutex d_mutex;
+    ntccfg::Condition      d_condition;
+    ResultQueue            d_resultQueue;
 
   private:
     SendFuture(const SendFuture&) BSLS_KEYWORD_DELETED;

--- a/groups/ntc/ntci/ntci_timerfuture.cpp
+++ b/groups/ntc/ntci/ntci_timerfuture.cpp
@@ -36,7 +36,7 @@ void TimerFuture::arrive(const bsl::shared_ptr<ntci::Timer>& timer,
 {
     NTCCFG_WARNING_UNUSED(timer);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     TimerResult result;
     result.setTimer(timer);
@@ -62,7 +62,7 @@ TimerFuture::~TimerFuture()
 
 ntsa::Error TimerFuture::wait(ntci::TimerResult* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (d_resultQueue.empty()) {
         d_condition.wait(&d_mutex);
@@ -77,7 +77,7 @@ ntsa::Error TimerFuture::wait(ntci::TimerResult* result)
 ntsa::Error TimerFuture::wait(ntci::TimerResult*        result,
                               const bsls::TimeInterval& timeout)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (d_resultQueue.empty()) {
         int rc = d_condition.timedWait(&d_mutex, timeout);

--- a/groups/ntc/ntci/ntci_timerfuture.h
+++ b/groups/ntc/ntci/ntci_timerfuture.h
@@ -47,9 +47,9 @@ class TimerFuture : public ntci::TimerCallback
     /// Define a type alias for a queue of results.
     typedef bsl::list<ntci::TimerResult> ResultQueue;
 
-    bslmt::Mutex     d_mutex;
-    bslmt::Condition d_condition;
-    ResultQueue      d_resultQueue;
+    ntccfg::ConditionMutex d_mutex;
+    ntccfg::Condition      d_condition;
+    ResultQueue            d_resultQueue;
 
   private:
     TimerFuture(const TimerFuture&) BSLS_KEYWORD_DELETED;

--- a/groups/ntc/ntcm/ntcm_collector.cpp
+++ b/groups/ntc/ntcm/ntcm_collector.cpp
@@ -71,14 +71,14 @@ Collector::~Collector()
 void Collector::registerPublisher(
     const bsl::shared_ptr<ntci::MonitorablePublisher>& publisher)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
     d_publishers.insert(publisher);
 }
 
 void Collector::deregisterPublisher(
     const bsl::shared_ptr<ntci::MonitorablePublisher>& publisher)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
     d_publishers.erase(publisher);
 }
 
@@ -101,7 +101,7 @@ void Collector::collect()
                     PublisherVector;
     PublisherVector publishers(&sequentialAllocator);
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+        LockGuard guard(&d_mutex);
 
         publishers.reserve(d_publishers.size());
         publishers.assign(d_publishers.begin(), d_publishers.end());

--- a/groups/ntc/ntcm/ntcm_collector.h
+++ b/groups/ntc/ntcm/ntcm_collector.h
@@ -63,7 +63,13 @@ class Collector : public ntci::MonitorableCollector
     typedef bsl::unordered_set<bsl::shared_ptr<ntci::MonitorablePublisher> >
         PublisherSet;
 
-    bslmt::Mutex                        d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    Mutex                               d_mutex;
     PublisherSet                        d_publishers;
     bdlma::ConcurrentMultipoolAllocator d_memoryPools;
     LoadCallback                        d_loader;

--- a/groups/ntc/ntcm/ntcm_collector.t.cpp
+++ b/groups/ntc/ntcm/ntcm_collector.t.cpp
@@ -158,7 +158,13 @@ class ObjectStatistic
 /// test driver.
 class Object : public ntci::Monitorable
 {
-    mutable bslmt::Mutex d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex        d_mutex;
     bsls::TimeInterval   d_currentTime;
     int                  d_seed;
     ObjectStatistic      d_statistic;
@@ -252,8 +258,14 @@ class Object : public ntci::Monitorable
 /// thread safe.
 class Publisher : public ntci::MonitorablePublisher
 {
-    mutable bslmt::Mutex d_mutex;
-    int                  d_numPublications;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex d_mutex;
+    int           d_numPublications;
 
   private:
     Publisher(const Publisher&) BSLS_KEYWORD_DELETED;
@@ -388,7 +400,7 @@ void Object::execute()
 
 void Object::getStats(bdld::ManagedDatum* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     bsl::int64_t count, total, min, max;
 
@@ -490,7 +502,7 @@ void Publisher::publish(const bsl::shared_ptr<ntci::Monitorable>& monitorable,
                         const bsls::TimeInterval&                 time,
                         bool                                      final)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     ASSERT(statistics.isArray());
 

--- a/groups/ntc/ntcm/ntcm_logpublisher.cpp
+++ b/groups/ntc/ntcm/ntcm_logpublisher.cpp
@@ -334,7 +334,7 @@ void LogPublisher::publish(
         return;
     }
 
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     // For each statistic retrieved from the monitorable object...
 

--- a/groups/ntc/ntcm/ntcm_logpublisher.h
+++ b/groups/ntc/ntcm/ntcm_logpublisher.h
@@ -152,7 +152,13 @@ class LogPublisher : public ntci::MonitorablePublisher
     /// statistics.
     typedef bsl::vector<LogPublisherRecord> RecordVector;
 
-    bslmt::Mutex      d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    Mutex             d_mutex;
     RecordVector      d_records;
     bsls::AtomicInt   d_severityLevel;
     bslma::Allocator* d_allocator_p;

--- a/groups/ntc/ntcm/ntcm_monitorableregistry.cpp
+++ b/groups/ntc/ntcm/ntcm_monitorableregistry.cpp
@@ -48,7 +48,7 @@ MonitorableRegistry::~MonitorableRegistry()
 void MonitorableRegistry::registerMonitorable(
     const bsl::shared_ptr<ntci::Monitorable>& object)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     if (!d_config.maxSize().isNull()) {
         if (d_objects.size() >= d_config.maxSize().value()) {
@@ -62,7 +62,7 @@ void MonitorableRegistry::registerMonitorable(
 void MonitorableRegistry::deregisterMonitorable(
     const bsl::shared_ptr<ntci::Monitorable>& object)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     d_objects.erase(static_cast<int>(object->objectId()));
 }
@@ -70,7 +70,7 @@ void MonitorableRegistry::deregisterMonitorable(
 void MonitorableRegistry::loadRegisteredObjects(
     bsl::vector<bsl::shared_ptr<ntci::Monitorable> >* result) const
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     result->reserve(result->size() + d_objects.size());
 

--- a/groups/ntc/ntcm/ntcm_monitorableregistry.h
+++ b/groups/ntc/ntcm/ntcm_monitorableregistry.h
@@ -51,7 +51,13 @@ class MonitorableRegistry : public ntci::MonitorableRegistry
     typedef bsl::unordered_map<int, bsl::shared_ptr<ntci::Monitorable> >
         ObjectMap;
 
-    mutable bslmt::Mutex            d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex                   d_mutex;
     ObjectMap                       d_objects;
     ntca::MonitorableRegistryConfig d_config;
     bslma::Allocator*               d_allocator_p;

--- a/groups/ntc/ntcm/ntcm_monitorableutil.t.cpp
+++ b/groups/ntc/ntcm/ntcm_monitorableutil.t.cpp
@@ -153,7 +153,13 @@ class ObjectStatistic
 /// test driver.
 class Object : public ntci::Monitorable
 {
-    mutable bslmt::Mutex d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+    
+    mutable Mutex        d_mutex;
     bsls::TimeInterval   d_currentTime;
     int                  d_seed;
     ObjectStatistic      d_statistic;
@@ -251,8 +257,14 @@ class ObjectRegistry : public ntci::MonitorableRegistry
     /// so identified.
     typedef bsl::map<int, bsl::shared_ptr<ntci::Monitorable> > ObjectMap;
 
-    mutable bslmt::Mutex d_mutex;
-    ObjectMap            d_objects;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex d_mutex;
+    ObjectMap     d_objects;
 
   private:
     ObjectRegistry(const ObjectRegistry&) BSLS_KEYWORD_DELETED;
@@ -403,7 +415,7 @@ void Object::execute()
 
 void Object::getStats(bdld::ManagedDatum* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     bsl::int64_t count, total, min, max;
     d_statistic.load(&count, &total, &min, &max, true);
@@ -503,7 +515,7 @@ ObjectRegistry::~ObjectRegistry()
 void ObjectRegistry::registerMonitorable(
     const bsl::shared_ptr<ntci::Monitorable>& object)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     d_objects[static_cast<int>(object->objectId())] = object;
 }
@@ -511,7 +523,7 @@ void ObjectRegistry::registerMonitorable(
 void ObjectRegistry::deregisterMonitorable(
     const bsl::shared_ptr<ntci::Monitorable>& object)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     d_objects.erase(static_cast<int>(object->objectId()));
 }
@@ -519,7 +531,7 @@ void ObjectRegistry::deregisterMonitorable(
 void ObjectRegistry::loadRegisteredObjects(
     bsl::vector<bsl::shared_ptr<ntci::Monitorable> >* result) const
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     result->reserve(result->size() + d_objects.size());
 

--- a/groups/ntc/ntcm/ntcm_periodiccollector.t.cpp
+++ b/groups/ntc/ntcm/ntcm_periodiccollector.t.cpp
@@ -160,7 +160,13 @@ class ObjectStatistic
 /// test driver.
 class Object : public ntci::Monitorable
 {
-    mutable bslmt::Mutex d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex        d_mutex;
     bsls::TimeInterval   d_currentTime;
     int                  d_seed;
     ObjectStatistic      d_statistic;
@@ -254,9 +260,15 @@ class Object : public ntci::Monitorable
 /// thread safe.
 class Publisher : public ntci::MonitorablePublisher
 {
-    mutable bslmt::Mutex d_mutex;
-    bslmt::Semaphore     d_semaphore;
-    int                  d_numPublications;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex    d_mutex;
+    bslmt::Semaphore d_semaphore;
+    int              d_numPublications;
 
   private:
     Publisher(const Publisher&) BSLS_KEYWORD_DELETED;
@@ -394,7 +406,7 @@ void Object::execute()
 
 void Object::getStats(bdld::ManagedDatum* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     bsl::int64_t count, total, min, max;
 
@@ -497,7 +509,7 @@ void Publisher::publish(const bsl::shared_ptr<ntci::Monitorable>& monitorable,
                         const bsls::TimeInterval&                 time,
                         bool                                      final)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     ASSERT(statistics.isArray());
 

--- a/groups/ntc/ntco/ntco_iocp.cpp
+++ b/groups/ntc/ntco/ntco_iocp.cpp
@@ -241,6 +241,12 @@ class Iocp : public ntci::Proactor,
     // Define a type alias for a map of proactive handles
     // to descriptors.
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     struct Result;
     // This struct describes the context of a waiter.
 
@@ -265,9 +271,9 @@ class Iocp : public ntci::Proactor,
     bsl::shared_ptr<ntci::Resolver>        d_resolver_sp;
     bsl::shared_ptr<ntci::Reservation>     d_connectionLimiter_sp;
     bsl::shared_ptr<ntci::ProactorMetrics> d_metrics_sp;
-    mutable bslmt::Mutex                   d_proactorSocketMapMutex;
+    mutable Mutex                          d_proactorSocketMapMutex;
     ProactorSocketMap                      d_proactorSocketMap;
-    mutable bslmt::Mutex                   d_waiterSetMutex;
+    mutable Mutex                          d_waiterSetMutex;
     WaiterSet                              d_waiterSet;
     bslmt::ThreadUtil::Handle              d_threadHandle;
     bsl::size_t                            d_threadIndex;
@@ -1230,7 +1236,7 @@ ntci::Waiter Iocp::registerWaiter(const ntca::WaiterOptions& waiterOptions)
     bdlb::NullableValue<bslmt::ThreadUtil::Handle> principleThreadHandle;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_waiterSetMutex);
+        LockGuard lockGuard(&d_waiterSetMutex);
 
         if (result->d_options.threadHandle() == bslmt::ThreadUtil::Handle()) {
             result->d_options.setThreadHandle(bslmt::ThreadUtil::self());
@@ -1289,7 +1295,7 @@ void Iocp::deregisterWaiter(ntci::Waiter waiter)
     bool nowEmpty = false;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_waiterSetMutex);
+        LockGuard lockGuard(&d_waiterSetMutex);
 
         bsl::size_t n = d_waiterSet.erase(result);
         BSLS_ASSERT_OPT(n == 1);
@@ -1343,7 +1349,7 @@ ntsa::Error Iocp::attachSocket(
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_proactorSocketMapMutex);
+        LockGuard lockGuard(&d_proactorSocketMapMutex);
 
         bsl::pair<ProactorSocketMap::iterator, bool> insertResult =
             d_proactorSocketMap.insert(
@@ -2447,7 +2453,7 @@ ntsa::Error Iocp::detachSocket(
     this->cancel(socket);
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_proactorSocketMapMutex);
+        LockGuard lockGuard(&d_proactorSocketMapMutex);
 
         bsl::size_t n = d_proactorSocketMap.erase(socket->handle());
         if (n == 0) {
@@ -2476,7 +2482,7 @@ ntsa::Error Iocp::closeAll()
 {
     ProactorSocketMap proactorSocketMap;
     {
-        bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_proactorSocketMapMutex);
+        LockGuard lockGuard(&d_proactorSocketMapMutex);
         proactorSocketMap = d_proactorSocketMap;
     }
 
@@ -2585,7 +2591,7 @@ void Iocp::interruptAll()
     else {
         bsl::size_t numWaiters;
         {
-            bslmt::LockGuard<bslmt::Mutex> guard(&d_waiterSetMutex);
+            LockGuard guard(&d_waiterSetMutex);
             numWaiters = d_waiterSet.size();
         }
 
@@ -2629,7 +2635,7 @@ void Iocp::clearTimers()
 
 void Iocp::clearSockets()
 {
-    bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_proactorSocketMapMutex);
+    LockGuard lockGuard(&d_proactorSocketMapMutex);
     d_proactorSocketMap.clear();
 }
 
@@ -2637,7 +2643,7 @@ void Iocp::clear()
 {
     d_chronology.clear();
 
-    bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_proactorSocketMapMutex);
+    LockGuard lockGuard(&d_proactorSocketMapMutex);
     d_proactorSocketMap.clear();
 }
 
@@ -2765,7 +2771,7 @@ void Iocp::createOutgoingBlobBuffer(bdlbb::BlobBuffer* blobBuffer)
 
 bsl::size_t Iocp::numSockets() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lockGuard(&d_proactorSocketMapMutex);
+    LockGuard lockGuard(&d_proactorSocketMapMutex);
     return d_proactorSocketMap.size();
 }
 
@@ -2791,19 +2797,19 @@ bsl::size_t Iocp::load() const
 
 bslmt::ThreadUtil::Handle Iocp::threadHandle() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_waiterSetMutex);
+    LockGuard lock(&d_waiterSetMutex);
     return d_threadHandle;
 }
 
 bsl::size_t Iocp::threadIndex() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_waiterSetMutex);
+    LockGuard lock(&d_waiterSetMutex);
     return d_threadIndex;
 }
 
 bsl::size_t Iocp::numWaiters() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_waiterSetMutex);
+    LockGuard lock(&d_waiterSetMutex);
     return d_waiterSet.size();
 }
 

--- a/groups/ntc/ntcp/ntcp_datagramsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_datagramsocket.cpp
@@ -174,7 +174,7 @@ void DatagramSocket::processSocketReceived(const ntsa::Error&          error,
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (NTCCFG_UNLIKELY(d_detachState.get() ==
                         ntcs::DetachState::e_DETACH_INITIATED))
@@ -228,7 +228,7 @@ void DatagramSocket::processSocketSent(const ntsa::Error&       error,
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (NTCCFG_UNLIKELY(d_detachState.get() ==
                         ntcs::DetachState::e_DETACH_INITIATED))
@@ -264,7 +264,7 @@ void DatagramSocket::processSocketError(const ntsa::Error& error)
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (NTCCFG_UNLIKELY(d_detachState.get() ==
                         ntcs::DetachState::e_DETACH_INITIATED))
@@ -284,7 +284,7 @@ void DatagramSocket::processSocketDetached()
 {
     NTCCFG_OBJECT_GUARD(&d_object);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
@@ -310,7 +310,7 @@ void DatagramSocket::processSendRateTimer(
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -354,7 +354,7 @@ void DatagramSocket::processSendDeadlineTimer(
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -401,7 +401,7 @@ void DatagramSocket::processReceiveRateTimer(
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -445,7 +445,7 @@ void DatagramSocket::processReceiveDeadlineTimer(
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -1869,7 +1869,7 @@ void DatagramSocket::processSourceEndpointResolution(
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error       error;
     ntca::BindContext bindContext;
@@ -1943,7 +1943,7 @@ void DatagramSocket::processRemoteEndpointResolution(
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error          error;
     ntca::ConnectContext connectContext;
@@ -2156,7 +2156,7 @@ ntsa::Error DatagramSocket::open()
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self);
 }
@@ -2165,7 +2165,7 @@ ntsa::Error DatagramSocket::open(ntsa::Transport::Value transport)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport);
 }
@@ -2175,7 +2175,7 @@ ntsa::Error DatagramSocket::open(ntsa::Transport::Value transport,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport, handle);
 }
@@ -2186,7 +2186,7 @@ ntsa::Error DatagramSocket::open(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport, datagramSocket);
 }
@@ -2206,7 +2206,7 @@ ntsa::Error DatagramSocket::bind(const ntsa::Endpoint&     endpoint,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -2269,7 +2269,7 @@ ntsa::Error DatagramSocket::bind(const bsl::string&        name,
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -2312,7 +2312,7 @@ ntsa::Error DatagramSocket::connect(const ntsa::Endpoint&        endpoint,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -2412,7 +2412,7 @@ ntsa::Error DatagramSocket::connect(const bsl::string&           name,
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -2445,7 +2445,7 @@ ntsa::Error DatagramSocket::send(const bdlbb::Blob&       data,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2551,7 +2551,7 @@ ntsa::Error DatagramSocket::send(const ntsa::Data&        data,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2665,7 +2665,7 @@ ntsa::Error DatagramSocket::send(const bdlbb::Blob&        data,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2785,7 +2785,7 @@ ntsa::Error DatagramSocket::send(const ntsa::Data&         data,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2896,7 +2896,7 @@ ntsa::Error DatagramSocket::receive(ntca::ReceiveContext*       context,
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2974,7 +2974,7 @@ ntsa::Error DatagramSocket::receive(const ntca::ReceiveOptions&  options,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3093,14 +3093,14 @@ ntsa::Error DatagramSocket::receive(const ntca::ReceiveOptions&  options,
 ntsa::Error DatagramSocket::registerResolver(
     const bsl::shared_ptr<ntci::Resolver>& resolver)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     d_resolver = resolver;
     return ntsa::Error();
 }
 
 ntsa::Error DatagramSocket::deregisterResolver()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     d_resolver.reset();
     return ntsa::Error();
 }
@@ -3110,7 +3110,7 @@ ntsa::Error DatagramSocket::registerManager(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (manager) {
         d_manager_sp       = manager;
@@ -3130,7 +3130,7 @@ ntsa::Error DatagramSocket::registerManager(
 
 ntsa::Error DatagramSocket::deregisterManager()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     d_manager_sp.reset();
     d_managerStrand_sp.reset();
@@ -3143,7 +3143,7 @@ ntsa::Error DatagramSocket::registerSession(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (session) {
         d_session_sp       = session;
@@ -3166,7 +3166,7 @@ ntsa::Error DatagramSocket::registerSessionCallback(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (callback) {
         bsl::shared_ptr<ntcu::DatagramSocketSession> session;
@@ -3196,7 +3196,7 @@ ntsa::Error DatagramSocket::registerSessionCallback(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (callback) {
         bsl::shared_ptr<ntcu::DatagramSocketSession> session;
@@ -3219,7 +3219,7 @@ ntsa::Error DatagramSocket::registerSessionCallback(
 
 ntsa::Error DatagramSocket::deregisterSession()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     d_session_sp.reset();
     d_sessionStrand_sp.reset();
@@ -3232,7 +3232,7 @@ ntsa::Error DatagramSocket::setWriteRateLimiter(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3260,7 +3260,7 @@ ntsa::Error DatagramSocket::setWriteQueueLowWatermark(bsl::size_t lowWatermark)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3295,7 +3295,7 @@ ntsa::Error DatagramSocket::setWriteQueueHighWatermark(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3330,7 +3330,7 @@ ntsa::Error DatagramSocket::setWriteQueueWatermarks(bsl::size_t lowWatermark,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3384,7 +3384,7 @@ ntsa::Error DatagramSocket::setReadRateLimiter(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3412,7 +3412,7 @@ ntsa::Error DatagramSocket::setReadQueueLowWatermark(bsl::size_t lowWatermark)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3453,7 +3453,7 @@ ntsa::Error DatagramSocket::setReadQueueHighWatermark(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3478,7 +3478,7 @@ ntsa::Error DatagramSocket::setReadQueueWatermarks(bsl::size_t lowWatermark,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3508,7 +3508,7 @@ ntsa::Error DatagramSocket::setReadQueueWatermarks(bsl::size_t lowWatermark,
 
 ntsa::Error DatagramSocket::setMulticastLoopback(bool value)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_socket_sp) {
         return d_socket_sp->setMulticastLoopback(value);
@@ -3520,7 +3520,7 @@ ntsa::Error DatagramSocket::setMulticastLoopback(bool value)
 
 ntsa::Error DatagramSocket::setMulticastTimeToLive(bsl::size_t value)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_socket_sp) {
         return d_socket_sp->setMulticastTimeToLive(value);
@@ -3532,7 +3532,7 @@ ntsa::Error DatagramSocket::setMulticastTimeToLive(bsl::size_t value)
 
 ntsa::Error DatagramSocket::setMulticastInterface(const ntsa::IpAddress& value)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_socket_sp) {
         return d_socket_sp->setMulticastInterface(value);
@@ -3546,7 +3546,7 @@ ntsa::Error DatagramSocket::joinMulticastGroup(
     const ntsa::IpAddress& interface,
     const ntsa::IpAddress& group)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_socket_sp) {
         return d_socket_sp->joinMulticastGroup(interface, group);
@@ -3560,7 +3560,7 @@ ntsa::Error DatagramSocket::leaveMulticastGroup(
     const ntsa::IpAddress& interface,
     const ntsa::IpAddress& group)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_socket_sp) {
         return d_socket_sp->leaveMulticastGroup(interface, group);
@@ -3575,7 +3575,7 @@ ntsa::Error DatagramSocket::relaxFlowControl(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3591,7 +3591,7 @@ ntsa::Error DatagramSocket::applyFlowControl(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3637,7 +3637,7 @@ ntsa::Error DatagramSocket::cancel(const ntca::SendToken& token)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3681,7 +3681,7 @@ ntsa::Error DatagramSocket::cancel(const ntca::ReceiveToken& token)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3722,7 +3722,7 @@ ntsa::Error DatagramSocket::shutdown(ntsa::ShutdownType::Value direction,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3747,7 +3747,7 @@ void DatagramSocket::close(const ntci::CloseCallback& callback)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3888,13 +3888,13 @@ ntsa::Transport::Value DatagramSocket::transport() const
 
 ntsa::Endpoint DatagramSocket::sourceEndpoint() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sourceEndpoint;
 }
 
 ntsa::Endpoint DatagramSocket::remoteEndpoint() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_remoteEndpoint;
 }
 
@@ -3927,37 +3927,37 @@ bsl::size_t DatagramSocket::threadIndex() const
 
 bsl::size_t DatagramSocket::readQueueSize() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_receiveQueue.size();
 }
 
 bsl::size_t DatagramSocket::readQueueLowWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_receiveQueue.lowWatermark();
 }
 
 bsl::size_t DatagramSocket::readQueueHighWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_receiveQueue.highWatermark();
 }
 
 bsl::size_t DatagramSocket::writeQueueSize() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sendQueue.size();
 }
 
 bsl::size_t DatagramSocket::writeQueueLowWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sendQueue.lowWatermark();
 }
 
 bsl::size_t DatagramSocket::writeQueueHighWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sendQueue.highWatermark();
 }
 

--- a/groups/ntc/ntcp/ntcp_datagramsocket.h
+++ b/groups/ntc/ntcp/ntcp_datagramsocket.h
@@ -67,8 +67,14 @@ class DatagramSocket : public ntci::DatagramSocket,
     /// buffer factory.
     typedef bsl::shared_ptr<bdlbb::BlobBufferFactory> BlobBufferFactoryPtr;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                               d_object;
-    mutable bslmt::Mutex                         d_mutex;
+    mutable Mutex                                d_mutex;
     ntsa::Handle                                 d_systemHandle;
     ntsa::Handle                                 d_publicHandle;
     ntsa::Transport::Value                       d_transport;

--- a/groups/ntc/ntcp/ntcp_datagramsocket.t.cpp
+++ b/groups/ntc/ntcp/ntcp_datagramsocket.t.cpp
@@ -388,10 +388,16 @@ class DatagramSocketManager : public ntci::DatagramSocketManager,
                                bsl::shared_ptr<DatagramSocketSession> >
         DatagramSocketApplicationMap;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                  d_object;
     bsl::shared_ptr<ntci::Proactor> d_proactor_sp;
     bsl::shared_ptr<ntcs::Metrics>  d_metrics_sp;
-    bslmt::Mutex                    d_socketMapMutex;
+    Mutex                           d_socketMapMutex;
     DatagramSocketApplicationMap    d_socketMap;
     bslmt::Latch                    d_socketsEstablished;
     bslmt::Latch                    d_socketsClosed;
@@ -936,7 +942,7 @@ void DatagramSocketManager::processDatagramSocketEstablished(
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
         d_socketMap.insert(
             DatagramSocketApplicationMap::value_type(datagramSocket,
                                                      datagramSocketSession));
@@ -956,7 +962,7 @@ void DatagramSocketManager::processDatagramSocketClosed(
                    (int)(datagramSocket->handle()));
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
         bsl::size_t                    n = d_socketMap.erase(datagramSocket);
         NTCCFG_TEST_EQ(n, 1);
     }
@@ -1047,7 +1053,7 @@ void DatagramSocketManager::run()
     // Start the timers for each datagram socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
 
         for (DatagramSocketApplicationMap::const_iterator it =
                  d_socketMap.begin();
@@ -1062,7 +1068,7 @@ void DatagramSocketManager::run()
     // Send data between each datagram socket pair.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
 
         BSLS_ASSERT(d_socketMap.size() % 2 == 0);
 
@@ -1100,7 +1106,7 @@ void DatagramSocketManager::run()
     // datagram socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
 
         for (DatagramSocketApplicationMap::const_iterator it =
                  d_socketMap.begin();
@@ -1122,7 +1128,7 @@ void DatagramSocketManager::run()
         socketVector.reserve(d_socketMap.size());
 
         {
-            bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+            LockGuard guard(&d_socketMapMutex);
 
             for (DatagramSocketApplicationMap::const_iterator it =
                      d_socketMap.begin();

--- a/groups/ntc/ntcp/ntcp_listenersocket.cpp
+++ b/groups/ntc/ntcp/ntcp_listenersocket.cpp
@@ -149,7 +149,7 @@ void ListenerSocket::processSocketAccepted(
 
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -183,7 +183,7 @@ void ListenerSocket::processSocketError(const ntsa::Error& error)
 
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (NTCCFG_UNLIKELY(d_detachState.get() ==
                         ntcs::DetachState::e_DETACH_INITIATED))
@@ -203,7 +203,7 @@ void ListenerSocket::processSocketDetached()
 {
     NTCCFG_OBJECT_GUARD(&d_object);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
@@ -229,7 +229,7 @@ void ListenerSocket::processAcceptRateTimer(
 
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -272,7 +272,7 @@ void ListenerSocket::processAcceptBackoffTimer(
 
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -301,7 +301,7 @@ void ListenerSocket::processAcceptDeadlineTimer(
 
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -1421,7 +1421,7 @@ void ListenerSocket::processSourceEndpointResolution(
 
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -1601,7 +1601,7 @@ ntsa::Error ListenerSocket::open()
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self);
 }
@@ -1610,7 +1610,7 @@ ntsa::Error ListenerSocket::open(ntsa::Transport::Value transport)
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport);
 }
@@ -1620,7 +1620,7 @@ ntsa::Error ListenerSocket::open(ntsa::Transport::Value transport,
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport, handle);
 }
@@ -1631,7 +1631,7 @@ ntsa::Error ListenerSocket::open(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport, listenerSocket);
 }
@@ -1651,7 +1651,7 @@ ntsa::Error ListenerSocket::bind(const ntsa::Endpoint&     endpoint,
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -1714,7 +1714,7 @@ ntsa::Error ListenerSocket::bind(const bsl::string&        name,
 
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -1756,7 +1756,7 @@ ntsa::Error ListenerSocket::listen(bsl::size_t backlog)
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -1810,7 +1810,7 @@ ntsa::Error ListenerSocket::accept(
 
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -1884,7 +1884,7 @@ ntsa::Error ListenerSocket::accept(const ntca::AcceptOptions&  options,
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -1999,14 +1999,14 @@ ntsa::Error ListenerSocket::accept(const ntca::AcceptOptions&  options,
 ntsa::Error ListenerSocket::registerResolver(
     const bsl::shared_ptr<ntci::Resolver>& resolver)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     d_resolver = resolver;
     return ntsa::Error();
 }
 
 ntsa::Error ListenerSocket::deregisterResolver()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     d_resolver.reset();
     return ntsa::Error();
 }
@@ -2016,7 +2016,7 @@ ntsa::Error ListenerSocket::registerManager(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (manager) {
         d_manager_sp       = manager;
@@ -2036,7 +2036,7 @@ ntsa::Error ListenerSocket::registerManager(
 
 ntsa::Error ListenerSocket::deregisterManager()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     d_manager_sp.reset();
     d_managerStrand_sp.reset();
@@ -2049,7 +2049,7 @@ ntsa::Error ListenerSocket::registerSession(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (session) {
         d_session_sp       = session;
@@ -2072,7 +2072,7 @@ ntsa::Error ListenerSocket::registerSessionCallback(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (callback) {
         bsl::shared_ptr<ntcu::ListenerSocketSession> session;
@@ -2102,7 +2102,7 @@ ntsa::Error ListenerSocket::registerSessionCallback(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (callback) {
         bsl::shared_ptr<ntcu::ListenerSocketSession> session;
@@ -2125,7 +2125,7 @@ ntsa::Error ListenerSocket::registerSessionCallback(
 
 ntsa::Error ListenerSocket::deregisterSession()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     d_session_sp.reset();
     d_sessionStrand_sp.reset();
@@ -2138,7 +2138,7 @@ ntsa::Error ListenerSocket::setAcceptRateLimiter(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2167,7 +2167,7 @@ ntsa::Error ListenerSocket::setAcceptQueueLowWatermark(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2208,7 +2208,7 @@ ntsa::Error ListenerSocket::setAcceptQueueHighWatermark(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2233,7 +2233,7 @@ ntsa::Error ListenerSocket::setAcceptQueueWatermarks(bsl::size_t lowWatermark,
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2266,7 +2266,7 @@ ntsa::Error ListenerSocket::relaxFlowControl(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2282,7 +2282,7 @@ ntsa::Error ListenerSocket::applyFlowControl(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2312,7 +2312,7 @@ ntsa::Error ListenerSocket::cancel(const ntca::AcceptToken& token)
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2350,7 +2350,7 @@ ntsa::Error ListenerSocket::shutdown()
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2378,7 +2378,7 @@ void ListenerSocket::close(const ntci::CloseCallback& callback)
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2547,7 +2547,7 @@ ntsa::Transport::Value ListenerSocket::transport() const
 
 ntsa::Endpoint ListenerSocket::sourceEndpoint() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sourceEndpoint;
 }
 
@@ -2580,19 +2580,19 @@ bsl::size_t ListenerSocket::threadIndex() const
 
 bsl::size_t ListenerSocket::acceptQueueSize() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_acceptQueue.size();
 }
 
 bsl::size_t ListenerSocket::acceptQueueLowWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_acceptQueue.lowWatermark();
 }
 
 bsl::size_t ListenerSocket::acceptQueueHighWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_acceptQueue.highWatermark();
 }
 

--- a/groups/ntc/ntcp/ntcp_listenersocket.h
+++ b/groups/ntc/ntcp/ntcp_listenersocket.h
@@ -67,8 +67,14 @@ class ListenerSocket : public ntci::ListenerSocket,
     /// buffer factory.
     typedef bsl::shared_ptr<bdlbb::BlobBufferFactory> BlobBufferFactoryPtr;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                               d_object;
-    mutable bslmt::Mutex                         d_mutex;
+    mutable Mutex                                d_mutex;
     ntsa::Handle                                 d_systemHandle;
     ntsa::Handle                                 d_publicHandle;
     ntsa::Transport::Value                       d_transport;

--- a/groups/ntc/ntcp/ntcp_listenersocket.t.cpp
+++ b/groups/ntc/ntcp/ntcp_listenersocket.t.cpp
@@ -467,14 +467,20 @@ class StreamSocketManager : public ntci::ListenerSocketManager,
                                bsl::shared_ptr<StreamSocketSession> >
         StreamSocketApplicationMap;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                  d_object;
     bsl::shared_ptr<ntci::Proactor> d_proactor_sp;
     bsl::shared_ptr<ntcs::Metrics>  d_metrics_sp;
-    bslmt::Mutex                    d_listenerSocketMapMutex;
+    Mutex                           d_listenerSocketMapMutex;
     ListenerSocketApplicationMap    d_listenerSocketMap;
     bslmt::Latch                    d_listenerSocketsEstablished;
     bslmt::Latch                    d_listenerSocketsClosed;
-    bslmt::Mutex                    d_streamSocketMapMutex;
+    Mutex                           d_streamSocketMapMutex;
     StreamSocketApplicationMap      d_streamSocketMap;
     bslmt::Latch                    d_streamSocketsConnected;
     bslmt::Latch                    d_streamSocketsEstablished;
@@ -1209,7 +1215,7 @@ void StreamSocketManager::processListenerSocketEstablished(
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+        LockGuard guard(&d_listenerSocketMapMutex);
         d_listenerSocketMap.insert(ListenerSocketApplicationMap::value_type(
             listenerSocket,
             listenerSocketApplication));
@@ -1229,7 +1235,7 @@ void StreamSocketManager::processListenerSocketClosed(
                    (int)(listenerSocket->handle()));
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+        LockGuard guard(&d_listenerSocketMapMutex);
         bsl::size_t n = d_listenerSocketMap.erase(listenerSocket);
         NTCCFG_TEST_EQ(n, 1);
     }
@@ -1262,7 +1268,7 @@ void StreamSocketManager::processStreamSocketEstablished(
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+        LockGuard guard(&d_streamSocketMapMutex);
         d_streamSocketMap.insert(
             StreamSocketApplicationMap::value_type(streamSocket,
                                                    streamSocketSession));
@@ -1281,7 +1287,7 @@ void StreamSocketManager::processStreamSocketClosed(
     NTCI_LOG_DEBUG("Stream socket %d closed", (int)(streamSocket->handle()));
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+        LockGuard guard(&d_streamSocketMapMutex);
         bsl::size_t n = d_streamSocketMap.erase(streamSocket);
         NTCCFG_TEST_EQ(n, 1);
     }
@@ -1394,7 +1400,7 @@ void StreamSocketManager::run()
     // Connect the configured number of sockets to each listener.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+        LockGuard guard(&d_listenerSocketMapMutex);
 
         for (ListenerSocketApplicationMap::const_iterator it =
                  d_listenerSocketMap.begin();
@@ -1479,7 +1485,7 @@ void StreamSocketManager::run()
     // Start the timers for each listener socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+        LockGuard guard(&d_listenerSocketMapMutex);
 
         for (ListenerSocketApplicationMap::const_iterator it =
                  d_listenerSocketMap.begin();
@@ -1495,7 +1501,7 @@ void StreamSocketManager::run()
     // Start the timers for each stream socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+        LockGuard guard(&d_streamSocketMapMutex);
 
         for (StreamSocketApplicationMap::const_iterator it =
                  d_streamSocketMap.begin();
@@ -1511,7 +1517,7 @@ void StreamSocketManager::run()
     // Send data from each connected socket pair.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+        LockGuard guard(&d_streamSocketMapMutex);
 
         for (StreamSocketApplicationMap::const_iterator it =
                  d_streamSocketMap.begin();
@@ -1528,7 +1534,7 @@ void StreamSocketManager::run()
     // stream socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+        LockGuard guard(&d_streamSocketMapMutex);
 
         for (StreamSocketApplicationMap::const_iterator it =
                  d_streamSocketMap.begin();
@@ -1545,7 +1551,7 @@ void StreamSocketManager::run()
     // listener socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+        LockGuard guard(&d_listenerSocketMapMutex);
 
         for (ListenerSocketApplicationMap::const_iterator it =
                  d_listenerSocketMap.begin();
@@ -1568,7 +1574,7 @@ void StreamSocketManager::run()
         streamSocketVector.reserve(d_streamSocketMap.size());
 
         {
-            bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+            LockGuard guard(&d_streamSocketMapMutex);
 
             for (StreamSocketApplicationMap::const_iterator it =
                      d_streamSocketMap.begin();
@@ -1606,7 +1612,7 @@ void StreamSocketManager::run()
         listenerSocketVector.reserve(d_listenerSocketMap.size());
 
         {
-            bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+            LockGuard guard(&d_listenerSocketMapMutex);
 
             for (ListenerSocketApplicationMap::const_iterator it =
                      d_listenerSocketMap.begin();

--- a/groups/ntc/ntcp/ntcp_streamsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.cpp
@@ -213,7 +213,7 @@ void StreamSocket::processSocketConnected(const ntsa::Error& error)
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (NTCCFG_UNLIKELY(d_detachState.get() ==
                         ntcs::DetachState::e_DETACH_INITIATED))
@@ -244,7 +244,7 @@ void StreamSocket::processSocketReceived(const ntsa::Error&          error,
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (NTCCFG_UNLIKELY(d_detachState.get() ==
                         ntcs::DetachState::e_DETACH_INITIATED))
@@ -283,7 +283,7 @@ void StreamSocket::processSocketSent(const ntsa::Error&       error,
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (NTCCFG_UNLIKELY(d_detachState.get() ==
                         ntcs::DetachState::e_DETACH_INITIATED))
@@ -319,7 +319,7 @@ void StreamSocket::processSocketError(const ntsa::Error& error)
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (NTCCFG_UNLIKELY(d_detachState.get() ==
                         ntcs::DetachState::e_DETACH_INITIATED))
@@ -340,7 +340,7 @@ void StreamSocket::processSocketDetached()
 {
     NTCCFG_OBJECT_GUARD(&d_object);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
@@ -366,7 +366,7 @@ void StreamSocket::processConnectDeadlineTimer(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -408,7 +408,7 @@ void StreamSocket::processConnectRetryTimer(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -448,7 +448,7 @@ void StreamSocket::processUpgradeTimer(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -477,7 +477,7 @@ void StreamSocket::processSendRateTimer(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -522,7 +522,7 @@ void StreamSocket::processSendDeadlineTimer(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -569,7 +569,7 @@ void StreamSocket::processReceiveRateTimer(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -614,7 +614,7 @@ void StreamSocket::processReceiveDeadlineTimer(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3083,7 +3083,7 @@ void StreamSocket::processSourceEndpointResolution(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error       error;
     ntca::BindContext bindContext;
@@ -3158,7 +3158,7 @@ void StreamSocket::processRemoteEndpointResolution(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (NTCCFG_UNLIKELY(d_detachState.get() ==
                         ntcs::DetachState::e_DETACH_INITIATED))
@@ -3660,7 +3660,7 @@ ntsa::Error StreamSocket::open()
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self);
 }
@@ -3669,7 +3669,7 @@ ntsa::Error StreamSocket::open(ntsa::Transport::Value transport)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport);
 }
@@ -3679,7 +3679,7 @@ ntsa::Error StreamSocket::open(ntsa::Transport::Value transport,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport, handle);
 }
@@ -3690,7 +3690,7 @@ ntsa::Error StreamSocket::open(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport, streamSocket);
 }
@@ -3702,7 +3702,7 @@ ntsa::Error StreamSocket::open(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport, handle, acceptor);
 }
@@ -3714,7 +3714,7 @@ ntsa::Error StreamSocket::open(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport, streamSocket, acceptor);
 }
@@ -3734,7 +3734,7 @@ ntsa::Error StreamSocket::bind(const ntsa::Endpoint&     endpoint,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -3801,7 +3801,7 @@ ntsa::Error StreamSocket::bind(const bsl::string&        name,
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -3848,7 +3848,7 @@ ntsa::Error StreamSocket::connect(const ntsa::Endpoint&        endpoint,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -3983,7 +3983,7 @@ ntsa::Error StreamSocket::connect(const bsl::string&           name,
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -4100,7 +4100,7 @@ ntsa::Error StreamSocket::upgrade(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4231,7 +4231,7 @@ ntsa::Error StreamSocket::send(const bdlbb::Blob&       data,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4312,7 +4312,7 @@ ntsa::Error StreamSocket::send(const ntsa::Data&        data,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4403,7 +4403,7 @@ ntsa::Error StreamSocket::send(const bdlbb::Blob&        data,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4510,7 +4510,7 @@ ntsa::Error StreamSocket::send(const ntsa::Data&         data,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4608,7 +4608,7 @@ ntsa::Error StreamSocket::receive(ntca::ReceiveContext*       context,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4730,7 +4730,7 @@ ntsa::Error StreamSocket::receive(const ntca::ReceiveOptions&  options,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4894,14 +4894,14 @@ ntsa::Error StreamSocket::receive(const ntca::ReceiveOptions&  options,
 ntsa::Error StreamSocket::registerResolver(
     const bsl::shared_ptr<ntci::Resolver>& resolver)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     d_resolver = resolver;
     return ntsa::Error();
 }
 
 ntsa::Error StreamSocket::deregisterResolver()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     d_resolver.reset();
     return ntsa::Error();
 }
@@ -4911,7 +4911,7 @@ ntsa::Error StreamSocket::registerManager(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (manager) {
         d_manager_sp       = manager;
@@ -4931,7 +4931,7 @@ ntsa::Error StreamSocket::registerManager(
 
 ntsa::Error StreamSocket::deregisterManager()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     d_manager_sp.reset();
     d_managerStrand_sp.reset();
@@ -4944,7 +4944,7 @@ ntsa::Error StreamSocket::registerSession(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (session) {
         d_session_sp       = session;
@@ -4967,7 +4967,7 @@ ntsa::Error StreamSocket::registerSessionCallback(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (callback) {
         bsl::shared_ptr<ntcu::StreamSocketSession> session;
@@ -4997,7 +4997,7 @@ ntsa::Error StreamSocket::registerSessionCallback(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (callback) {
         bsl::shared_ptr<ntcu::StreamSocketSession> session;
@@ -5020,7 +5020,7 @@ ntsa::Error StreamSocket::registerSessionCallback(
 
 ntsa::Error StreamSocket::deregisterSession()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     d_session_sp.reset();
     d_sessionStrand_sp.reset();
@@ -5033,7 +5033,7 @@ ntsa::Error StreamSocket::setWriteRateLimiter(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5062,7 +5062,7 @@ ntsa::Error StreamSocket::setWriteQueueLowWatermark(bsl::size_t lowWatermark)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5101,7 +5101,7 @@ ntsa::Error StreamSocket::setWriteQueueHighWatermark(bsl::size_t highWatermark)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5141,7 +5141,7 @@ ntsa::Error StreamSocket::setWriteQueueWatermarks(bsl::size_t lowWatermark,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5204,7 +5204,7 @@ ntsa::Error StreamSocket::setReadRateLimiter(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5233,7 +5233,7 @@ ntsa::Error StreamSocket::setReadQueueLowWatermark(bsl::size_t lowWatermark)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5274,7 +5274,7 @@ ntsa::Error StreamSocket::setReadQueueHighWatermark(bsl::size_t highWatermark)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5300,7 +5300,7 @@ ntsa::Error StreamSocket::setReadQueueWatermarks(bsl::size_t lowWatermark,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5334,7 +5334,7 @@ ntsa::Error StreamSocket::relaxFlowControl(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5351,7 +5351,7 @@ ntsa::Error StreamSocket::applyFlowControl(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5393,7 +5393,7 @@ ntsa::Error StreamSocket::cancel(const ntca::ConnectToken& token)
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5419,7 +5419,7 @@ ntsa::Error StreamSocket::cancel(const ntca::UpgradeToken& token)
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5468,7 +5468,7 @@ ntsa::Error StreamSocket::cancel(const ntca::SendToken& token)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5512,7 +5512,7 @@ ntsa::Error StreamSocket::cancel(const ntca::ReceiveToken& token)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5553,7 +5553,7 @@ ntsa::Error StreamSocket::downgrade()
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5640,7 +5640,7 @@ ntsa::Error StreamSocket::shutdown(ntsa::ShutdownType::Value direction,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5686,7 +5686,7 @@ void StreamSocket::close(const ntci::CloseCallback& callback)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5838,20 +5838,20 @@ ntsa::Transport::Value StreamSocket::transport() const
 
 ntsa::Endpoint StreamSocket::sourceEndpoint() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sourceEndpoint;
 }
 
 ntsa::Endpoint StreamSocket::remoteEndpoint() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_remoteEndpoint;
 }
 
 bsl::shared_ptr<ntci::EncryptionCertificate> StreamSocket::sourceCertificate()
     const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     bsl::shared_ptr<ntci::EncryptionCertificate> result;
     if (d_encryption_sp) {
@@ -5864,7 +5864,7 @@ bsl::shared_ptr<ntci::EncryptionCertificate> StreamSocket::sourceCertificate()
 bsl::shared_ptr<ntci::EncryptionCertificate> StreamSocket::remoteCertificate()
     const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     bsl::shared_ptr<ntci::EncryptionCertificate> result;
     if (d_encryption_sp) {
@@ -5876,7 +5876,7 @@ bsl::shared_ptr<ntci::EncryptionCertificate> StreamSocket::remoteCertificate()
 
 bsl::shared_ptr<ntci::EncryptionKey> StreamSocket::privateKey() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     bsl::shared_ptr<ntci::EncryptionKey> result;
     if (d_encryption_sp) {
@@ -5920,37 +5920,37 @@ bsl::size_t StreamSocket::threadIndex() const
 
 bsl::size_t StreamSocket::readQueueSize() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_receiveQueue.size();
 }
 
 bsl::size_t StreamSocket::readQueueLowWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_receiveQueue.lowWatermark();
 }
 
 bsl::size_t StreamSocket::readQueueHighWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_receiveQueue.highWatermark();
 }
 
 bsl::size_t StreamSocket::writeQueueSize() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sendQueue.size();
 }
 
 bsl::size_t StreamSocket::writeQueueLowWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sendQueue.lowWatermark();
 }
 
 bsl::size_t StreamSocket::writeQueueHighWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sendQueue.highWatermark();
 }
 

--- a/groups/ntc/ntcp/ntcp_streamsocket.h
+++ b/groups/ntc/ntcp/ntcp_streamsocket.h
@@ -80,8 +80,14 @@ class StreamSocket : public ntci::StreamSocket,
     /// buffer factory.
     typedef bsl::shared_ptr<bdlbb::BlobBufferFactory> BlobBufferFactoryPtr;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                             d_object;
-    mutable bslmt::Mutex                       d_mutex;
+    mutable Mutex                              d_mutex;
     ntsa::Handle                               d_systemHandle;
     ntsa::Handle                               d_publicHandle;
     ntsa::Transport::Value                     d_transport;

--- a/groups/ntc/ntcp/ntcp_streamsocket.t.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.t.cpp
@@ -396,10 +396,16 @@ class StreamSocketManager : public ntci::StreamSocketManager,
                                bsl::shared_ptr<StreamSocketSession> >
         StreamSocketApplicationMap;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                  d_object;
     bsl::shared_ptr<ntci::Proactor> d_proactor_sp;
     bsl::shared_ptr<ntcs::Metrics>  d_metrics_sp;
-    bslmt::Mutex                    d_socketMapMutex;
+    Mutex                           d_socketMapMutex;
     StreamSocketApplicationMap      d_socketMap;
     bslmt::Latch                    d_socketsEstablished;
     bslmt::Latch                    d_socketsClosed;
@@ -901,7 +907,7 @@ void StreamSocketManager::processStreamSocketEstablished(
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
         d_socketMap.insert(
             StreamSocketApplicationMap::value_type(streamSocket,
                                                    streamSocketSession));
@@ -920,7 +926,7 @@ void StreamSocketManager::processStreamSocketClosed(
     NTCI_LOG_DEBUG("Stream socket %d closed", (int)(streamSocket->handle()));
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
         bsl::size_t                    n = d_socketMap.erase(streamSocket);
         NTCCFG_TEST_EQ(n, 1);
     }
@@ -1028,7 +1034,7 @@ void StreamSocketManager::run()
     // Start the timers for each stream socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
 
         for (StreamSocketApplicationMap::const_iterator it =
                  d_socketMap.begin();
@@ -1043,7 +1049,7 @@ void StreamSocketManager::run()
     // Send data between each stream socket pair.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
 
         for (StreamSocketApplicationMap::const_iterator it =
                  d_socketMap.begin();
@@ -1059,7 +1065,7 @@ void StreamSocketManager::run()
     // stream socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
 
         for (StreamSocketApplicationMap::const_iterator it =
                  d_socketMap.begin();
@@ -1081,7 +1087,7 @@ void StreamSocketManager::run()
         socketVector.reserve(d_socketMap.size());
 
         {
-            bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+            LockGuard guard(&d_socketMapMutex);
 
             for (StreamSocketApplicationMap::const_iterator it =
                      d_socketMap.begin();

--- a/groups/ntc/ntcp/ntcp_thread.cpp
+++ b/groups/ntc/ntcp/ntcp_thread.cpp
@@ -80,7 +80,7 @@ void* Thread::run(ntcp::Thread* thread)
                    thread->d_config.threadName().value().c_str());
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&thread->d_runMutex);
+        ntccfg::ConditionMutexGuard guard(&thread->d_runMutex);
         thread->d_runState = RUN_STATE_STARTED;
         thread->d_runCondition.signal();
     }
@@ -293,7 +293,7 @@ ntsa::Error Thread::start(const bslmt::ThreadAttributes& threadAttributes)
         return error;
     }
 
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_runMutex);
+    ntccfg::ConditionMutexGuard guard(&d_runMutex);
     while (d_runState != RUN_STATE_STARTED) {
         d_runCondition.wait(&d_runMutex);
     }
@@ -307,7 +307,7 @@ void Thread::shutdown()
 
     NTCI_LOG_CONTEXT_GUARD_OWNER(d_config.metricName().value().c_str());
 
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_runMutex);
+    ntccfg::ConditionMutexGuard guard(&d_runMutex);
 
     if (d_runState != RUN_STATE_STARTED) {
         return;

--- a/groups/ntc/ntcp/ntcp_thread.h
+++ b/groups/ntc/ntcp/ntcp_thread.h
@@ -64,8 +64,8 @@ class Thread : public ntci::Thread, public ntccfg::Shared<Thread>
     bsl::shared_ptr<ntci::Proactor> d_proactor_sp;
     bslmt::ThreadUtil::Handle       d_threadHandle;
     bslmt::ThreadAttributes         d_threadAttributes;
-    bslmt::Mutex                    d_runMutex;
-    bslmt::Condition                d_runCondition;
+    ntccfg::ConditionMutex          d_runMutex;
+    ntccfg::Condition               d_runCondition;
     bsls::AtomicInt                 d_runState;
     ntca::ThreadConfig              d_config;
     bslma::Allocator*               d_allocator_p;

--- a/groups/ntc/ntcq/ntcq_accept.cpp
+++ b/groups/ntc/ntcq/ntcq_accept.cpp
@@ -67,7 +67,7 @@ void AcceptCallbackQueueEntry::dispatch(
     const bsl::shared_ptr<ntci::Strand>&                   strand,
     const bsl::shared_ptr<ntci::Executor>&                 executor,
     bool                                                   defer,
-    bslmt::Mutex*                                          mutex)
+    ntccfg::Mutex*                                         mutex)
 {
     if (NTCCFG_LIKELY(entry->d_state.finish())) {
         if (entry->d_timer_sp) {

--- a/groups/ntc/ntcq/ntcq_accept.h
+++ b/groups/ntc/ntcq/ntcq_accept.h
@@ -107,7 +107,7 @@ class AcceptCallbackQueueEntry
         const bsl::shared_ptr<ntci::Strand>&                   strand,
         const bsl::shared_ptr<ntci::Executor>&                 executor,
         bool                                                   defer,
-        bslmt::Mutex*                                          mutex);
+        ntccfg::Mutex*                                         mutex);
 
     /// Defines the traits of this type. These traits can be used to select,
     /// at compile-time, the most efficient algorithm to manipulate objects

--- a/groups/ntc/ntcq/ntcq_bind.cpp
+++ b/groups/ntc/ntcq/ntcq_bind.cpp
@@ -62,7 +62,7 @@ void BindCallbackEntry::dispatch(
     const bsl::shared_ptr<ntci::Strand>&            strand,
     const bsl::shared_ptr<ntci::Executor>&          executor,
     bool                                            defer,
-    bslmt::Mutex*                                   mutex)
+    ntccfg::Mutex*                                  mutex)
 {
     if (NTCCFG_LIKELY(entry->d_state.finish())) {
         ntci::BindCallback callback = entry->d_callback;

--- a/groups/ntc/ntcq/ntcq_bind.h
+++ b/groups/ntc/ntcq/ntcq_bind.h
@@ -89,7 +89,7 @@ class BindCallbackEntry
                          const bsl::shared_ptr<ntci::Strand>&   strand,
                          const bsl::shared_ptr<ntci::Executor>& executor,
                          bool                                   defer,
-                         bslmt::Mutex*                          mutex);
+                         ntccfg::Mutex*                         mutex);
 
     /// Defines the traits of this type. These traits can be used to select,
     /// at compile-time, the most efficient algorithm to manipulate objects

--- a/groups/ntc/ntcq/ntcq_connect.cpp
+++ b/groups/ntc/ntcq/ntcq_connect.cpp
@@ -62,7 +62,7 @@ void ConnectCallbackEntry::dispatch(
     const bsl::shared_ptr<ntci::Strand>&               strand,
     const bsl::shared_ptr<ntci::Executor>&             executor,
     bool                                               defer,
-    bslmt::Mutex*                                      mutex)
+    ntccfg::Mutex*                                     mutex)
 {
     if (NTCCFG_LIKELY(entry->d_state.finish())) {
         ntci::ConnectCallback callback = entry->d_callback;

--- a/groups/ntc/ntcq/ntcq_connect.h
+++ b/groups/ntc/ntcq/ntcq_connect.h
@@ -90,7 +90,7 @@ class ConnectCallbackEntry
         const bsl::shared_ptr<ntci::Strand>&               strand,
         const bsl::shared_ptr<ntci::Executor>&             executor,
         bool                                               defer,
-        bslmt::Mutex*                                      mutex);
+        ntccfg::Mutex*                                     mutex);
 
     /// Defines the traits of this type. These traits can be used to select,
     /// at compile-time, the most efficient algorithm to manipulate objects

--- a/groups/ntc/ntcq/ntcq_receive.cpp
+++ b/groups/ntc/ntcq/ntcq_receive.cpp
@@ -66,7 +66,7 @@ void ReceiveCallbackQueueEntry::dispatch(
     const bsl::shared_ptr<ntci::Strand>&                    strand,
     const bsl::shared_ptr<ntci::Executor>&                  executor,
     bool                                                    defer,
-    bslmt::Mutex*                                           mutex)
+    ntccfg::Mutex*                                          mutex)
 {
     if (NTCCFG_LIKELY(entry->d_state.finish())) {
         if (entry->d_timer_sp) {

--- a/groups/ntc/ntcq/ntcq_receive.h
+++ b/groups/ntc/ntcq/ntcq_receive.h
@@ -112,7 +112,7 @@ class ReceiveCallbackQueueEntry
         const bsl::shared_ptr<ntci::Strand>&                    strand,
         const bsl::shared_ptr<ntci::Executor>&                  executor,
         bool                                                    defer,
-        bslmt::Mutex*                                           mutex);
+        ntccfg::Mutex*                                          mutex);
 
     /// Defines the traits of this type. These traits can be used to select,
     /// at compile-time, the most efficient algorithm to manipulate objects

--- a/groups/ntc/ntcq/ntcq_receive.t.cpp
+++ b/groups/ntc/ntcq/ntcq_receive.t.cpp
@@ -173,8 +173,8 @@ bool complete(const bsl::shared_ptr<ntcq::ReceiveCallbackQueueEntry>& entry)
     bsl::shared_ptr<ntci::Strand>   strand;
     bsl::shared_ptr<ntci::Executor> executor;
 
-    bslmt::Mutex                   mutex;
-    bslmt::LockGuard<bslmt::Mutex> guard(&mutex);
+    ntccfg::Mutex     mutex;
+    ntccfg::LockGuard guard(&mutex);
 
     bsl::shared_ptr<bdlbb::Blob> data;
 
@@ -187,8 +187,8 @@ bool fail(const bsl::shared_ptr<ntcq::ReceiveCallbackQueueEntry>& entry)
     bsl::shared_ptr<ntci::Strand>   strand;
     bsl::shared_ptr<ntci::Executor> executor;
 
-    bslmt::Mutex                   mutex;
-    bslmt::LockGuard<bslmt::Mutex> guard(&mutex);
+    ntccfg::Mutex     mutex;
+    ntccfg::LockGuard guard(&mutex);
 
     return ntcq::ReceiveCallbackQueueEntry::fail(
         entry,

--- a/groups/ntc/ntcr/ntcr_datagramsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.cpp
@@ -237,7 +237,7 @@ void DatagramSocket::processSocketReadable(const ntca::ReactorEvent& event)
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -295,7 +295,7 @@ void DatagramSocket::processSocketWritable(const ntca::ReactorEvent& event)
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -351,7 +351,7 @@ void DatagramSocket::processSocketError(const ntca::ReactorEvent& event)
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -375,7 +375,7 @@ void DatagramSocket::processNotifications(
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -709,7 +709,7 @@ void DatagramSocket::processSendRateTimer(
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -754,7 +754,7 @@ void DatagramSocket::processSendDeadlineTimer(
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -801,7 +801,7 @@ void DatagramSocket::processReceiveRateTimer(
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -846,7 +846,7 @@ void DatagramSocket::processReceiveDeadlineTimer(
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2554,7 +2554,7 @@ void DatagramSocket::processSourceEndpointResolution(
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error       error;
     ntca::BindContext bindContext;
@@ -2628,7 +2628,7 @@ void DatagramSocket::processRemoteEndpointResolution(
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error          error;
     ntca::ConnectContext connectContext;
@@ -2857,7 +2857,7 @@ ntsa::Error DatagramSocket::open()
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self);
 }
@@ -2866,7 +2866,7 @@ ntsa::Error DatagramSocket::open(ntsa::Transport::Value transport)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport);
 }
@@ -2876,7 +2876,7 @@ ntsa::Error DatagramSocket::open(ntsa::Transport::Value transport,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport, handle);
 }
@@ -2887,7 +2887,7 @@ ntsa::Error DatagramSocket::open(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport, datagramSocket);
 }
@@ -2907,7 +2907,7 @@ ntsa::Error DatagramSocket::bind(const ntsa::Endpoint&     endpoint,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -2970,7 +2970,7 @@ ntsa::Error DatagramSocket::bind(const bsl::string&        name,
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -3013,7 +3013,7 @@ ntsa::Error DatagramSocket::connect(const ntsa::Endpoint&        endpoint,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -3113,7 +3113,7 @@ ntsa::Error DatagramSocket::connect(const bsl::string&           name,
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -3169,7 +3169,7 @@ ntsa::Error DatagramSocket::send(const bdlbb::Blob&        data,
     ntsa::Error error;
 
     bsl::shared_ptr<DatagramSocket> self(this->getSelf(this));
-    bslmt::LockGuard<bslmt::Mutex>  lock(&d_mutex);
+    LockGuard  lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3331,7 +3331,7 @@ ntsa::Error DatagramSocket::send(const ntsa::Data&         data,
     ntsa::Error error;
 
     bsl::shared_ptr<DatagramSocket> self(this->getSelf(this));
-    bslmt::LockGuard<bslmt::Mutex>  lock(&d_mutex);
+    LockGuard  lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3483,7 +3483,7 @@ ntsa::Error DatagramSocket::receive(ntca::ReceiveContext*       context,
 
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3582,7 +3582,7 @@ ntsa::Error DatagramSocket::receive(const ntca::ReceiveOptions&  options,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3775,14 +3775,14 @@ ntsa::Error DatagramSocket::receive(const ntca::ReceiveOptions&  options,
 ntsa::Error DatagramSocket::registerResolver(
     const bsl::shared_ptr<ntci::Resolver>& resolver)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     d_resolver = resolver;
     return ntsa::Error();
 }
 
 ntsa::Error DatagramSocket::deregisterResolver()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     d_resolver.reset();
     return ntsa::Error();
 }
@@ -3792,7 +3792,7 @@ ntsa::Error DatagramSocket::registerManager(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (manager) {
         d_manager_sp       = manager;
@@ -3812,7 +3812,7 @@ ntsa::Error DatagramSocket::registerManager(
 
 ntsa::Error DatagramSocket::deregisterManager()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     d_manager_sp.reset();
     d_managerStrand_sp.reset();
@@ -3825,7 +3825,7 @@ ntsa::Error DatagramSocket::registerSession(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (session) {
         d_session_sp       = session;
@@ -3848,7 +3848,7 @@ ntsa::Error DatagramSocket::registerSessionCallback(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (callback) {
         bsl::shared_ptr<ntcu::DatagramSocketSession> session;
@@ -3878,7 +3878,7 @@ ntsa::Error DatagramSocket::registerSessionCallback(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (callback) {
         bsl::shared_ptr<ntcu::DatagramSocketSession> session;
@@ -3901,7 +3901,7 @@ ntsa::Error DatagramSocket::registerSessionCallback(
 
 ntsa::Error DatagramSocket::deregisterSession()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     d_session_sp.reset();
     d_sessionStrand_sp.reset();
@@ -3912,7 +3912,7 @@ ntsa::Error DatagramSocket::deregisterSession()
 ntsa::Error DatagramSocket::setZeroCopyThreshold(bsl::size_t value)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
-    bslmt::LockGuard<bslmt::Mutex>  lock(&d_mutex);
+    LockGuard  lock(&d_mutex);
 
     return this->privateZeroCopyEngage(self, value);
 }
@@ -3922,7 +3922,7 @@ ntsa::Error DatagramSocket::setWriteRateLimiter(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3951,7 +3951,7 @@ ntsa::Error DatagramSocket::setWriteQueueLowWatermark(bsl::size_t lowWatermark)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3987,7 +3987,7 @@ ntsa::Error DatagramSocket::setWriteQueueHighWatermark(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4023,7 +4023,7 @@ ntsa::Error DatagramSocket::setWriteQueueWatermarks(bsl::size_t lowWatermark,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4078,7 +4078,7 @@ ntsa::Error DatagramSocket::setReadRateLimiter(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4107,7 +4107,7 @@ ntsa::Error DatagramSocket::setReadQueueLowWatermark(bsl::size_t lowWatermark)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4149,7 +4149,7 @@ ntsa::Error DatagramSocket::setReadQueueHighWatermark(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4175,7 +4175,7 @@ ntsa::Error DatagramSocket::setReadQueueWatermarks(bsl::size_t lowWatermark,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4206,7 +4206,7 @@ ntsa::Error DatagramSocket::setReadQueueWatermarks(bsl::size_t lowWatermark,
 
 ntsa::Error DatagramSocket::setMulticastLoopback(bool value)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_socket_sp) {
         return d_socket_sp->setMulticastLoopback(value);
@@ -4218,7 +4218,7 @@ ntsa::Error DatagramSocket::setMulticastLoopback(bool value)
 
 ntsa::Error DatagramSocket::setMulticastTimeToLive(bsl::size_t value)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_socket_sp) {
         return d_socket_sp->setMulticastTimeToLive(value);
@@ -4230,7 +4230,7 @@ ntsa::Error DatagramSocket::setMulticastTimeToLive(bsl::size_t value)
 
 ntsa::Error DatagramSocket::setMulticastInterface(const ntsa::IpAddress& value)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_socket_sp) {
         return d_socket_sp->setMulticastInterface(value);
@@ -4244,7 +4244,7 @@ ntsa::Error DatagramSocket::joinMulticastGroup(
     const ntsa::IpAddress& interface,
     const ntsa::IpAddress& group)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_socket_sp) {
         return d_socket_sp->joinMulticastGroup(interface, group);
@@ -4258,7 +4258,7 @@ ntsa::Error DatagramSocket::leaveMulticastGroup(
     const ntsa::IpAddress& interface,
     const ntsa::IpAddress& group)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (d_socket_sp) {
         return d_socket_sp->leaveMulticastGroup(interface, group);
@@ -4272,7 +4272,7 @@ ntsa::Error DatagramSocket::timestampOutgoingData(bool enable)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return privateTimestampOutgoingData(self, enable);
 }
@@ -4281,7 +4281,7 @@ ntsa::Error DatagramSocket::timestampIncomingData(bool enable)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return privateTimestampIncomingData(self, enable);
 }
@@ -4291,7 +4291,7 @@ ntsa::Error DatagramSocket::relaxFlowControl(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4308,7 +4308,7 @@ ntsa::Error DatagramSocket::applyFlowControl(
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4355,7 +4355,7 @@ ntsa::Error DatagramSocket::cancel(const ntca::SendToken& token)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4399,7 +4399,7 @@ ntsa::Error DatagramSocket::cancel(const ntca::ReceiveToken& token)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4440,7 +4440,7 @@ ntsa::Error DatagramSocket::shutdown(ntsa::ShutdownType::Value direction,
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4465,7 +4465,7 @@ void DatagramSocket::close(const ntci::CloseCallback& callback)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -4607,13 +4607,13 @@ ntsa::Transport::Value DatagramSocket::transport() const
 
 ntsa::Endpoint DatagramSocket::sourceEndpoint() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sourceEndpoint;
 }
 
 ntsa::Endpoint DatagramSocket::remoteEndpoint() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_remoteEndpoint;
 }
 
@@ -4646,49 +4646,49 @@ bsl::size_t DatagramSocket::threadIndex() const
 
 bsl::size_t DatagramSocket::readQueueSize() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_receiveQueue.size();
 }
 
 bsl::size_t DatagramSocket::readQueueLowWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_receiveQueue.lowWatermark();
 }
 
 bsl::size_t DatagramSocket::readQueueHighWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_receiveQueue.highWatermark();
 }
 
 bsl::size_t DatagramSocket::writeQueueSize() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sendQueue.size();
 }
 
 bsl::size_t DatagramSocket::writeQueueLowWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sendQueue.lowWatermark();
 }
 
 bsl::size_t DatagramSocket::writeQueueHighWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sendQueue.highWatermark();
 }
 
 bsl::size_t DatagramSocket::totalBytesSent() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_totalBytesSent;
 }
 
 bsl::size_t DatagramSocket::totalBytesReceived() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_totalBytesReceived;
 }
 

--- a/groups/ntc/ntcr/ntcr_datagramsocket.h
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.h
@@ -73,8 +73,14 @@ class DatagramSocket : public ntci::DatagramSocket,
     /// buffer factory.
     typedef bsl::shared_ptr<bdlbb::BlobBufferFactory> BlobBufferFactoryPtr;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                               d_object;
-    mutable bslmt::Mutex                         d_mutex;
+    mutable Mutex                                d_mutex;
     ntsa::Handle                                 d_systemHandle;
     ntsa::Handle                                 d_publicHandle;
     ntsa::Transport::Value                       d_transport;

--- a/groups/ntc/ntcr/ntcr_datagramsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.t.cpp
@@ -428,10 +428,16 @@ class DatagramSocketManager : public ntci::DatagramSocketManager,
                                bsl::shared_ptr<DatagramSocketSession> >
         DatagramSocketApplicationMap;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                 d_object;
     bsl::shared_ptr<ntci::Reactor> d_reactor_sp;
     bsl::shared_ptr<ntcs::Metrics> d_metrics_sp;
-    bslmt::Mutex                   d_socketMapMutex;
+    Mutex                          d_socketMapMutex;
     DatagramSocketApplicationMap   d_socketMap;
     bslmt::Latch                   d_socketsEstablished;
     bslmt::Latch                   d_socketsClosed;
@@ -976,7 +982,7 @@ void DatagramSocketManager::processDatagramSocketEstablished(
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
         d_socketMap.insert(
             DatagramSocketApplicationMap::value_type(datagramSocket,
                                                      datagramSocketSession));
@@ -996,7 +1002,7 @@ void DatagramSocketManager::processDatagramSocketClosed(
                    (int)(datagramSocket->handle()));
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
         bsl::size_t                    n = d_socketMap.erase(datagramSocket);
         NTCCFG_TEST_EQ(n, 1);
     }
@@ -1102,7 +1108,7 @@ void DatagramSocketManager::run()
     // Start the timers for each datagram socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
 
         for (DatagramSocketApplicationMap::const_iterator it =
                  d_socketMap.begin();
@@ -1117,7 +1123,7 @@ void DatagramSocketManager::run()
     // Send data between each datagram socket pair.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
 
         BSLS_ASSERT(d_socketMap.size() % 2 == 0);
 
@@ -1155,7 +1161,7 @@ void DatagramSocketManager::run()
     // datagram socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
 
         for (DatagramSocketApplicationMap::const_iterator it =
                  d_socketMap.begin();
@@ -1345,7 +1351,7 @@ void DatagramSocketManager::run()
         socketVector.reserve(d_socketMap.size());
 
         {
-            bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+            LockGuard guard(&d_socketMapMutex);
 
             for (DatagramSocketApplicationMap::const_iterator it =
                      d_socketMap.begin();

--- a/groups/ntc/ntcr/ntcr_listenersocket.cpp
+++ b/groups/ntc/ntcr/ntcr_listenersocket.cpp
@@ -155,7 +155,7 @@ void ListenerSocket::processSocketReadable(const ntca::ReactorEvent& event)
 
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -215,7 +215,7 @@ void ListenerSocket::processSocketError(const ntca::ReactorEvent& event)
 
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -245,7 +245,7 @@ void ListenerSocket::processAcceptRateTimer(
 
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -288,7 +288,7 @@ void ListenerSocket::processAcceptBackoffTimer(
 
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -317,7 +317,7 @@ void ListenerSocket::processAcceptDeadlineTimer(
 
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -1471,7 +1471,7 @@ void ListenerSocket::processSourceEndpointResolution(
 
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -1657,7 +1657,7 @@ ntsa::Error ListenerSocket::open()
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self);
 }
@@ -1666,7 +1666,7 @@ ntsa::Error ListenerSocket::open(ntsa::Transport::Value transport)
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport);
 }
@@ -1676,7 +1676,7 @@ ntsa::Error ListenerSocket::open(ntsa::Transport::Value transport,
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport, handle);
 }
@@ -1687,7 +1687,7 @@ ntsa::Error ListenerSocket::open(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport, listenerSocket);
 }
@@ -1707,7 +1707,7 @@ ntsa::Error ListenerSocket::bind(const ntsa::Endpoint&     endpoint,
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -1770,7 +1770,7 @@ ntsa::Error ListenerSocket::bind(const bsl::string&        name,
 
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -1812,7 +1812,7 @@ ntsa::Error ListenerSocket::listen(bsl::size_t backlog)
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -1866,7 +1866,7 @@ ntsa::Error ListenerSocket::accept(
 
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -1948,7 +1948,7 @@ ntsa::Error ListenerSocket::accept(const ntca::AcceptOptions&  options,
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2122,14 +2122,14 @@ ntsa::Error ListenerSocket::accept(const ntca::AcceptOptions&  options,
 ntsa::Error ListenerSocket::registerResolver(
     const bsl::shared_ptr<ntci::Resolver>& resolver)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     d_resolver = resolver;
     return ntsa::Error();
 }
 
 ntsa::Error ListenerSocket::deregisterResolver()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     d_resolver.reset();
     return ntsa::Error();
 }
@@ -2139,7 +2139,7 @@ ntsa::Error ListenerSocket::registerManager(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (manager) {
         d_manager_sp       = manager;
@@ -2159,7 +2159,7 @@ ntsa::Error ListenerSocket::registerManager(
 
 ntsa::Error ListenerSocket::deregisterManager()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     d_manager_sp.reset();
     d_managerStrand_sp.reset();
@@ -2172,7 +2172,7 @@ ntsa::Error ListenerSocket::registerSession(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (session) {
         d_session_sp       = session;
@@ -2195,7 +2195,7 @@ ntsa::Error ListenerSocket::registerSessionCallback(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (callback) {
         bsl::shared_ptr<ntcu::ListenerSocketSession> session;
@@ -2225,7 +2225,7 @@ ntsa::Error ListenerSocket::registerSessionCallback(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (callback) {
         bsl::shared_ptr<ntcu::ListenerSocketSession> session;
@@ -2248,7 +2248,7 @@ ntsa::Error ListenerSocket::registerSessionCallback(
 
 ntsa::Error ListenerSocket::deregisterSession()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     d_session_sp.reset();
     d_sessionStrand_sp.reset();
@@ -2261,7 +2261,7 @@ ntsa::Error ListenerSocket::setAcceptRateLimiter(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2290,7 +2290,7 @@ ntsa::Error ListenerSocket::setAcceptQueueLowWatermark(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2331,7 +2331,7 @@ ntsa::Error ListenerSocket::setAcceptQueueHighWatermark(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2356,7 +2356,7 @@ ntsa::Error ListenerSocket::setAcceptQueueWatermarks(bsl::size_t lowWatermark,
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2389,7 +2389,7 @@ ntsa::Error ListenerSocket::relaxFlowControl(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2405,7 +2405,7 @@ ntsa::Error ListenerSocket::applyFlowControl(
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2435,7 +2435,7 @@ ntsa::Error ListenerSocket::cancel(const ntca::AcceptToken& token)
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2473,7 +2473,7 @@ ntsa::Error ListenerSocket::shutdown()
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2501,7 +2501,7 @@ void ListenerSocket::close(const ntci::CloseCallback& callback)
 {
     bsl::shared_ptr<ListenerSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -2670,7 +2670,7 @@ ntsa::Transport::Value ListenerSocket::transport() const
 
 ntsa::Endpoint ListenerSocket::sourceEndpoint() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sourceEndpoint;
 }
 
@@ -2703,19 +2703,19 @@ bsl::size_t ListenerSocket::threadIndex() const
 
 bsl::size_t ListenerSocket::acceptQueueSize() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_acceptQueue.size();
 }
 
 bsl::size_t ListenerSocket::acceptQueueLowWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_acceptQueue.lowWatermark();
 }
 
 bsl::size_t ListenerSocket::acceptQueueHighWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_acceptQueue.highWatermark();
 }
 

--- a/groups/ntc/ntcr/ntcr_listenersocket.h
+++ b/groups/ntc/ntcr/ntcr_listenersocket.h
@@ -67,8 +67,14 @@ class ListenerSocket : public ntci::ListenerSocket,
     /// buffer factory.
     typedef bsl::shared_ptr<bdlbb::BlobBufferFactory> BlobBufferFactoryPtr;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                               d_object;
-    mutable bslmt::Mutex                         d_mutex;
+    mutable Mutex                                d_mutex;
     ntsa::Handle                                 d_systemHandle;
     ntsa::Handle                                 d_publicHandle;
     ntsa::Transport::Value                       d_transport;

--- a/groups/ntc/ntcr/ntcr_listenersocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_listenersocket.t.cpp
@@ -470,14 +470,20 @@ class StreamSocketManager : public ntci::ListenerSocketManager,
                                bsl::shared_ptr<StreamSocketSession> >
         StreamSocketApplicationMap;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                 d_object;
     bsl::shared_ptr<ntci::Reactor> d_reactor_sp;
     bsl::shared_ptr<ntcs::Metrics> d_metrics_sp;
-    bslmt::Mutex                   d_listenerSocketMapMutex;
+    Mutex                          d_listenerSocketMapMutex;
     ListenerSocketApplicationMap   d_listenerSocketMap;
     bslmt::Latch                   d_listenerSocketsEstablished;
     bslmt::Latch                   d_listenerSocketsClosed;
-    bslmt::Mutex                   d_streamSocketMapMutex;
+    Mutex                          d_streamSocketMapMutex;
     StreamSocketApplicationMap     d_streamSocketMap;
     bslmt::Latch                   d_streamSocketsConnected;
     bslmt::Latch                   d_streamSocketsEstablished;
@@ -1212,7 +1218,7 @@ void StreamSocketManager::processListenerSocketEstablished(
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+        LockGuard guard(&d_listenerSocketMapMutex);
         d_listenerSocketMap.insert(ListenerSocketApplicationMap::value_type(
             listenerSocket,
             listenerSocketApplication));
@@ -1232,7 +1238,7 @@ void StreamSocketManager::processListenerSocketClosed(
                    (int)(listenerSocket->handle()));
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+        LockGuard guard(&d_listenerSocketMapMutex);
         bsl::size_t n = d_listenerSocketMap.erase(listenerSocket);
         NTCCFG_TEST_EQ(n, 1);
     }
@@ -1265,7 +1271,7 @@ void StreamSocketManager::processStreamSocketEstablished(
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+        LockGuard guard(&d_streamSocketMapMutex);
         d_streamSocketMap.insert(
             StreamSocketApplicationMap::value_type(streamSocket,
                                                    streamSocketSession));
@@ -1284,7 +1290,7 @@ void StreamSocketManager::processStreamSocketClosed(
     NTCI_LOG_DEBUG("Stream socket %d closed", (int)(streamSocket->handle()));
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+        LockGuard guard(&d_streamSocketMapMutex);
         bsl::size_t n = d_streamSocketMap.erase(streamSocket);
         NTCCFG_TEST_EQ(n, 1);
     }
@@ -1397,7 +1403,7 @@ void StreamSocketManager::run()
     // Connect the configured number of sockets to each listener.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+        LockGuard guard(&d_listenerSocketMapMutex);
 
         for (ListenerSocketApplicationMap::const_iterator it =
                  d_listenerSocketMap.begin();
@@ -1482,7 +1488,7 @@ void StreamSocketManager::run()
     // Start the timers for each listener socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+        LockGuard guard(&d_listenerSocketMapMutex);
 
         for (ListenerSocketApplicationMap::const_iterator it =
                  d_listenerSocketMap.begin();
@@ -1498,7 +1504,7 @@ void StreamSocketManager::run()
     // Start the timers for each stream socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+        LockGuard guard(&d_streamSocketMapMutex);
 
         for (StreamSocketApplicationMap::const_iterator it =
                  d_streamSocketMap.begin();
@@ -1514,7 +1520,7 @@ void StreamSocketManager::run()
     // Send data from each connected socket pair.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+        LockGuard guard(&d_streamSocketMapMutex);
 
         for (StreamSocketApplicationMap::const_iterator it =
                  d_streamSocketMap.begin();
@@ -1531,7 +1537,7 @@ void StreamSocketManager::run()
     // stream socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+        LockGuard guard(&d_streamSocketMapMutex);
 
         for (StreamSocketApplicationMap::const_iterator it =
                  d_streamSocketMap.begin();
@@ -1548,7 +1554,7 @@ void StreamSocketManager::run()
     // listener socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+        LockGuard guard(&d_listenerSocketMapMutex);
 
         for (ListenerSocketApplicationMap::const_iterator it =
                  d_listenerSocketMap.begin();
@@ -1571,7 +1577,7 @@ void StreamSocketManager::run()
         streamSocketVector.reserve(d_streamSocketMap.size());
 
         {
-            bslmt::LockGuard<bslmt::Mutex> guard(&d_streamSocketMapMutex);
+            LockGuard guard(&d_streamSocketMapMutex);
 
             for (StreamSocketApplicationMap::const_iterator it =
                      d_streamSocketMap.begin();
@@ -1609,7 +1615,7 @@ void StreamSocketManager::run()
         listenerSocketVector.reserve(d_listenerSocketMap.size());
 
         {
-            bslmt::LockGuard<bslmt::Mutex> guard(&d_listenerSocketMapMutex);
+            LockGuard guard(&d_listenerSocketMapMutex);
 
             for (ListenerSocketApplicationMap::const_iterator it =
                      d_listenerSocketMap.begin();

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -293,7 +293,7 @@ void StreamSocket::processSocketReadable(const ntca::ReactorEvent& event)
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -351,7 +351,7 @@ void StreamSocket::processSocketWritable(const ntca::ReactorEvent& event)
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -412,7 +412,7 @@ void StreamSocket::processSocketError(const ntca::ReactorEvent& event)
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -444,7 +444,7 @@ void StreamSocket::processNotifications(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -483,7 +483,7 @@ void StreamSocket::processConnectDeadlineTimer(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -525,7 +525,7 @@ void StreamSocket::processConnectRetryTimer(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -566,7 +566,7 @@ void StreamSocket::processUpgradeTimer(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -593,7 +593,7 @@ void StreamSocket::processSendRateTimer(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -638,7 +638,7 @@ void StreamSocket::processSendDeadlineTimer(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -685,7 +685,7 @@ void StreamSocket::processReceiveRateTimer(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -730,7 +730,7 @@ void StreamSocket::processReceiveDeadlineTimer(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -3793,7 +3793,7 @@ void StreamSocket::processSourceEndpointResolution(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error       error;
     ntca::BindContext bindContext;
@@ -3864,7 +3864,7 @@ void StreamSocket::processRemoteEndpointResolution(
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (NTCCFG_UNLIKELY(d_detachState.get() ==
                         ntcs::DetachState::e_DETACH_INITIATED))
@@ -4726,7 +4726,7 @@ ntsa::Error StreamSocket::open()
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self);
 }
@@ -4735,7 +4735,7 @@ ntsa::Error StreamSocket::open(ntsa::Transport::Value transport)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport);
 }
@@ -4745,7 +4745,7 @@ ntsa::Error StreamSocket::open(ntsa::Transport::Value transport,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport, handle);
 }
@@ -4756,7 +4756,7 @@ ntsa::Error StreamSocket::open(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport, streamSocket);
 }
@@ -4768,7 +4768,7 @@ ntsa::Error StreamSocket::open(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport, handle, acceptor);
 }
@@ -4780,7 +4780,7 @@ ntsa::Error StreamSocket::open(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateOpen(self, transport, streamSocket, acceptor);
 }
@@ -4800,7 +4800,7 @@ ntsa::Error StreamSocket::bind(const ntsa::Endpoint&     endpoint,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -4867,7 +4867,7 @@ ntsa::Error StreamSocket::bind(const bsl::string&        name,
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -4914,7 +4914,7 @@ ntsa::Error StreamSocket::connect(const ntsa::Endpoint&        endpoint,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -5049,7 +5049,7 @@ ntsa::Error StreamSocket::connect(const bsl::string&           name,
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     ntsa::Error error;
 
@@ -5166,7 +5166,7 @@ ntsa::Error StreamSocket::upgrade(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5319,7 +5319,7 @@ ntsa::Error StreamSocket::send(const bdlbb::Blob&        data,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5396,7 +5396,7 @@ ntsa::Error StreamSocket::send(const ntsa::Data&         data,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5464,7 +5464,7 @@ ntsa::Error StreamSocket::receive(ntca::ReceiveContext*       context,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5586,7 +5586,7 @@ ntsa::Error StreamSocket::receive(const ntca::ReceiveOptions&  options,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5750,14 +5750,14 @@ ntsa::Error StreamSocket::receive(const ntca::ReceiveOptions&  options,
 ntsa::Error StreamSocket::registerResolver(
     const bsl::shared_ptr<ntci::Resolver>& resolver)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     d_resolver = resolver;
     return ntsa::Error();
 }
 
 ntsa::Error StreamSocket::deregisterResolver()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     d_resolver.reset();
     return ntsa::Error();
 }
@@ -5767,7 +5767,7 @@ ntsa::Error StreamSocket::registerManager(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (manager) {
         d_manager_sp       = manager;
@@ -5787,7 +5787,7 @@ ntsa::Error StreamSocket::registerManager(
 
 ntsa::Error StreamSocket::deregisterManager()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     d_manager_sp.reset();
     d_managerStrand_sp.reset();
@@ -5800,7 +5800,7 @@ ntsa::Error StreamSocket::registerSession(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (session) {
         d_session_sp       = session;
@@ -5823,7 +5823,7 @@ ntsa::Error StreamSocket::registerSessionCallback(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (callback) {
         bsl::shared_ptr<ntcu::StreamSocketSession> session;
@@ -5853,7 +5853,7 @@ ntsa::Error StreamSocket::registerSessionCallback(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (callback) {
         bsl::shared_ptr<ntcu::StreamSocketSession> session;
@@ -5876,7 +5876,7 @@ ntsa::Error StreamSocket::registerSessionCallback(
 
 ntsa::Error StreamSocket::deregisterSession()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     d_session_sp.reset();
     d_sessionStrand_sp.reset();
@@ -5887,7 +5887,7 @@ ntsa::Error StreamSocket::deregisterSession()
 ntsa::Error StreamSocket::setZeroCopyThreshold(bsl::size_t value)
 {
     bsl::shared_ptr<StreamSocket>  self = this->getSelf(this);
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return this->privateZeroCopyEngage(self, value);
 }
@@ -5897,7 +5897,7 @@ ntsa::Error StreamSocket::setWriteRateLimiter(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5926,7 +5926,7 @@ ntsa::Error StreamSocket::setWriteQueueLowWatermark(bsl::size_t lowWatermark)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -5965,7 +5965,7 @@ ntsa::Error StreamSocket::setWriteQueueHighWatermark(bsl::size_t highWatermark)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -6005,7 +6005,7 @@ ntsa::Error StreamSocket::setWriteQueueWatermarks(bsl::size_t lowWatermark,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -6068,7 +6068,7 @@ ntsa::Error StreamSocket::setReadRateLimiter(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -6097,7 +6097,7 @@ ntsa::Error StreamSocket::setReadQueueLowWatermark(bsl::size_t lowWatermark)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -6138,7 +6138,7 @@ ntsa::Error StreamSocket::setReadQueueHighWatermark(bsl::size_t highWatermark)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -6164,7 +6164,7 @@ ntsa::Error StreamSocket::setReadQueueWatermarks(bsl::size_t lowWatermark,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -6197,7 +6197,7 @@ ntsa::Error StreamSocket::timestampOutgoingData(bool enable)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return privateTimestampOutgoingData(self, enable);
 }
@@ -6206,7 +6206,7 @@ ntsa::Error StreamSocket::timestampIncomingData(bool enable)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     return privateTimestampIncomingData(self, enable);
 }
@@ -6216,7 +6216,7 @@ ntsa::Error StreamSocket::relaxFlowControl(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -6233,7 +6233,7 @@ ntsa::Error StreamSocket::applyFlowControl(
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -6275,7 +6275,7 @@ ntsa::Error StreamSocket::cancel(const ntca::ConnectToken& token)
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -6301,7 +6301,7 @@ ntsa::Error StreamSocket::cancel(const ntca::UpgradeToken& token)
 
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -6350,7 +6350,7 @@ ntsa::Error StreamSocket::cancel(const ntca::SendToken& token)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -6394,7 +6394,7 @@ ntsa::Error StreamSocket::cancel(const ntca::ReceiveToken& token)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -6435,7 +6435,7 @@ ntsa::Error StreamSocket::downgrade()
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -6529,7 +6529,7 @@ ntsa::Error StreamSocket::shutdown(ntsa::ShutdownType::Value direction,
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -6575,7 +6575,7 @@ void StreamSocket::close(const ntci::CloseCallback& callback)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     NTCI_LOG_CONTEXT();
 
@@ -6728,20 +6728,20 @@ ntsa::Transport::Value StreamSocket::transport() const
 
 ntsa::Endpoint StreamSocket::sourceEndpoint() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sourceEndpoint;
 }
 
 ntsa::Endpoint StreamSocket::remoteEndpoint() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_remoteEndpoint;
 }
 
 bsl::shared_ptr<ntci::EncryptionCertificate> StreamSocket::sourceCertificate()
     const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     bsl::shared_ptr<ntci::EncryptionCertificate> result;
     if (d_encryption_sp) {
@@ -6754,7 +6754,7 @@ bsl::shared_ptr<ntci::EncryptionCertificate> StreamSocket::sourceCertificate()
 bsl::shared_ptr<ntci::EncryptionCertificate> StreamSocket::remoteCertificate()
     const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     bsl::shared_ptr<ntci::EncryptionCertificate> result;
     if (d_encryption_sp) {
@@ -6766,7 +6766,7 @@ bsl::shared_ptr<ntci::EncryptionCertificate> StreamSocket::remoteCertificate()
 
 bsl::shared_ptr<ntci::EncryptionKey> StreamSocket::privateKey() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     bsl::shared_ptr<ntci::EncryptionKey> result;
     if (d_encryption_sp) {
@@ -6810,49 +6810,49 @@ bsl::size_t StreamSocket::threadIndex() const
 
 bsl::size_t StreamSocket::readQueueSize() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_receiveQueue.size();
 }
 
 bsl::size_t StreamSocket::readQueueLowWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_receiveQueue.lowWatermark();
 }
 
 bsl::size_t StreamSocket::readQueueHighWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_receiveQueue.highWatermark();
 }
 
 bsl::size_t StreamSocket::writeQueueSize() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sendQueue.size();
 }
 
 bsl::size_t StreamSocket::writeQueueLowWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sendQueue.lowWatermark();
 }
 
 bsl::size_t StreamSocket::writeQueueHighWatermark() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_sendQueue.highWatermark();
 }
 
 bsl::size_t StreamSocket::totalBytesSent() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_totalBytesSent;
 }
 
 bsl::size_t StreamSocket::totalBytesReceived() const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
     return d_totalBytesReceived;
 }
 

--- a/groups/ntc/ntcr/ntcr_streamsocket.h
+++ b/groups/ntc/ntcr/ntcr_streamsocket.h
@@ -83,8 +83,14 @@ class StreamSocket : public ntci::StreamSocket,
     /// buffer factory.
     typedef bsl::shared_ptr<bdlbb::BlobBufferFactory> BlobBufferFactoryPtr;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                             d_object;
-    mutable bslmt::Mutex                       d_mutex;
+    mutable Mutex                              d_mutex;
     ntsa::Handle                               d_systemHandle;
     ntsa::Handle                               d_publicHandle;
     ntsa::Transport::Value                     d_transport;

--- a/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.t.cpp
@@ -444,10 +444,16 @@ class StreamSocketManager : public ntci::StreamSocketManager,
                                bsl::shared_ptr<StreamSocketSession> >
         StreamSocketApplicationMap;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     ntccfg::Object                 d_object;
     bsl::shared_ptr<ntci::Reactor> d_reactor_sp;
     bsl::shared_ptr<ntcs::Metrics> d_metrics_sp;
-    bslmt::Mutex                   d_socketMapMutex;
+    Mutex                          d_socketMapMutex;
     StreamSocketApplicationMap     d_socketMap;
     bslmt::Latch                   d_socketsEstablished;
     bslmt::Latch                   d_socketsClosed;
@@ -949,7 +955,7 @@ void StreamSocketManager::processStreamSocketEstablished(
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
         d_socketMap.insert(
             StreamSocketApplicationMap::value_type(streamSocket,
                                                    streamSocketSession));
@@ -968,7 +974,7 @@ void StreamSocketManager::processStreamSocketClosed(
     NTCI_LOG_DEBUG("Stream socket %d closed", (int)(streamSocket->handle()));
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
         bsl::size_t                    n = d_socketMap.erase(streamSocket);
         NTCCFG_TEST_EQ(n, 1);
     }
@@ -1091,7 +1097,7 @@ void StreamSocketManager::run()
     // Start the timers for each stream socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
 
         for (StreamSocketApplicationMap::const_iterator it =
                  d_socketMap.begin();
@@ -1106,7 +1112,7 @@ void StreamSocketManager::run()
     // Send data between each stream socket pair.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
 
         for (StreamSocketApplicationMap::const_iterator it =
                  d_socketMap.begin();
@@ -1122,7 +1128,7 @@ void StreamSocketManager::run()
     // stream socket.
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+        LockGuard guard(&d_socketMapMutex);
 
         for (StreamSocketApplicationMap::const_iterator it =
                  d_socketMap.begin();
@@ -1313,7 +1319,7 @@ void StreamSocketManager::run()
         socketVector.reserve(d_socketMap.size());
 
         {
-            bslmt::LockGuard<bslmt::Mutex> guard(&d_socketMapMutex);
+            LockGuard guard(&d_socketMapMutex);
 
             for (StreamSocketApplicationMap::const_iterator it =
                      d_socketMap.begin();

--- a/groups/ntc/ntcr/ntcr_thread.cpp
+++ b/groups/ntc/ntcr/ntcr_thread.cpp
@@ -80,7 +80,7 @@ void* Thread::run(ntcr::Thread* thread)
                    thread->d_config.threadName().value().c_str());
 
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&thread->d_runMutex);
+        ntccfg::ConditionMutexGuard guard(&thread->d_runMutex);
         thread->d_runState = RUN_STATE_STARTED;
         thread->d_runCondition.signal();
     }
@@ -294,7 +294,7 @@ ntsa::Error Thread::start(const bslmt::ThreadAttributes& threadAttributes)
         return error;
     }
 
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_runMutex);
+    ntccfg::ConditionMutexGuard guard(&d_runMutex);
     while (d_runState != RUN_STATE_STARTED) {
         d_runCondition.wait(&d_runMutex);
     }
@@ -308,7 +308,7 @@ void Thread::shutdown()
 
     NTCI_LOG_CONTEXT_GUARD_OWNER(d_config.metricName().value().c_str());
 
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_runMutex);
+    ntccfg::ConditionMutexGuard guard(&d_runMutex);
 
     if (d_runState != RUN_STATE_STARTED) {
         return;

--- a/groups/ntc/ntcr/ntcr_thread.h
+++ b/groups/ntc/ntcr/ntcr_thread.h
@@ -64,8 +64,8 @@ class Thread : public ntci::Thread, public ntccfg::Shared<Thread>
     bsl::shared_ptr<ntci::Reactor> d_reactor_sp;
     bslmt::ThreadUtil::Handle      d_threadHandle;
     bslmt::ThreadAttributes        d_threadAttributes;
-    bslmt::Mutex                   d_runMutex;
-    bslmt::Condition               d_runCondition;
+    ntccfg::ConditionMutex         d_runMutex;
+    ntccfg::Condition              d_runCondition;
     bsls::AtomicInt                d_runState;
     ntca::ThreadConfig             d_config;
     bslma::Allocator*              d_allocator_p;

--- a/groups/ntc/ntcs/ntcs_blobbufferfactory.cpp
+++ b/groups/ntc/ntcs/ntcs_blobbufferfactory.cpp
@@ -162,7 +162,7 @@ BlobBufferFactoryMetrics::~BlobBufferFactoryMetrics()
 
 void BlobBufferFactoryMetrics::getStats(bdld::ManagedDatum* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     bdld::DatumMutableArrayRef array;
     bdld::Datum::createUninitializedArray(&array,

--- a/groups/ntc/ntcs/ntcs_blobbufferfactory.h
+++ b/groups/ntc/ntcs/ntcs_blobbufferfactory.h
@@ -46,13 +46,17 @@ class BlobBufferFactoryMetrics
 : public ntci::Monitorable,
   public ntccfg::Shared<BlobBufferFactoryMetrics>
 {
-    mutable bslmt::Mutex d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
 
-    bsls::AtomicUint64 d_numAllocated;
-    bsls::AtomicUint64 d_numAvailable;
-    bsls::AtomicUint64 d_numPooled;
-    bsls::AtomicUint64 d_numBytesInUse;
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
 
+    mutable Mutex                                   d_mutex;
+    bsls::AtomicUint64                              d_numAllocated;
+    bsls::AtomicUint64                              d_numAvailable;
+    bsls::AtomicUint64                              d_numPooled;
+    bsls::AtomicUint64                              d_numBytesInUse;
     bsl::string                                     d_prefix;
     bsl::string                                     d_objectName;
     bsl::shared_ptr<ntcs::BlobBufferFactoryMetrics> d_parent_sp;

--- a/groups/ntc/ntcs/ntcs_chronology.h
+++ b/groups/ntc/ntcs/ntcs_chronology.h
@@ -52,11 +52,6 @@ BSLS_IDENT("$Id: $")
 // Undefine or set to 0 to use a linked list.
 #define NTCS_CHRONOLOGY_USE_FUNCTOR_QUEUE_VECTOR 1
 
-// Define and set to 1 to use a custom mutex implementation that directly
-// makes futex system calls on Linux, and devolves to 'bslmt::Mutex' on
-// other platforms. Undefine or set to 0 to use 'bslmt::Mutex'.
-#define NTCS_CHRONOLOGY_USE_CUSTOM_MUTEX 1
-
 namespace BloombergLP {
 namespace ntcs {
 class Chronology;
@@ -406,13 +401,11 @@ class Chronology
         TimerNode*                   d_next_p;
     };
 
-#if NTCS_CHRONOLOGY_USE_CUSTOM_MUTEX
-    typedef ntci::Mutex                   Mutex;
-    typedef bslmt::LockGuard<ntci::Mutex> LockGuard;
-#else
-    typedef bslmt::Mutex                    Mutex;
-    typedef bslmt::LockGuard<ntccfg::Mutex> LockGuard;
-#endif
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
 
     ntccfg::Object                      d_object;
     mutable Mutex                       d_mutex;

--- a/groups/ntc/ntcs/ntcs_chronology.t.cpp
+++ b/groups/ntc/ntcs/ntcs_chronology.t.cpp
@@ -495,14 +495,14 @@ class MtDriver : public ntcs::Driver,
 
     void interruptOne() BSLS_KEYWORD_OVERRIDE
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+        ntccfg::ConditionMutexGuard guard(&d_mutex);
         d_blocked = false;
         d_condition.signal();
     }
 
     void interruptAll() BSLS_KEYWORD_OVERRIDE
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+        ntccfg::ConditionMutexGuard guard(&d_mutex);
         d_blocked = false;
         d_condition.broadcast();
     }
@@ -566,7 +566,7 @@ class MtDriver : public ntcs::Driver,
     /// Defer the execution of the specified 'functor'.
     void execute(const Functor& functor) BSLS_KEYWORD_OVERRIDE
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+        ntccfg::ConditionMutexGuard guard(&d_mutex);
         d_chronology->defer(functor);
         d_blocked = false;
         d_condition.signal();
@@ -578,7 +578,7 @@ class MtDriver : public ntcs::Driver,
     void moveAndExecute(FunctorSequence* functorSequence,
                         const Functor&   functor) BSLS_KEYWORD_OVERRIDE
     {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+        ntccfg::ConditionMutexGuard guard(&d_mutex);
         d_chronology->defer(functorSequence, functor);
         d_blocked = false;
         d_condition.signal();
@@ -626,8 +626,8 @@ class MtDriver : public ntcs::Driver,
   private:
     bslma::Allocator* d_allocator_p;
 
-    bslmt::Mutex                      d_mutex;
-    bslmt::Condition                  d_condition;
+    ntccfg::ConditionMutex            d_mutex;
+    ntccfg::Condition                 d_condition;
     bool                              d_blocked;
     bsls::AtomicBool                  d_run;
     bsl::shared_ptr<ntcs::Chronology> d_chronology;
@@ -810,7 +810,7 @@ class MtTestSuite
         NTCI_LOG_DEBUG("processTimer called: remaining = %d", res);
 
         if (res == 0) {
-            bslmt::LockGuard<bslmt::Mutex> lock(&d_allOneShotConsumedMutex);
+            ntccfg::ConditionMutexGuard lock(&d_allOneShotConsumedMutex);
             d_allOneShotConsumedCondition.signal();
         }
 
@@ -895,12 +895,12 @@ class MtTestSuite
     bsl::shared_ptr<bslmt::ThreadGroup> d_consumers;
     bsl::shared_ptr<bslmt::ThreadGroup> d_producers;
 
-    bsls::AtomicInt  d_numTimersToProduce;
-    bsls::AtomicInt  d_numOneShotTimersToConsume;
-    bsls::AtomicInt  d_numExpectedCloseEvents;
-    bsls::AtomicInt  d_numPeriodicTimersShot;
-    bslmt::Condition d_allOneShotConsumedCondition;
-    bslmt::Mutex     d_allOneShotConsumedMutex;
+    bsls::AtomicInt        d_numTimersToProduce;
+    bsls::AtomicInt        d_numOneShotTimersToConsume;
+    bsls::AtomicInt        d_numExpectedCloseEvents;
+    bsls::AtomicInt        d_numPeriodicTimersShot;
+    ntccfg::Condition      d_allOneShotConsumedCondition;
+    ntccfg::ConditionMutex d_allOneShotConsumedMutex;
 
     typedef bsl::pair<bsl::shared_ptr<ntcs::Strand>, bsls::AtomicBool>
         StrandAndFlag;

--- a/groups/ntc/ntcs/ntcs_dispatch.cpp
+++ b/groups/ntc/ntcs/ntcs_dispatch.cpp
@@ -38,7 +38,7 @@ void Dispatch::announceEstablished(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!manager) {
         return;
@@ -48,7 +48,7 @@ void Dispatch::announceEstablished(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketManager> managerGuard = manager;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         managerGuard->processDatagramSocketEstablished(socket);
     }
     else if (destination) {
@@ -72,7 +72,7 @@ void Dispatch::announceClosed(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!manager) {
         return;
@@ -82,7 +82,7 @@ void Dispatch::announceClosed(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketManager> managerGuard = manager;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         managerGuard->processDatagramSocketClosed(socket);
     }
     else if (destination) {
@@ -107,7 +107,7 @@ void Dispatch::announceReadQueueFlowControlRelaxed(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -117,7 +117,7 @@ void Dispatch::announceReadQueueFlowControlRelaxed(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processReadQueueFlowControlRelaxed(socket, event);
     }
     else if (destination) {
@@ -144,7 +144,7 @@ void Dispatch::announceReadQueueFlowControlApplied(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -154,7 +154,7 @@ void Dispatch::announceReadQueueFlowControlApplied(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processReadQueueFlowControlApplied(socket, event);
     }
     else if (destination) {
@@ -181,7 +181,7 @@ void Dispatch::announceReadQueueLowWatermark(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -191,7 +191,7 @@ void Dispatch::announceReadQueueLowWatermark(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processReadQueueLowWatermark(socket, event);
     }
     else if (destination) {
@@ -218,7 +218,7 @@ void Dispatch::announceReadQueueHighWatermark(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -228,7 +228,7 @@ void Dispatch::announceReadQueueHighWatermark(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processReadQueueHighWatermark(socket, event);
     }
     else if (destination) {
@@ -255,7 +255,7 @@ void Dispatch::announceReadQueueDiscarded(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -265,7 +265,7 @@ void Dispatch::announceReadQueueDiscarded(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processReadQueueDiscarded(socket, event);
     }
     else if (destination) {
@@ -292,7 +292,7 @@ void Dispatch::announceReadQueueRateLimitApplied(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -302,7 +302,7 @@ void Dispatch::announceReadQueueRateLimitApplied(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processReadQueueRateLimitApplied(socket, event);
     }
     else if (destination) {
@@ -329,7 +329,7 @@ void Dispatch::announceReadQueueRateLimitRelaxed(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -339,7 +339,7 @@ void Dispatch::announceReadQueueRateLimitRelaxed(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processReadQueueRateLimitRelaxed(socket, event);
     }
     else if (destination) {
@@ -366,7 +366,7 @@ void Dispatch::announceWriteQueueFlowControlRelaxed(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -376,7 +376,7 @@ void Dispatch::announceWriteQueueFlowControlRelaxed(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processWriteQueueFlowControlRelaxed(socket, event);
     }
     else if (destination) {
@@ -403,7 +403,7 @@ void Dispatch::announceWriteQueueFlowControlApplied(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -413,7 +413,7 @@ void Dispatch::announceWriteQueueFlowControlApplied(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processWriteQueueFlowControlApplied(socket, event);
     }
     else if (destination) {
@@ -440,7 +440,7 @@ void Dispatch::announceWriteQueueLowWatermark(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -450,7 +450,7 @@ void Dispatch::announceWriteQueueLowWatermark(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processWriteQueueLowWatermark(socket, event);
     }
     else if (destination) {
@@ -477,7 +477,7 @@ void Dispatch::announceWriteQueueHighWatermark(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -487,7 +487,7 @@ void Dispatch::announceWriteQueueHighWatermark(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processWriteQueueHighWatermark(socket, event);
     }
     else if (destination) {
@@ -514,7 +514,7 @@ void Dispatch::announceWriteQueueDiscarded(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -524,7 +524,7 @@ void Dispatch::announceWriteQueueDiscarded(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processWriteQueueDiscarded(socket, event);
     }
     else if (destination) {
@@ -551,7 +551,7 @@ void Dispatch::announceWriteQueueRateLimitApplied(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -561,7 +561,7 @@ void Dispatch::announceWriteQueueRateLimitApplied(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processWriteQueueRateLimitApplied(socket, event);
     }
     else if (destination) {
@@ -588,7 +588,7 @@ void Dispatch::announceWriteQueueRateLimitRelaxed(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -598,7 +598,7 @@ void Dispatch::announceWriteQueueRateLimitRelaxed(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processWriteQueueRateLimitRelaxed(socket, event);
     }
     else if (destination) {
@@ -625,7 +625,7 @@ void Dispatch::announceShutdownInitiated(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -635,7 +635,7 @@ void Dispatch::announceShutdownInitiated(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processShutdownInitiated(socket, event);
     }
     else if (destination) {
@@ -662,7 +662,7 @@ void Dispatch::announceShutdownReceive(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -672,7 +672,7 @@ void Dispatch::announceShutdownReceive(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processShutdownReceive(socket, event);
     }
     else if (destination) {
@@ -699,7 +699,7 @@ void Dispatch::announceShutdownSend(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -709,7 +709,7 @@ void Dispatch::announceShutdownSend(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processShutdownSend(socket, event);
     }
     else if (destination) {
@@ -736,7 +736,7 @@ void Dispatch::announceShutdownComplete(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -746,7 +746,7 @@ void Dispatch::announceShutdownComplete(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processShutdownComplete(socket, event);
     }
     else if (destination) {
@@ -773,7 +773,7 @@ void Dispatch::announceError(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -783,7 +783,7 @@ void Dispatch::announceError(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processError(socket, event);
     }
     else if (destination) {
@@ -811,7 +811,7 @@ void Dispatch::announceEstablished(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!manager) {
         return;
@@ -821,7 +821,7 @@ void Dispatch::announceEstablished(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::ListenerSocketManager> managerGuard = manager;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         managerGuard->processListenerSocketEstablished(socket);
     }
     else if (destination) {
@@ -845,7 +845,7 @@ void Dispatch::announceClosed(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!manager) {
         return;
@@ -855,7 +855,7 @@ void Dispatch::announceClosed(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::ListenerSocketManager> managerGuard = manager;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         managerGuard->processListenerSocketClosed(socket);
     }
     else if (destination) {
@@ -880,7 +880,7 @@ void Dispatch::announceAcceptQueueFlowControlRelaxed(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -890,7 +890,7 @@ void Dispatch::announceAcceptQueueFlowControlRelaxed(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::ListenerSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processAcceptQueueFlowControlRelaxed(socket, event);
     }
     else if (destination) {
@@ -917,7 +917,7 @@ void Dispatch::announceAcceptQueueFlowControlApplied(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -927,7 +927,7 @@ void Dispatch::announceAcceptQueueFlowControlApplied(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::ListenerSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processAcceptQueueFlowControlApplied(socket, event);
     }
     else if (destination) {
@@ -954,7 +954,7 @@ void Dispatch::announceAcceptQueueLowWatermark(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -964,7 +964,7 @@ void Dispatch::announceAcceptQueueLowWatermark(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::ListenerSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processAcceptQueueLowWatermark(socket, event);
     }
     else if (destination) {
@@ -991,7 +991,7 @@ void Dispatch::announceAcceptQueueHighWatermark(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -1001,7 +1001,7 @@ void Dispatch::announceAcceptQueueHighWatermark(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::ListenerSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processAcceptQueueHighWatermark(socket, event);
     }
     else if (destination) {
@@ -1028,7 +1028,7 @@ void Dispatch::announceAcceptQueueDiscarded(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -1038,7 +1038,7 @@ void Dispatch::announceAcceptQueueDiscarded(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::ListenerSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processAcceptQueueDiscarded(socket, event);
     }
     else if (destination) {
@@ -1065,7 +1065,7 @@ void Dispatch::announceAcceptQueueRateLimitApplied(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -1075,7 +1075,7 @@ void Dispatch::announceAcceptQueueRateLimitApplied(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::ListenerSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processAcceptQueueRateLimitApplied(socket, event);
     }
     else if (destination) {
@@ -1102,7 +1102,7 @@ void Dispatch::announceAcceptQueueRateLimitRelaxed(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -1112,7 +1112,7 @@ void Dispatch::announceAcceptQueueRateLimitRelaxed(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::ListenerSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processAcceptQueueRateLimitRelaxed(socket, event);
     }
     else if (destination) {
@@ -1139,7 +1139,7 @@ void Dispatch::announceShutdownInitiated(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -1149,7 +1149,7 @@ void Dispatch::announceShutdownInitiated(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::ListenerSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processShutdownInitiated(socket, event);
     }
     else if (destination) {
@@ -1176,7 +1176,7 @@ void Dispatch::announceShutdownReceive(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -1186,7 +1186,7 @@ void Dispatch::announceShutdownReceive(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::ListenerSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processShutdownReceive(socket, event);
     }
     else if (destination) {
@@ -1213,7 +1213,7 @@ void Dispatch::announceShutdownSend(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -1223,7 +1223,7 @@ void Dispatch::announceShutdownSend(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::ListenerSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processShutdownSend(socket, event);
     }
     else if (destination) {
@@ -1250,7 +1250,7 @@ void Dispatch::announceShutdownComplete(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -1260,7 +1260,7 @@ void Dispatch::announceShutdownComplete(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::ListenerSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processShutdownComplete(socket, event);
     }
     else if (destination) {
@@ -1287,7 +1287,7 @@ void Dispatch::announceError(
     const bsl::shared_ptr<ntci::Strand>&                source,
     const bsl::shared_ptr<ntci::Executor>&              executor,
     bool                                                defer,
-    bslmt::Mutex*                                       mutex)
+    ntccfg::Mutex*                                      mutex)
 {
     if (!session) {
         return;
@@ -1297,7 +1297,7 @@ void Dispatch::announceError(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::ListenerSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>             guard(mutex);
+        ntccfg::UnLockGuard                          guard(mutex);
         sessionGuard->processError(socket, event);
     }
     else if (destination) {
@@ -1325,7 +1325,7 @@ void Dispatch::announceEstablished(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!manager) {
         return;
@@ -1335,7 +1335,7 @@ void Dispatch::announceEstablished(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketManager> managerGuard = manager;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         managerGuard->processStreamSocketEstablished(socket);
     }
     else if (destination) {
@@ -1359,7 +1359,7 @@ void Dispatch::announceClosed(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!manager) {
         return;
@@ -1369,7 +1369,7 @@ void Dispatch::announceClosed(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketManager> managerGuard = manager;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         managerGuard->processStreamSocketClosed(socket);
     }
     else if (destination) {
@@ -1394,7 +1394,7 @@ void Dispatch::announceReadQueueFlowControlRelaxed(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1404,7 +1404,7 @@ void Dispatch::announceReadQueueFlowControlRelaxed(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processReadQueueFlowControlRelaxed(socket, event);
     }
     else if (destination) {
@@ -1431,7 +1431,7 @@ void Dispatch::announceReadQueueFlowControlApplied(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1441,7 +1441,7 @@ void Dispatch::announceReadQueueFlowControlApplied(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processReadQueueFlowControlApplied(socket, event);
     }
     else if (destination) {
@@ -1468,7 +1468,7 @@ void Dispatch::announceReadQueueLowWatermark(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1478,7 +1478,7 @@ void Dispatch::announceReadQueueLowWatermark(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processReadQueueLowWatermark(socket, event);
     }
     else if (destination) {
@@ -1505,7 +1505,7 @@ void Dispatch::announceReadQueueHighWatermark(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1515,7 +1515,7 @@ void Dispatch::announceReadQueueHighWatermark(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processReadQueueHighWatermark(socket, event);
     }
     else if (destination) {
@@ -1542,7 +1542,7 @@ void Dispatch::announceReadQueueDiscarded(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1552,7 +1552,7 @@ void Dispatch::announceReadQueueDiscarded(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processReadQueueDiscarded(socket, event);
     }
     else if (destination) {
@@ -1579,7 +1579,7 @@ void Dispatch::announceReadQueueRateLimitApplied(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1589,7 +1589,7 @@ void Dispatch::announceReadQueueRateLimitApplied(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processReadQueueRateLimitApplied(socket, event);
     }
     else if (destination) {
@@ -1616,7 +1616,7 @@ void Dispatch::announceReadQueueRateLimitRelaxed(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1626,7 +1626,7 @@ void Dispatch::announceReadQueueRateLimitRelaxed(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processReadQueueRateLimitRelaxed(socket, event);
     }
     else if (destination) {
@@ -1653,7 +1653,7 @@ void Dispatch::announceWriteQueueFlowControlRelaxed(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1663,7 +1663,7 @@ void Dispatch::announceWriteQueueFlowControlRelaxed(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processWriteQueueFlowControlRelaxed(socket, event);
     }
     else if (destination) {
@@ -1690,7 +1690,7 @@ void Dispatch::announceWriteQueueFlowControlApplied(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1700,7 +1700,7 @@ void Dispatch::announceWriteQueueFlowControlApplied(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processWriteQueueFlowControlApplied(socket, event);
     }
     else if (destination) {
@@ -1727,7 +1727,7 @@ void Dispatch::announceWriteQueueLowWatermark(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1737,7 +1737,7 @@ void Dispatch::announceWriteQueueLowWatermark(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processWriteQueueLowWatermark(socket, event);
     }
     else if (destination) {
@@ -1764,7 +1764,7 @@ void Dispatch::announceWriteQueueHighWatermark(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1774,7 +1774,7 @@ void Dispatch::announceWriteQueueHighWatermark(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processWriteQueueHighWatermark(socket, event);
     }
     else if (destination) {
@@ -1801,7 +1801,7 @@ void Dispatch::announceWriteQueueDiscarded(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1811,7 +1811,7 @@ void Dispatch::announceWriteQueueDiscarded(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processWriteQueueDiscarded(socket, event);
     }
     else if (destination) {
@@ -1838,7 +1838,7 @@ void Dispatch::announceWriteQueueRateLimitApplied(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1848,7 +1848,7 @@ void Dispatch::announceWriteQueueRateLimitApplied(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processWriteQueueRateLimitApplied(socket, event);
     }
     else if (destination) {
@@ -1875,7 +1875,7 @@ void Dispatch::announceWriteQueueRateLimitRelaxed(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1885,7 +1885,7 @@ void Dispatch::announceWriteQueueRateLimitRelaxed(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processWriteQueueRateLimitRelaxed(socket, event);
     }
     else if (destination) {
@@ -1912,7 +1912,7 @@ void Dispatch::announceDowngradeInitiated(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1922,7 +1922,7 @@ void Dispatch::announceDowngradeInitiated(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processDowngradeInitiated(socket, event);
     }
     else if (destination) {
@@ -1949,7 +1949,7 @@ void Dispatch::announceDowngradeComplete(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1959,7 +1959,7 @@ void Dispatch::announceDowngradeComplete(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processDowngradeComplete(socket, event);
     }
     else if (destination) {
@@ -1986,7 +1986,7 @@ void Dispatch::announceShutdownInitiated(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -1996,7 +1996,7 @@ void Dispatch::announceShutdownInitiated(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processShutdownInitiated(socket, event);
     }
     else if (destination) {
@@ -2023,7 +2023,7 @@ void Dispatch::announceShutdownReceive(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -2033,7 +2033,7 @@ void Dispatch::announceShutdownReceive(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processShutdownReceive(socket, event);
     }
     else if (destination) {
@@ -2060,7 +2060,7 @@ void Dispatch::announceShutdownSend(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -2070,7 +2070,7 @@ void Dispatch::announceShutdownSend(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processShutdownSend(socket, event);
     }
     else if (destination) {
@@ -2097,7 +2097,7 @@ void Dispatch::announceShutdownComplete(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -2107,7 +2107,7 @@ void Dispatch::announceShutdownComplete(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processShutdownComplete(socket, event);
     }
     else if (destination) {
@@ -2134,7 +2134,7 @@ void Dispatch::announceError(
     const bsl::shared_ptr<ntci::Strand>&              source,
     const bsl::shared_ptr<ntci::Executor>&            executor,
     bool                                              defer,
-    bslmt::Mutex*                                     mutex)
+    ntccfg::Mutex*                                    mutex)
 {
     if (!session) {
         return;
@@ -2144,7 +2144,7 @@ void Dispatch::announceError(
                       ntci::Strand::passthrough(destination, source)))
     {
         bsl::shared_ptr<ntci::StreamSocketSession> sessionGuard = session;
-        bslmt::UnLockGuard<bslmt::Mutex>           guard(mutex);
+        ntccfg::UnLockGuard                        guard(mutex);
         sessionGuard->processError(socket, event);
     }
     else if (destination) {

--- a/groups/ntc/ntcs/ntcs_dispatch.h
+++ b/groups/ntc/ntcs/ntcs_dispatch.h
@@ -77,7 +77,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'manager' the closure of the specified
     /// 'socket'. If the specified 'defer' flag is false and the
@@ -99,7 +99,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition that read queue
     /// flow control has been relaxed. If the specified 'defer' flag is
@@ -122,7 +122,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition that read queue
     /// flow control has been applied. If the specified 'defer' flag is
@@ -145,7 +145,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition of the specified
     /// 'socket' that the size of the read queue is greater than or equal to
@@ -169,7 +169,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition of the specified
     /// 'socket' that the size of the read queue is greater than the read
@@ -193,7 +193,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition of the specified
     /// 'socket' that the read queue has been discarded because
@@ -218,7 +218,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition that read queue
     /// rate limit has been reached. If the specified 'defer' flag is
@@ -241,7 +241,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition that read queue
     /// rate limit timer has fired. If the specified 'defer' flag is
@@ -264,7 +264,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition that write queue
     /// flow control has been relaxed. If the specified 'defer' flag is
@@ -287,7 +287,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition that write queue
     /// flow control has been applied. If the specified 'defer' flag is
@@ -310,7 +310,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition of the specified
     /// 'socket' that the size of the write queue is less than or equal to
@@ -334,7 +334,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition of the specified
     /// 'socket' that the size of the write queue is greater than the write
@@ -358,7 +358,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the  condition of the specified
     /// 'socket' that the write queue has been discarded because
@@ -383,7 +383,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition that write queue
     /// rate limit has been reached. If the specified 'defer' flag is
@@ -406,7 +406,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition that write queue
     /// rate limit timer has fired. If the specified 'defer' flag is
@@ -429,7 +429,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the initiation of the shutdown
     /// sequence of the specified 'socket' from the specified 'origin'. If
@@ -453,7 +453,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' that the specified 'socket' is
     /// shut down for reading. If the specified 'defer' flag is false and
@@ -476,7 +476,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' that the specified 'socket' is
     /// shut down for writing. If the specified 'defer' flag is false and
@@ -499,7 +499,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the shutdown sequence of the
     /// specified 'socket' has completed. If the specified 'defer' flag is
@@ -522,7 +522,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the detection of an error for
     /// the specified 'socket'. If the specified 'defer' flag is false and
@@ -545,7 +545,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     // *** Listener Socket ***
 
@@ -569,7 +569,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'manager' the closure of the specified
     /// 'socket'. If the specified 'defer' flag is false and the
@@ -591,7 +591,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition that accept queue
     /// flow control has been relaxed. If the specified 'defer' flag is
@@ -614,7 +614,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition that accept queue
     /// flow control has been applied. If the specified 'defer' flag is
@@ -637,7 +637,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition of the specified
     /// 'socket' that the size of the accept queue is greater than or equal
@@ -661,7 +661,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition of the specified
     /// 'socket' that the size of the accept queue is greater than the read
@@ -685,7 +685,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition of the specified
     /// 'socket' that the accept queue has been discarded because
@@ -710,7 +710,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition that acccept queue
     /// rate limit has been reached. If the specified 'defer' flag is
@@ -733,7 +733,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the condition that accept queue
     /// rate limit timer has fired. If the specified 'defer' flag is
@@ -756,7 +756,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the initiation of the shutdown
     /// sequence of the specified 'socket' from the specified 'origin'. If
@@ -780,7 +780,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' that the specified 'socket' is
     /// shut down for reading. If the specified 'defer' flag is false and
@@ -803,7 +803,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' that the specified 'socket' is
     /// shut down for writing. If the specified 'defer' flag is false and
@@ -826,7 +826,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the shutdown sequence of the
     /// specified 'socket' has completed. If the specified 'defer' flag is
@@ -849,7 +849,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     /// Announce to the specified 'session' the detection of an error for
     /// the specified 'socket'. If the specified 'defer' flag is false and
@@ -872,7 +872,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&                source,
         const bsl::shared_ptr<ntci::Executor>&              executor,
         bool                                                defer,
-        bslmt::Mutex*                                       mutex);
+        ntccfg::Mutex*                                      mutex);
 
     // *** Stream Socket ***
 
@@ -896,7 +896,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'manager' the closure of the specified
     /// 'socket'. If the specified 'defer' flag is false and the
@@ -918,7 +918,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the condition that read queue
     /// flow control has been relaxed. If the specified 'defer' flag is
@@ -941,7 +941,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the condition that read queue
     /// flow control has been applied. If the specified 'defer' flag is
@@ -964,7 +964,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the condition of the specified
     /// 'socket' that the size of the read queue is greater than or equal to
@@ -988,7 +988,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the condition of the specified
     /// 'socket' that the size of the read queue is greater than the read
@@ -1012,7 +1012,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the condition of the specified
     /// 'socket' that the read queue has been discarded because
@@ -1037,7 +1037,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the condition that read queue
     /// rate limit has been reached. If the specified 'defer' flag is
@@ -1060,7 +1060,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the condition that read queue
     /// rate limit timer has fired. If the specified 'defer' flag is
@@ -1083,7 +1083,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the condition that write queue
     /// flow control has been relaxed. If the specified 'defer' flag is
@@ -1106,7 +1106,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the condition that write queue
     /// flow control has been applied. If the specified 'defer' flag is
@@ -1129,7 +1129,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the condition of the specified
     /// 'socket' that the size of the write queue is less than or equal to
@@ -1153,7 +1153,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the condition of the specified
     /// 'socket' that the size of the write queue is greater than the write
@@ -1177,7 +1177,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the  condition of the specified
     /// 'socket' that the write queue has been discarded because
@@ -1202,7 +1202,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the condition that write queue
     /// rate limit has been reached. If the specified 'defer' flag is
@@ -1225,7 +1225,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the condition that write queue
     /// rate limit timer has fired. If the specified 'defer' flag is
@@ -1248,7 +1248,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the initiation of a downgrade of
     /// the specified 'socket' from encrypted to unencrypted communication.
@@ -1272,7 +1272,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the initiation of a downgrade of
     /// the specified 'socket' from encrypted to unencrypted communication.
@@ -1296,7 +1296,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the initiation of the shutdown
     /// sequence of the specified 'socket' from the specified 'origin'. If
@@ -1320,7 +1320,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' that the specified 'socket' is
     /// shut down for reading. If the specified 'defer' flag is false and
@@ -1343,7 +1343,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' that the specified 'socket' is
     /// shut down for writing. If the specified 'defer' flag is false and
@@ -1366,7 +1366,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the shutdown sequence of the
     /// specified 'socket' has completed. If the specified 'defer' flag is
@@ -1389,7 +1389,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     /// Announce to the specified 'session' the detection of an error for
     /// the specified 'socket'. If the specified 'defer' flag is false and
@@ -1412,7 +1412,7 @@ struct Dispatch {
         const bsl::shared_ptr<ntci::Strand>&              source,
         const bsl::shared_ptr<ntci::Executor>&            executor,
         bool                                              defer,
-        bslmt::Mutex*                                     mutex);
+        ntccfg::Mutex*                                    mutex);
 
     // *** Reactor Socket ***
 

--- a/groups/ntc/ntcs/ntcs_metrics.cpp
+++ b/groups/ntc/ntcs/ntcs_metrics.cpp
@@ -386,7 +386,7 @@ void Metrics::logRxDelay(const bsls::TimeInterval& rxDelay)
 
 void Metrics::getStats(bdld::ManagedDatum* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     bdld::DatumMutableArrayRef array;
     bdld::Datum::createUninitializedArray(&array,

--- a/groups/ntc/ntcs/ntcs_metrics.h
+++ b/groups/ntc/ntcs/ntcs_metrics.h
@@ -41,7 +41,13 @@ namespace ntcs {
 /// @ingroup module_ntcs
 class Metrics : public ntci::Monitorable, public ntccfg::Shared<Metrics>
 {
-    mutable bslmt::Mutex           d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex                  d_mutex;
     ntci::Metric                   d_numBytesSendable;
     ntci::Metric                   d_numBytesSent;
     ntci::Metric                   d_numBytesReceivable;

--- a/groups/ntc/ntcs/ntcs_proactormetrics.cpp
+++ b/groups/ntc/ntcs/ntcs_proactormetrics.cpp
@@ -184,7 +184,7 @@ void ProactorMetrics::logErrorCallback(const bsls::TimeInterval& duration)
 
 void ProactorMetrics::getStats(bdld::ManagedDatum* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     bdld::DatumMutableArrayRef array;
     bdld::Datum::createUninitializedArray(&array,

--- a/groups/ntc/ntcs/ntcs_proactormetrics.h
+++ b/groups/ntc/ntcs/ntcs_proactormetrics.h
@@ -45,7 +45,13 @@ namespace ntcs {
 class ProactorMetrics : public ntci::ProactorMetrics,
                         public ntccfg::Shared<ProactorMetrics>
 {
-    mutable bslmt::Mutex                   d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex                          d_mutex;
     ntci::Metric                           d_numInterrupts;
     ntci::Metric                           d_numReadablePerPoll;
     ntci::Metric                           d_numWritablePerPoll;

--- a/groups/ntc/ntcs/ntcs_processmetrics.cpp
+++ b/groups/ntc/ntcs/ntcs_processmetrics.cpp
@@ -109,7 +109,7 @@ ProcessMetrics::~ProcessMetrics()
 
 void ProcessMetrics::getStats(bdld::ManagedDatum* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     this->collect();
 

--- a/groups/ntc/ntcs/ntcs_processmetrics.h
+++ b/groups/ntc/ntcs/ntcs_processmetrics.h
@@ -42,7 +42,13 @@ namespace ntcs {
 class ProcessMetrics : public ntci::Monitorable,
                        public ntccfg::Shared<ProcessMetrics>
 {
-    mutable bslmt::Mutex d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex        d_mutex;
     ntci::MetricTotal    d_cpuTimeUser;
     ntci::MetricTotal    d_cpuTimeSystem;
     ntci::MetricGauge    d_memoryResident;

--- a/groups/ntc/ntcs/ntcs_reactormetrics.cpp
+++ b/groups/ntc/ntcs/ntcs_reactormetrics.cpp
@@ -184,7 +184,7 @@ void ReactorMetrics::logErrorCallback(const bsls::TimeInterval& duration)
 
 void ReactorMetrics::getStats(bdld::ManagedDatum* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    LockGuard guard(&d_mutex);
 
     bdld::DatumMutableArrayRef array;
     bdld::Datum::createUninitializedArray(&array,

--- a/groups/ntc/ntcs/ntcs_reactormetrics.h
+++ b/groups/ntc/ntcs/ntcs_reactormetrics.h
@@ -45,7 +45,13 @@ namespace ntcs {
 class ReactorMetrics : public ntci::ReactorMetrics,
                        public ntccfg::Shared<ReactorMetrics>
 {
-    mutable bslmt::Mutex                  d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
+    mutable Mutex                         d_mutex;
     ntci::Metric                          d_numInterrupts;
     ntci::Metric                          d_numReadablePerPoll;
     ntci::Metric                          d_numWritablePerPoll;

--- a/groups/ntc/ntcs/ntcs_registry.cpp
+++ b/groups/ntc/ntcs/ntcs_registry.cpp
@@ -163,7 +163,7 @@ bool RegistryEntry::announceDetached(
     }
     if (process) {
         if (NTCCFG_LIKELY(callback)) {
-            callback.dispatch(d_unknown_sp, executor, true, (bslmt::Mutex*) NULL);
+            callback.dispatch(d_unknown_sp, executor, true, NTCCFG_MUTEX_NULL);
         }
     }
     return process;

--- a/groups/ntc/ntcu/ntcu_datagramsocketeventqueue.cpp
+++ b/groups/ntc/ntcu/ntcu_datagramsocketeventqueue.cpp
@@ -53,7 +53,7 @@ void DatagramSocketEventQueue::processReadQueueFlowControlRelaxed(
 
     NTCU_DATAGRAMSOCKETEVENTQUEUE_LOG_EVENT(datagramSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() ==
                 ntca::ReadQueueEventType::e_FLOW_CONTROL_RELAXED);
@@ -74,7 +74,7 @@ void DatagramSocketEventQueue::processReadQueueFlowControlApplied(
 
     NTCU_DATAGRAMSOCKETEVENTQUEUE_LOG_EVENT(datagramSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() ==
                 ntca::ReadQueueEventType::e_FLOW_CONTROL_APPLIED);
@@ -95,7 +95,7 @@ void DatagramSocketEventQueue::processReadQueueLowWatermark(
 
     NTCU_DATAGRAMSOCKETEVENTQUEUE_LOG_EVENT(datagramSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ReadQueueEventType::e_LOW_WATERMARK);
 
@@ -115,7 +115,7 @@ void DatagramSocketEventQueue::processReadQueueHighWatermark(
 
     NTCU_DATAGRAMSOCKETEVENTQUEUE_LOG_EVENT(datagramSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ReadQueueEventType::e_HIGH_WATERMARK);
 
@@ -135,7 +135,7 @@ void DatagramSocketEventQueue::processReadQueueDiscarded(
 
     NTCU_DATAGRAMSOCKETEVENTQUEUE_LOG_EVENT(datagramSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ReadQueueEventType::e_DISCARDED);
 
@@ -155,7 +155,7 @@ void DatagramSocketEventQueue::processWriteQueueFlowControlRelaxed(
 
     NTCU_DATAGRAMSOCKETEVENTQUEUE_LOG_EVENT(datagramSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() ==
                 ntca::WriteQueueEventType::e_FLOW_CONTROL_RELAXED);
@@ -176,7 +176,7 @@ void DatagramSocketEventQueue::processWriteQueueFlowControlApplied(
 
     NTCU_DATAGRAMSOCKETEVENTQUEUE_LOG_EVENT(datagramSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() ==
                 ntca::WriteQueueEventType::e_FLOW_CONTROL_APPLIED);
@@ -197,7 +197,7 @@ void DatagramSocketEventQueue::processWriteQueueLowWatermark(
 
     NTCU_DATAGRAMSOCKETEVENTQUEUE_LOG_EVENT(datagramSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::WriteQueueEventType::e_LOW_WATERMARK);
 
@@ -217,7 +217,7 @@ void DatagramSocketEventQueue::processWriteQueueHighWatermark(
 
     NTCU_DATAGRAMSOCKETEVENTQUEUE_LOG_EVENT(datagramSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::WriteQueueEventType::e_HIGH_WATERMARK);
 
@@ -237,7 +237,7 @@ void DatagramSocketEventQueue::processWriteQueueDiscarded(
 
     NTCU_DATAGRAMSOCKETEVENTQUEUE_LOG_EVENT(datagramSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::WriteQueueEventType::e_DISCARDED);
 
@@ -257,7 +257,7 @@ void DatagramSocketEventQueue::processShutdownInitiated(
 
     NTCU_DATAGRAMSOCKETEVENTQUEUE_LOG_EVENT(datagramSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ShutdownEventType::e_INITIATED);
 
@@ -277,7 +277,7 @@ void DatagramSocketEventQueue::processShutdownReceive(
 
     NTCU_DATAGRAMSOCKETEVENTQUEUE_LOG_EVENT(datagramSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ShutdownEventType::e_RECEIVE);
 
@@ -297,7 +297,7 @@ void DatagramSocketEventQueue::processShutdownSend(
 
     NTCU_DATAGRAMSOCKETEVENTQUEUE_LOG_EVENT(datagramSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ShutdownEventType::e_SEND);
 
@@ -317,7 +317,7 @@ void DatagramSocketEventQueue::processShutdownComplete(
 
     NTCU_DATAGRAMSOCKETEVENTQUEUE_LOG_EVENT(datagramSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ShutdownEventType::e_COMPLETE);
 
@@ -337,7 +337,7 @@ void DatagramSocketEventQueue::processError(
 
     NTCU_DATAGRAMSOCKETEVENTQUEUE_LOG_EVENT(datagramSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (!d_closed && this->want(event.type())) {
         d_queue.push_back(ntca::DatagramSocketEvent(event));
@@ -540,7 +540,7 @@ void DatagramSocketEventQueue::hide(ntca::ErrorEventType::Value type)
 
 ntsa::Error DatagramSocketEventQueue::wait(ntca::DatagramSocketEvent* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (!d_closed && d_queue.empty()) {
         d_condition.wait(&d_mutex);
@@ -559,7 +559,7 @@ ntsa::Error DatagramSocketEventQueue::wait(ntca::DatagramSocketEvent* result)
 ntsa::Error DatagramSocketEventQueue::wait(ntca::DatagramSocketEvent* result,
                                            const bsls::TimeInterval&  timeout)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (!d_closed && d_queue.empty()) {
         int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -587,7 +587,7 @@ ntsa::Error DatagramSocketEventQueue::wait(ntca::DatagramSocketEvent* result,
 ntsa::Error DatagramSocketEventQueue::wait(ntca::ReadQueueEvent* result)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -612,7 +612,7 @@ ntsa::Error DatagramSocketEventQueue::wait(ntca::ReadQueueEvent*     result,
                                            const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -647,7 +647,7 @@ ntsa::Error DatagramSocketEventQueue::wait(
     ntca::ReadQueueEventType::Value type)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -676,7 +676,7 @@ ntsa::Error DatagramSocketEventQueue::wait(
     const bsls::TimeInterval&       timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -711,7 +711,7 @@ ntsa::Error DatagramSocketEventQueue::wait(
 ntsa::Error DatagramSocketEventQueue::wait(ntca::WriteQueueEvent* result)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -736,7 +736,7 @@ ntsa::Error DatagramSocketEventQueue::wait(ntca::WriteQueueEvent*    result,
                                            const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -771,7 +771,7 @@ ntsa::Error DatagramSocketEventQueue::wait(
     ntca::WriteQueueEventType::Value type)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -800,7 +800,7 @@ ntsa::Error DatagramSocketEventQueue::wait(
     const bsls::TimeInterval&        timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -835,7 +835,7 @@ ntsa::Error DatagramSocketEventQueue::wait(
 ntsa::Error DatagramSocketEventQueue::wait(ntca::ShutdownEvent* result)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -860,7 +860,7 @@ ntsa::Error DatagramSocketEventQueue::wait(ntca::ShutdownEvent*      result,
                                            const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -894,7 +894,7 @@ ntsa::Error DatagramSocketEventQueue::wait(ntca::ShutdownEvent* result,
                                            ntca::ShutdownEventType::Value type)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -922,7 +922,7 @@ ntsa::Error DatagramSocketEventQueue::wait(ntca::ShutdownEvent* result,
                                            const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -957,7 +957,7 @@ ntsa::Error DatagramSocketEventQueue::wait(ntca::ShutdownEvent* result,
 ntsa::Error DatagramSocketEventQueue::wait(ntca::ErrorEvent* result)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -982,7 +982,7 @@ ntsa::Error DatagramSocketEventQueue::wait(ntca::ErrorEvent*         result,
                                            const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -1016,7 +1016,7 @@ ntsa::Error DatagramSocketEventQueue::wait(ntca::ErrorEvent*           result,
                                            ntca::ErrorEventType::Value type)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -1042,7 +1042,7 @@ ntsa::Error DatagramSocketEventQueue::wait(ntca::ErrorEvent*           result,
                                            const bsls::TimeInterval&   timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -1074,7 +1074,7 @@ ntsa::Error DatagramSocketEventQueue::wait(ntca::ErrorEvent*           result,
 
 void DatagramSocketEventQueue::close()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (!d_closed) {
         d_closed = true;

--- a/groups/ntc/ntcu/ntcu_datagramsocketeventqueue.h
+++ b/groups/ntc/ntcu/ntcu_datagramsocketeventqueue.h
@@ -51,6 +51,12 @@ class DatagramSocketEventQueue : public ntci::DatagramSocketSession
     /// Define a type alias for a queue of events.
     typedef bsl::list<ntca::DatagramSocketEvent> Queue;
 
+    /// Define a type alias for a mutex.
+    typedef ntccfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntccfg::LockGuard LockGuard;
+
     enum Constant {
         // This enumeration defines the constants used by this class.
 
@@ -58,8 +64,8 @@ class DatagramSocketEventQueue : public ntci::DatagramSocketSession
         k_NUM_EVENT_TYPES = 6
     };
 
-    bslmt::Mutex                  d_mutex;
-    bslmt::Condition              d_condition;
+    ntccfg::ConditionMutex        d_mutex;
+    ntccfg::Condition             d_condition;
     Queue                         d_queue;
     bsl::uint32_t                 d_interest[k_NUM_EVENT_TYPES];
     bool                          d_closed;

--- a/groups/ntc/ntcu/ntcu_listenersocketeventqueue.cpp
+++ b/groups/ntc/ntcu/ntcu_listenersocketeventqueue.cpp
@@ -52,7 +52,7 @@ void ListenerSocketEventQueue::processAcceptQueueFlowControlRelaxed(
 
     NTCU_LISTENERSOCKETEVENTQUEUE_LOG_EVENT(listenerSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() ==
                 ntca::AcceptQueueEventType::e_FLOW_CONTROL_RELAXED);
@@ -73,7 +73,7 @@ void ListenerSocketEventQueue::processAcceptQueueFlowControlApplied(
 
     NTCU_LISTENERSOCKETEVENTQUEUE_LOG_EVENT(listenerSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() ==
                 ntca::AcceptQueueEventType::e_FLOW_CONTROL_APPLIED);
@@ -94,7 +94,7 @@ void ListenerSocketEventQueue::processAcceptQueueLowWatermark(
 
     NTCU_LISTENERSOCKETEVENTQUEUE_LOG_EVENT(listenerSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::AcceptQueueEventType::e_LOW_WATERMARK);
 
@@ -114,7 +114,7 @@ void ListenerSocketEventQueue::processAcceptQueueHighWatermark(
 
     NTCU_LISTENERSOCKETEVENTQUEUE_LOG_EVENT(listenerSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::AcceptQueueEventType::e_HIGH_WATERMARK);
 
@@ -134,7 +134,7 @@ void ListenerSocketEventQueue::processAcceptQueueDiscarded(
 
     NTCU_LISTENERSOCKETEVENTQUEUE_LOG_EVENT(listenerSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::AcceptQueueEventType::e_DISCARDED);
 
@@ -154,7 +154,7 @@ void ListenerSocketEventQueue::processShutdownInitiated(
 
     NTCU_LISTENERSOCKETEVENTQUEUE_LOG_EVENT(listenerSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ShutdownEventType::e_INITIATED);
 
@@ -174,7 +174,7 @@ void ListenerSocketEventQueue::processShutdownReceive(
 
     NTCU_LISTENERSOCKETEVENTQUEUE_LOG_EVENT(listenerSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ShutdownEventType::e_RECEIVE);
 
@@ -194,7 +194,7 @@ void ListenerSocketEventQueue::processShutdownSend(
 
     NTCU_LISTENERSOCKETEVENTQUEUE_LOG_EVENT(listenerSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ShutdownEventType::e_SEND);
 
@@ -214,7 +214,7 @@ void ListenerSocketEventQueue::processShutdownComplete(
 
     NTCU_LISTENERSOCKETEVENTQUEUE_LOG_EVENT(listenerSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ShutdownEventType::e_COMPLETE);
 
@@ -234,7 +234,7 @@ void ListenerSocketEventQueue::processError(
 
     NTCU_LISTENERSOCKETEVENTQUEUE_LOG_EVENT(listenerSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (!d_closed && this->want(event.type())) {
         d_queue.push_back(ntca::ListenerSocketEvent(event));
@@ -402,7 +402,7 @@ void ListenerSocketEventQueue::hide(ntca::ErrorEventType::Value type)
 
 ntsa::Error ListenerSocketEventQueue::wait(ntca::ListenerSocketEvent* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (!d_closed && d_queue.empty()) {
         d_condition.wait(&d_mutex);
@@ -421,7 +421,7 @@ ntsa::Error ListenerSocketEventQueue::wait(ntca::ListenerSocketEvent* result)
 ntsa::Error ListenerSocketEventQueue::wait(ntca::ListenerSocketEvent* result,
                                            const bsls::TimeInterval&  timeout)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (!d_closed && d_queue.empty()) {
         int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -449,7 +449,7 @@ ntsa::Error ListenerSocketEventQueue::wait(ntca::ListenerSocketEvent* result,
 ntsa::Error ListenerSocketEventQueue::wait(ntca::AcceptQueueEvent* result)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -474,7 +474,7 @@ ntsa::Error ListenerSocketEventQueue::wait(ntca::AcceptQueueEvent*   result,
                                            const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -509,7 +509,7 @@ ntsa::Error ListenerSocketEventQueue::wait(
     ntca::AcceptQueueEventType::Value type)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -538,7 +538,7 @@ ntsa::Error ListenerSocketEventQueue::wait(
     const bsls::TimeInterval&         timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -573,7 +573,7 @@ ntsa::Error ListenerSocketEventQueue::wait(
 ntsa::Error ListenerSocketEventQueue::wait(ntca::ShutdownEvent* result)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -598,7 +598,7 @@ ntsa::Error ListenerSocketEventQueue::wait(ntca::ShutdownEvent*      result,
                                            const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -632,7 +632,7 @@ ntsa::Error ListenerSocketEventQueue::wait(ntca::ShutdownEvent* result,
                                            ntca::ShutdownEventType::Value type)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -660,7 +660,7 @@ ntsa::Error ListenerSocketEventQueue::wait(ntca::ShutdownEvent* result,
                                            const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -695,7 +695,7 @@ ntsa::Error ListenerSocketEventQueue::wait(ntca::ShutdownEvent* result,
 ntsa::Error ListenerSocketEventQueue::wait(ntca::ErrorEvent* result)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -720,7 +720,7 @@ ntsa::Error ListenerSocketEventQueue::wait(ntca::ErrorEvent*         result,
                                            const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -754,7 +754,7 @@ ntsa::Error ListenerSocketEventQueue::wait(ntca::ErrorEvent*           result,
                                            ntca::ErrorEventType::Value type)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -780,7 +780,7 @@ ntsa::Error ListenerSocketEventQueue::wait(ntca::ErrorEvent*           result,
                                            const bsls::TimeInterval&   timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -812,7 +812,7 @@ ntsa::Error ListenerSocketEventQueue::wait(ntca::ErrorEvent*           result,
 
 void ListenerSocketEventQueue::close()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (!d_closed) {
         d_closed = true;

--- a/groups/ntc/ntcu/ntcu_listenersocketeventqueue.h
+++ b/groups/ntc/ntcu/ntcu_listenersocketeventqueue.h
@@ -58,8 +58,8 @@ class ListenerSocketEventQueue : public ntci::ListenerSocketSession
         k_NUM_EVENT_TYPES = 4
     };
 
-    bslmt::Mutex                  d_mutex;
-    bslmt::Condition              d_condition;
+    ntccfg::ConditionMutex        d_mutex;
+    ntccfg::Condition             d_condition;
     Queue                         d_queue;
     bsl::uint32_t                 d_interest[k_NUM_EVENT_TYPES];
     bool                          d_closed;

--- a/groups/ntc/ntcu/ntcu_streamsocketeventqueue.cpp
+++ b/groups/ntc/ntcu/ntcu_streamsocketeventqueue.cpp
@@ -53,7 +53,7 @@ void StreamSocketEventQueue::processReadQueueFlowControlRelaxed(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() ==
                 ntca::ReadQueueEventType::e_FLOW_CONTROL_RELAXED);
@@ -74,7 +74,7 @@ void StreamSocketEventQueue::processReadQueueFlowControlApplied(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() ==
                 ntca::ReadQueueEventType::e_FLOW_CONTROL_APPLIED);
@@ -95,7 +95,7 @@ void StreamSocketEventQueue::processReadQueueLowWatermark(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ReadQueueEventType::e_LOW_WATERMARK);
 
@@ -115,7 +115,7 @@ void StreamSocketEventQueue::processReadQueueHighWatermark(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ReadQueueEventType::e_HIGH_WATERMARK);
 
@@ -135,7 +135,7 @@ void StreamSocketEventQueue::processReadQueueDiscarded(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ReadQueueEventType::e_DISCARDED);
 
@@ -155,7 +155,7 @@ void StreamSocketEventQueue::processWriteQueueFlowControlRelaxed(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() ==
                 ntca::WriteQueueEventType::e_FLOW_CONTROL_RELAXED);
@@ -176,7 +176,7 @@ void StreamSocketEventQueue::processWriteQueueFlowControlApplied(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() ==
                 ntca::WriteQueueEventType::e_FLOW_CONTROL_APPLIED);
@@ -197,7 +197,7 @@ void StreamSocketEventQueue::processWriteQueueLowWatermark(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::WriteQueueEventType::e_LOW_WATERMARK);
 
@@ -217,7 +217,7 @@ void StreamSocketEventQueue::processWriteQueueHighWatermark(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::WriteQueueEventType::e_HIGH_WATERMARK);
 
@@ -237,7 +237,7 @@ void StreamSocketEventQueue::processWriteQueueDiscarded(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::WriteQueueEventType::e_DISCARDED);
 
@@ -257,7 +257,7 @@ void StreamSocketEventQueue::processDowngradeInitiated(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::DowngradeEventType::e_INITIATED);
 
@@ -277,7 +277,7 @@ void StreamSocketEventQueue::processDowngradeComplete(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::DowngradeEventType::e_COMPLETE);
 
@@ -297,7 +297,7 @@ void StreamSocketEventQueue::processShutdownInitiated(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ShutdownEventType::e_INITIATED);
 
@@ -317,7 +317,7 @@ void StreamSocketEventQueue::processShutdownReceive(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ShutdownEventType::e_RECEIVE);
 
@@ -337,7 +337,7 @@ void StreamSocketEventQueue::processShutdownSend(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ShutdownEventType::e_SEND);
 
@@ -357,7 +357,7 @@ void StreamSocketEventQueue::processShutdownComplete(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     BSLS_ASSERT(event.type() == ntca::ShutdownEventType::e_COMPLETE);
 
@@ -377,7 +377,7 @@ void StreamSocketEventQueue::processError(
 
     NTCU_STREAMSOCKETEVENTQUEUE_LOG_EVENT(streamSocket, event);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (!d_closed && this->want(event.type())) {
         d_queue.push_back(ntca::StreamSocketEvent(event));
@@ -613,7 +613,7 @@ void StreamSocketEventQueue::hide(ntca::ErrorEventType::Value type)
 
 ntsa::Error StreamSocketEventQueue::wait(ntca::StreamSocketEvent* result)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (!d_closed && d_queue.empty()) {
         d_condition.wait(&d_mutex);
@@ -632,7 +632,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::StreamSocketEvent* result)
 ntsa::Error StreamSocketEventQueue::wait(ntca::StreamSocketEvent*  result,
                                          const bsls::TimeInterval& timeout)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     while (!d_closed && d_queue.empty()) {
         int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -660,7 +660,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::StreamSocketEvent*  result,
 ntsa::Error StreamSocketEventQueue::wait(ntca::ReadQueueEvent* result)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -685,7 +685,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::ReadQueueEvent*     result,
                                          const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -719,7 +719,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::ReadQueueEvent* result,
                                          ntca::ReadQueueEventType::Value type)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -747,7 +747,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::ReadQueueEvent* result,
                                          const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -782,7 +782,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::ReadQueueEvent* result,
 ntsa::Error StreamSocketEventQueue::wait(ntca::WriteQueueEvent* result)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -807,7 +807,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::WriteQueueEvent*    result,
                                          const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -841,7 +841,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::WriteQueueEvent* result,
                                          ntca::WriteQueueEventType::Value type)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -869,7 +869,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::WriteQueueEvent* result,
                                          const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -904,7 +904,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::WriteQueueEvent* result,
 ntsa::Error StreamSocketEventQueue::wait(ntca::DowngradeEvent* result)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -929,7 +929,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::DowngradeEvent*     result,
                                          const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -963,7 +963,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::DowngradeEvent* result,
                                          ntca::DowngradeEventType::Value type)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -991,7 +991,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::DowngradeEvent* result,
                                          const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -1026,7 +1026,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::DowngradeEvent* result,
 ntsa::Error StreamSocketEventQueue::wait(ntca::ShutdownEvent* result)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -1051,7 +1051,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::ShutdownEvent*      result,
                                          const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -1085,7 +1085,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::ShutdownEvent*           result,
                                          ntca::ShutdownEventType::Value type)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -1113,7 +1113,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::ShutdownEvent*           result,
                                          const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -1148,7 +1148,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::ShutdownEvent*           result,
 ntsa::Error StreamSocketEventQueue::wait(ntca::ErrorEvent* result)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -1173,7 +1173,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::ErrorEvent*         result,
                                          const bsls::TimeInterval& timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -1207,7 +1207,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::ErrorEvent*           result,
                                          ntca::ErrorEventType::Value type)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             d_condition.wait(&d_mutex);
@@ -1233,7 +1233,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::ErrorEvent*           result,
                                          const bsls::TimeInterval&   timeout)
 {
     while (true) {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntccfg::ConditionMutexGuard lock(&d_mutex);
 
         while (!d_closed && d_queue.empty()) {
             int rc = d_condition.timedWait(&d_mutex, timeout);
@@ -1265,7 +1265,7 @@ ntsa::Error StreamSocketEventQueue::wait(ntca::ErrorEvent*           result,
 
 void StreamSocketEventQueue::close()
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntccfg::ConditionMutexGuard lock(&d_mutex);
 
     if (!d_closed) {
         d_closed = true;

--- a/groups/ntc/ntcu/ntcu_streamsocketeventqueue.h
+++ b/groups/ntc/ntcu/ntcu_streamsocketeventqueue.h
@@ -58,8 +58,8 @@ class StreamSocketEventQueue : public ntci::StreamSocketSession
         k_NUM_EVENT_TYPES = 6
     };
 
-    bslmt::Mutex                  d_mutex;
-    bslmt::Condition              d_condition;
+    ntccfg::ConditionMutex        d_mutex;
+    ntccfg::Condition             d_condition;
     Queue                         d_queue;
     bsl::uint32_t                 d_interest[k_NUM_EVENT_TYPES];
     bool                          d_closed;

--- a/groups/nts/ntsb/ntsb_controller.cpp
+++ b/groups/nts/ntsb/ntsb_controller.cpp
@@ -250,7 +250,7 @@ ntsa::Error Controller::interrupt(unsigned int numWakeups)
 #if NTSB_CONTROLLER_IMP == NTSB_CONTROLLER_IMP_TCP_SOCKET ||                  \
     NTSB_CONTROLLER_IMP == NTSB_CONTROLLER_IMP_UNIX_DOMAIN_SOCKET
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (numWakeups <= d_pending) {
         return ntsa::Error();
@@ -295,7 +295,7 @@ ntsa::Error Controller::interrupt(unsigned int numWakeups)
 
 #elif NTSB_CONTROLLER_IMP == NTSB_CONTROLLER_IMP_ANONYMOUS_PIPE
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (numWakeups <= d_pending) {
         return ntsa::Error();
@@ -335,7 +335,7 @@ ntsa::Error Controller::interrupt(unsigned int numWakeups)
 
 #elif NTSB_CONTROLLER_IMP == NTSB_CONTROLLER_IMP_EVENTFD
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     if (numWakeups <= d_pending) {
         return ntsa::Error();
@@ -385,7 +385,7 @@ ntsa::Error Controller::acknowledge()
 #if NTSB_CONTROLLER_IMP == NTSB_CONTROLLER_IMP_TCP_SOCKET ||                  \
     NTSB_CONTROLLER_IMP == NTSB_CONTROLLER_IMP_UNIX_DOMAIN_SOCKET
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     char buffer;
 
@@ -415,7 +415,7 @@ ntsa::Error Controller::acknowledge()
 
 #elif NTSB_CONTROLLER_IMP == NTSB_CONTROLLER_IMP_ANONYMOUS_PIPE
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     char        buffer;
     bsl::size_t bytesRead = 0;
@@ -445,7 +445,7 @@ ntsa::Error Controller::acknowledge()
 
 #elif NTSB_CONTROLLER_IMP == NTSB_CONTROLLER_IMP_EVENTFD
 
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    LockGuard lock(&d_mutex);
 
     bsl::uint64_t value = 0;
 

--- a/groups/nts/ntsb/ntsb_controller.h
+++ b/groups/nts/ntsb/ntsb_controller.h
@@ -38,7 +38,13 @@ namespace ntsb {
 /// @ingroup module_ntsb
 class Controller
 {
-    bslmt::Mutex d_mutex;
+    /// Define a type alias for a mutex.
+    typedef ntscfg::Mutex Mutex;
+
+    /// Define a type alias for a mutex lock guard.
+    typedef ntscfg::LockGuard LockGuard;
+
+    Mutex        d_mutex;
     ntsa::Handle d_clientHandle;
     ntsa::Handle d_serverHandle;
     bsl::size_t  d_pending;

--- a/groups/nts/ntsb/ntsb_resolver.cpp
+++ b/groups/nts/ntsb/ntsb_resolver.cpp
@@ -52,7 +52,7 @@ ntsa::Error ResolverOverrides::setIpAddress(
     const bslstl::StringRef&            domainName,
     const bsl::vector<ntsa::IpAddress>& ipAddressList)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntscfg::LockGuard lock(&d_mutex);
 
     IpAddressVector& target = d_ipAddressByDomainName[domainName];
 
@@ -82,7 +82,7 @@ ntsa::Error ResolverOverrides::addIpAddress(
     const bslstl::StringRef&            domainName,
     const bsl::vector<ntsa::IpAddress>& ipAddressList)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntscfg::LockGuard lock(&d_mutex);
 
     IpAddressVector& target = d_ipAddressByDomainName[domainName];
 
@@ -103,7 +103,7 @@ ntsa::Error ResolverOverrides::addIpAddress(
     const bslstl::StringRef& domainName,
     const ntsa::IpAddress&   ipAddress)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntscfg::LockGuard lock(&d_mutex);
 
     IpAddressVector& target = d_ipAddressByDomainName[domainName];
     target.push_back(ipAddress);
@@ -116,7 +116,7 @@ ntsa::Error ResolverOverrides::setPort(const bslstl::StringRef& serviceName,
                                        const bsl::vector<ntsa::Port>& portList,
                                        ntsa::Transport::Value transport)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntscfg::LockGuard lock(&d_mutex);
 
     if (transport == ntsa::Transport::e_TCP_IPV4_STREAM ||
         transport == ntsa::Transport::e_TCP_IPV6_STREAM)
@@ -175,7 +175,7 @@ ntsa::Error ResolverOverrides::addPort(const bslstl::StringRef& serviceName,
                                        const bsl::vector<ntsa::Port>& portList,
                                        ntsa::Transport::Value transport)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntscfg::LockGuard lock(&d_mutex);
 
     if (transport == ntsa::Transport::e_TCP_IPV4_STREAM ||
         transport == ntsa::Transport::e_TCP_IPV6_STREAM)
@@ -216,7 +216,7 @@ ntsa::Error ResolverOverrides::addPort(const bslstl::StringRef& serviceName,
                                        ntsa::Port               port,
                                        ntsa::Transport::Value   transport)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntscfg::LockGuard lock(&d_mutex);
 
     if (transport == ntsa::Transport::e_TCP_IPV4_STREAM ||
         transport == ntsa::Transport::e_TCP_IPV6_STREAM)
@@ -242,14 +242,14 @@ ntsa::Error ResolverOverrides::addPort(const bslstl::StringRef& serviceName,
 ntsa::Error ResolverOverrides::setLocalIpAddress(
     const bsl::vector<ntsa::IpAddress>& ipAddressList)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntscfg::LockGuard lock(&d_mutex);
     d_localIpAddressList = ipAddressList;
     return ntsa::Error();
 }
 
 ntsa::Error ResolverOverrides::setHostname(const bsl::string& name)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntscfg::LockGuard lock(&d_mutex);
     d_hostname = name;
     return ntsa::Error();
 }
@@ -257,7 +257,7 @@ ntsa::Error ResolverOverrides::setHostname(const bsl::string& name)
 ntsa::Error ResolverOverrides::setHostnameFullyQualified(
     const bsl::string& name)
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntscfg::LockGuard lock(&d_mutex);
     d_hostnameFullyQualified = name;
     return ntsa::Error();
 }
@@ -279,7 +279,7 @@ ntsa::Error ResolverOverrides::getIpAddress(
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntscfg::LockGuard lock(&d_mutex);
 
         IpAddressByDomainName::const_iterator it =
             d_ipAddressByDomainName.find(domainName);
@@ -326,7 +326,7 @@ ntsa::Error ResolverOverrides::getDomainName(
     bsl::string*           result,
     const ntsa::IpAddress& ipAddress) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntscfg::LockGuard lock(&d_mutex);
 
     DomainNameByIpAddress::const_iterator it =
         d_domainNameByIpAddress.find(ipAddress);
@@ -380,7 +380,7 @@ ntsa::Error ResolverOverrides::getPort(bsl::vector<ntsa::Port>* result,
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntscfg::LockGuard lock(&d_mutex);
 
         if (examineTcpPortList) {
             PortByServiceName::const_iterator it =
@@ -425,7 +425,7 @@ ntsa::Error ResolverOverrides::getServiceName(
     ntsa::Port             port,
     ntsa::Transport::Value transport) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntscfg::LockGuard lock(&d_mutex);
 
     bool found = false;
 
@@ -486,7 +486,7 @@ ntsa::Error ResolverOverrides::getLocalIpAddress(
     }
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        ntscfg::LockGuard lock(&d_mutex);
 
         if (ipAddressType.isNull()) {
             ipAddressList = d_localIpAddressList;
@@ -523,7 +523,7 @@ ntsa::Error ResolverOverrides::getLocalIpAddress(
 
 ntsa::Error ResolverOverrides::getHostname(bsl::string* result) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntscfg::LockGuard lock(&d_mutex);
 
     if (d_hostname.isNull()) {
         return ntsa::Error(ntsa::Error::e_EOF);
@@ -536,7 +536,7 @@ ntsa::Error ResolverOverrides::getHostname(bsl::string* result) const
 ntsa::Error ResolverOverrides::getHostnameFullyQualified(
     bsl::string* result) const
 {
-    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    ntscfg::LockGuard lock(&d_mutex);
 
     if (d_hostnameFullyQualified.isNull()) {
         return ntsa::Error(ntsa::Error::e_EOF);

--- a/groups/nts/ntsb/ntsb_resolver.h
+++ b/groups/nts/ntsb/ntsb_resolver.h
@@ -69,7 +69,7 @@ class ResolverOverrides
     /// service names.
     typedef bsl::unordered_map<ntsa::Port, bsl::string> ServiceNameByPort;
 
-    mutable bslmt::Mutex             d_mutex;
+    mutable ntscfg::Mutex            d_mutex;
     IpAddressByDomainName            d_ipAddressByDomainName;
     DomainNameByIpAddress            d_domainNameByIpAddress;
     PortByServiceName                d_tcpPortByServiceName;

--- a/groups/nts/ntscfg/ntscfg_platform.h
+++ b/groups/nts/ntscfg/ntscfg_platform.h
@@ -22,6 +22,8 @@ BSLS_IDENT("$Id: $")
 #include <ntscfg_config.h>
 #include <ntsscm_version.h>
 #include <bslalg_typetraits.h>
+#include <bslmt_lockguard.h>
+#include <bslmt_mutex.h>
 #include <bsls_assert.h>
 #include <bsls_keyword.h>
 #include <bsls_log.h>
@@ -283,6 +285,27 @@ NTSCFG_INLINE bsl::shared_ptr<TYPE> Shared<TYPE>::getSelf(TYPE* self)
 
     return sharedSelf;
 }
+
+/// @internal @brief
+/// Provide a synchronization primitive for mutually-exclusive access.
+///
+/// @par Thread Safety
+/// This class is thread safe.
+///
+/// @ingroup module_ntscfg
+typedef bslmt::Mutex Mutex;
+
+/// @internal @brief
+/// Define a type alias for a guard to lock and unlock a mutex.
+///
+/// @ingroup module_ntscfg
+typedef bslmt::LockGuard<bslmt::Mutex> LockGuard;
+
+/// @internal @brief
+/// Define a type alias for a guard to unlock and lock a mutex.
+///
+/// @ingroup module_ntscfg
+typedef bslmt::UnLockGuard<bslmt::Mutex> UnLockGuard;
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/groups/nts/ntsf/ntsf_system.cpp
+++ b/groups/nts/ntsf/ntsf_system.cpp
@@ -51,7 +51,7 @@ namespace ntsf {
 namespace {
 
 bslma::Allocator*    s_globalAllocator_p;
-bslmt::Mutex*        s_globalMutex_p;
+ntscfg::Mutex*       s_globalMutex_p;
 ntsi::Resolver*      s_globalResolver_p;
 bslma::SharedPtrRep* s_globalResolverRep_p;
 
@@ -73,7 +73,7 @@ ntsa::Error System::initialize()
 
         s_globalAllocator_p = &bslma::NewDeleteAllocator::singleton();
 
-        s_globalMutex_p = new (*s_globalAllocator_p) bslmt::Mutex();
+        s_globalMutex_p = new (*s_globalAllocator_p) ntscfg::Mutex();
 
         bsl::atexit(&System::exit);
     }
@@ -1207,7 +1207,7 @@ void System::setDefault(const bsl::shared_ptr<ntsi::Resolver>& resolver)
 
     bsl::shared_ptr<ntsi::Resolver> result;
 
-    bslmt::LockGuard<bslmt::Mutex> lock(s_globalMutex_p);
+    ntscfg::LockGuard lock(s_globalMutex_p);
 
     if (s_globalResolver_p != 0) {
         BSLS_ASSERT_OPT(s_globalResolverRep_p);
@@ -1242,7 +1242,7 @@ void System::getDefault(bsl::shared_ptr<ntsi::Resolver>* result)
     error = ntsf::System::initialize();
     BSLS_ASSERT_OPT(!error);
 
-    bslmt::LockGuard<bslmt::Mutex> lock(s_globalMutex_p);
+    ntscfg::LockGuard lock(s_globalMutex_p);
 
     if (NTSCFG_UNLIKELY(s_globalResolver_p == 0)) {
         BSLS_ASSERT_OPT(s_globalAllocator_p);


### PR DESCRIPTION
This PR enables the near universal selection of the implementation of all mutexes used in the code through ./configure options.