### PR TITLE
Define move and nothrow semantics for ntsa::Ipv4Address and ntsa::TcpCongestionControl

### DIFF
--- a/groups/nts/ntsa/ntsa_ipv4address.cpp
+++ b/groups/nts/ntsa/ntsa_ipv4address.cpp
@@ -74,7 +74,7 @@ Ipv4Address& Ipv4Address::operator=(const bslstl::StringRef& text)
     return *this;
 }
 
-bool Ipv4Address::parse(const bslstl::StringRef& text)
+bool Ipv4Address::parse(const bslstl::StringRef& text) NTSCFG_NOEXCEPT
 {
     BSLMF_ASSERT(sizeof d_value == 4);
     BSLMF_ASSERT(sizeof *this == 4);
@@ -135,7 +135,7 @@ bool Ipv4Address::parse(const bslstl::StringRef& text)
     return true;
 }
 
-bsl::size_t Ipv4Address::copyFrom(const void* source, bsl::size_t size)
+bsl::size_t Ipv4Address::copyFrom(const void* source, bsl::size_t size) NTSCFG_NOEXCEPT
 {
     if (!checkIpv4BufferUnderflow(size)) {
         return 0;
@@ -145,7 +145,7 @@ bsl::size_t Ipv4Address::copyFrom(const void* source, bsl::size_t size)
     return sizeof d_value;
 }
 
-bsl::size_t Ipv4Address::copyTo(void* destination, bsl::size_t capacity) const
+bsl::size_t Ipv4Address::copyTo(void* destination, bsl::size_t capacity) const NTSCFG_NOEXCEPT
 {
     if (!checkIpv4BufferOverflow(capacity)) {
         return 0;
@@ -155,7 +155,7 @@ bsl::size_t Ipv4Address::copyTo(void* destination, bsl::size_t capacity) const
     return sizeof d_value;
 }
 
-bsl::size_t Ipv4Address::format(char* buffer, bsl::size_t capacity) const
+bsl::size_t Ipv4Address::format(char* buffer, bsl::size_t capacity) const NTSCFG_NOEXCEPT
 {
     if (capacity < ntsa::Ipv4Address::MAX_TEXT_LENGTH + 1) {
         if (capacity > 0) {
@@ -206,14 +206,14 @@ bsl::size_t Ipv4Address::format(char* buffer, bsl::size_t capacity) const
     return count;
 }
 
-Ipv4Address Ipv4Address::any()
+Ipv4Address Ipv4Address::any() NTSCFG_NOEXCEPT
 {
     Ipv4Address result;
     result.d_value.d_asDword = 0;
     return result;
 }
 
-Ipv4Address Ipv4Address::loopback()
+Ipv4Address Ipv4Address::loopback() NTSCFG_NOEXCEPT
 {
     Ipv4Address result;
 #if defined(BSLS_PLATFORM_IS_BIG_ENDIAN)

--- a/groups/nts/ntsa/ntsa_ipv4address.cpp
+++ b/groups/nts/ntsa/ntsa_ipv4address.cpp
@@ -135,7 +135,8 @@ bool Ipv4Address::parse(const bslstl::StringRef& text) NTSCFG_NOEXCEPT
     return true;
 }
 
-bsl::size_t Ipv4Address::copyFrom(const void* source, bsl::size_t size) NTSCFG_NOEXCEPT
+bsl::size_t Ipv4Address::copyFrom(const void* source,
+                                  bsl::size_t size) NTSCFG_NOEXCEPT
 {
     if (!checkIpv4BufferUnderflow(size)) {
         return 0;
@@ -145,7 +146,8 @@ bsl::size_t Ipv4Address::copyFrom(const void* source, bsl::size_t size) NTSCFG_N
     return sizeof d_value;
 }
 
-bsl::size_t Ipv4Address::copyTo(void* destination, bsl::size_t capacity) const NTSCFG_NOEXCEPT
+bsl::size_t Ipv4Address::copyTo(void*       destination,
+                                bsl::size_t capacity) const NTSCFG_NOEXCEPT
 {
     if (!checkIpv4BufferOverflow(capacity)) {
         return 0;
@@ -155,7 +157,8 @@ bsl::size_t Ipv4Address::copyTo(void* destination, bsl::size_t capacity) const N
     return sizeof d_value;
 }
 
-bsl::size_t Ipv4Address::format(char* buffer, bsl::size_t capacity) const NTSCFG_NOEXCEPT
+bsl::size_t Ipv4Address::format(char*       buffer,
+                                bsl::size_t capacity) const NTSCFG_NOEXCEPT
 {
     if (capacity < ntsa::Ipv4Address::MAX_TEXT_LENGTH + 1) {
         if (capacity > 0) {

--- a/groups/nts/ntsa/ntsa_ipv4address.h
+++ b/groups/nts/ntsa/ntsa_ipv4address.h
@@ -32,8 +32,8 @@ namespace ntsa {
 /// Provide an Internet Protocol version 4 address.
 ///
 /// @details
-/// Provide a value-semantic type that represents an Internet
-/// Protocol version 4 address.
+/// This class is value-semantic type that represents an Internet Protocol
+/// version 4 address.
 ///
 /// @par Thread Safety
 /// This class is not thread safe.
@@ -58,38 +58,50 @@ class Ipv4Address
     Representation d_value;
 
   public:
-    enum {
+    /// Declare constants used by this implementation.
+    enum Constant {
+        /// The maximum required capacity of a buffer to store the longest
+        /// textual representation of an IPv4 addresses, not including the
+        /// null terminator.
         MAX_TEXT_LENGTH = 15
-        // The maximum required capacity of a buffer to store the longest
-        // textual representation of an IPv4 addresses, not including the
-        // null terminator.
     };
 
     /// Create a new IPv4 address having a default value.
-    Ipv4Address();
+    Ipv4Address() NTSCFG_NOEXCEPT;
+
+    /// Create a new IPv4 address having the same value as the specified
+    /// 'original' object. Assign an unspecified but valid value to the 
+    /// 'original' original.
+    Ipv4Address(bslmf::MovableRef<Ipv4Address> original) NTSCFG_NOEXCEPT;
+
+    /// Create a new IPv4 address having the same value as the specified
+    /// 'original' object.
+    Ipv4Address(const Ipv4Address& original) NTSCFG_NOEXCEPT;
 
     /// Create a new IPv4 address having the specified 'value' encoded in
     /// network byte order.
-    explicit Ipv4Address(bsl::uint32_t value);
+    explicit Ipv4Address(bsl::uint32_t value) NTSCFG_NOEXCEPT;
 
     /// Create a new IPv4 address parsed from the specified 'text'
     /// representation.
     explicit Ipv4Address(const bslstl::StringRef& text);
 
-    /// Create a new IPv4 address having the same value as the specified
-    /// 'other' object.
-    Ipv4Address(const Ipv4Address& other);
-
     /// Destroy this object.
-    ~Ipv4Address();
+    ~Ipv4Address() NTSCFG_NOEXCEPT;
+
+    /// Assign the value of the specified 'other' object to this object. Assign
+    /// an unspecified but valid value to the 'original' original. Return a
+    /// reference to this modifiable object.
+    Ipv4Address& operator=(bslmf::MovableRef<Ipv4Address> other) 
+        NTSCFG_NOEXCEPT;
 
     /// Assign the value of the specified 'other' object to this object.
     /// Return a reference to this modifiable object.
-    Ipv4Address& operator=(const Ipv4Address& other);
+    Ipv4Address& operator=(const Ipv4Address& other) NTSCFG_NOEXCEPT;
 
     /// Set the value of the object from the specified 'value' encoded in
     /// network byte order. Return a reference to this modifiable object.
-    Ipv4Address& operator=(bsl::uint32_t value);
+    Ipv4Address& operator=(bsl::uint32_t value) NTSCFG_NOEXCEPT;
 
     /// Set the value of the object from the specified 'text'. Return
     /// a reference to this modifiable object.
@@ -97,60 +109,67 @@ class Ipv4Address
 
     /// Reset the value of this object to its value upon default
     /// construction.
-    void reset();
+    void reset() NTSCFG_NOEXCEPT;
 
     /// Set the value of this object from the value parsed from its textual
     /// representation. Return true if the 'text' is in a valid format and
     /// was parsed successfully, otherwise return false.
-    bool parse(const bslstl::StringRef& text);
+    bool parse(const bslstl::StringRef& text) NTSCFG_NOEXCEPT;
 
     /// Copy the representation of the IPv4 address from the specified
     /// 'source' having the specified 'size' to this object. Return the
     /// number of bytes read.
-    bsl::size_t copyFrom(const void* source, bsl::size_t size);
+    bsl::size_t copyFrom(const void* source, bsl::size_t size) NTSCFG_NOEXCEPT;
 
     /// Return a reference to the modifiable byte at the specified 'index'.
     /// The behavior is undefined unless 'index < 4'.
-    bsl::uint8_t& operator[](bsl::size_t index);
+    bsl::uint8_t& operator[](bsl::size_t index) NTSCFG_NOEXCEPT;
 
     /// Copy the value of this object to the representation in the specified
     /// 'destination' having the specified 'capacity'. Return the number of
     /// bytes written.
-    bsl::size_t copyTo(void* destination, bsl::size_t capacity) const;
+    bsl::size_t copyTo(void* destination, bsl::size_t capacity) const 
+                       NTSCFG_NOEXCEPT;
 
     /// Format the IPv4 address into the specified 'buffer' having the
     /// specified 'capacity'. Return the number of bytes written.
-    bsl::size_t format(char* buffer, bsl::size_t capacity) const;
+    bsl::size_t format(char* buffer, bsl::size_t capacity) const 
+                       NTSCFG_NOEXCEPT;
 
     /// Return the value of this object encoded in network byte order.
-    bsl::uint32_t value() const;
+    bsl::uint32_t value() const NTSCFG_NOEXCEPT;
 
     /// Return the textual representation of this object.
     bsl::string text() const;
 
     /// Return true if the IPv4 address is the wildcard address, otherwise
     /// return false.
-    bool isAny() const;
+    bool isAny() const NTSCFG_NOEXCEPT;
 
     /// Return true if the IPv4 address identifies the loopback device,
     /// otherwise return false.
-    bool isLoopback() const;
+    bool isLoopback() const NTSCFG_NOEXCEPT;
 
     /// Return true if the IPv4 address is a private address, otherwise
     /// return false.
-    bool isPrivate() const;
+    bool isPrivate() const NTSCFG_NOEXCEPT;
 
     /// Return true if the IPv4 address is a link-local address, otherwise
     /// return false.
-    bool isLinkLocal() const;
+    bool isLinkLocal() const NTSCFG_NOEXCEPT;
 
     /// Return true if this object has the same value as the specified
     /// 'other' object, otherwise return false.
-    bool equals(const Ipv4Address& other) const;
+    bool equals(const Ipv4Address& other) const NTSCFG_NOEXCEPT;
 
     /// Return true if the value of this object is less than the value of
     /// the specified 'other' object, otherwise return false.
-    bool less(const Ipv4Address& other) const;
+    bool less(const Ipv4Address& other) const NTSCFG_NOEXCEPT;
+
+    /// Contribute the values of the salient attributes of this object to the
+    /// specified hash 'algorithm'.
+    template <typename HASH_ALGORITHM>
+    void hash(HASH_ALGORITHM& algorithm) const NTSCFG_NOEXCEPT;
 
     /// Format this object to the specified output 'stream' at the
     /// optionally specified indentation 'level' and return a reference to
@@ -169,18 +188,33 @@ class Ipv4Address
 
     /// Return the value of the byte at the specified 'index'. The behavior
     /// is undefined unless 'index < 4'.
-    bsl::uint8_t operator[](bsl::size_t index) const;
+    bsl::uint8_t operator[](bsl::size_t index) const NTSCFG_NOEXCEPT;
 
     /// Return the wildcard address.
-    static Ipv4Address any();
+    static Ipv4Address any() NTSCFG_NOEXCEPT;
 
     /// Return the loopback address.
-    static Ipv4Address loopback();
+    static Ipv4Address loopback() NTSCFG_NOEXCEPT;
 
-    /// Defines the traits of this type. These traits can be used to select,
-    /// at compile-time, the most efficient algorithm to manipulate objects
-    /// of this type.
-    NTSCFG_DECLARE_NESTED_BITWISE_MOVABLE_TRAITS(Ipv4Address);
+    /// This type's default constructor is equivalent to setting each byte of
+    /// the object's footprint to zero.
+    NTSCFG_TYPE_TRAIT_BITWISE_INITIALIZABLE(Ipv4Address);
+
+    /// This type's copy-constructor and copy-assignment operator is equivalent
+    /// to copying each byte of the source object's footprint to each
+    /// corresponding byte of the destination object's footprint.
+    NTSCFG_TYPE_TRAIT_BITWISE_COPYABLE(Ipv4Address);
+
+    /// This type's move-constructor and move-assignment operator is equivalent
+    /// to copying each byte of the source object's footprint to each
+    /// corresponding byte of the destination object's footprint.
+    NTSCFG_TYPE_TRAIT_BITWISE_MOVABLE(Ipv4Address);
+
+    /// This type's equality-comparison operator is equivalent to comparing
+    /// each byte of one comparand's footprint to each corresponding byte of
+    /// the other comparand's footprint. Note that this trait implies that an
+    /// object of this type has no padding bytes between data members.
+    NTSCFG_TYPE_TRAIT_BITWISE_COMPARABLE(Ipv4Address);
 };
 
 /// Write a formatted, human-readable description of the specified 'object'
@@ -216,75 +250,93 @@ template <typename HASH_ALGORITHM>
 void hashAppend(HASH_ALGORITHM& algorithm, const Ipv4Address& value);
 
 NTSCFG_INLINE
-Ipv4Address::Ipv4Address()
+Ipv4Address::Ipv4Address() NTSCFG_NOEXCEPT
 {
     d_value.d_asDword = 0;
 }
 
 NTSCFG_INLINE
-Ipv4Address::Ipv4Address(bsl::uint32_t value)
+Ipv4Address::Ipv4Address(bslmf::MovableRef<Ipv4Address> original) 
+                         NTSCFG_NOEXCEPT
+{
+    d_value.d_asDword = NTSCFG_MOVE_FROM(original, d_value.d_asDword);
+    NTSCFG_MOVE_RESET(original);
+}
+
+NTSCFG_INLINE
+Ipv4Address::Ipv4Address(const Ipv4Address& original) NTSCFG_NOEXCEPT
+{
+    d_value.d_asDword = original.d_value.d_asDword;
+}
+
+NTSCFG_INLINE
+Ipv4Address::Ipv4Address(bsl::uint32_t value) NTSCFG_NOEXCEPT
 {
     d_value.d_asDword = value;
 }
 
 NTSCFG_INLINE
-Ipv4Address::Ipv4Address(const Ipv4Address& other)
-{
-    d_value.d_asDword = other.d_value.d_asDword;
-}
-
-NTSCFG_INLINE
-Ipv4Address::~Ipv4Address()
+Ipv4Address::~Ipv4Address() NTSCFG_NOEXCEPT
 {
 }
 
 NTSCFG_INLINE
-Ipv4Address& Ipv4Address::operator=(const Ipv4Address& other)
+Ipv4Address& Ipv4Address::operator=(bslmf::MovableRef<Ipv4Address> other) 
+        NTSCFG_NOEXCEPT
+{
+    d_value.d_asDword = NTSCFG_MOVE_FROM(other, d_value.d_asDword);
+    NTSCFG_MOVE_RESET(other);
+
+    return *this;
+}
+
+NTSCFG_INLINE
+Ipv4Address& Ipv4Address::operator=(const Ipv4Address& other) NTSCFG_NOEXCEPT
 {
     d_value.d_asDword = other.d_value.d_asDword;
     return *this;
 }
 
 NTSCFG_INLINE
-Ipv4Address& Ipv4Address::operator=(bsl::uint32_t value)
+Ipv4Address& Ipv4Address::operator=(bsl::uint32_t value) NTSCFG_NOEXCEPT
 {
     d_value.d_asDword = value;
     return *this;
 }
 
 NTSCFG_INLINE
-void Ipv4Address::reset()
+void Ipv4Address::reset() NTSCFG_NOEXCEPT
 {
     d_value.d_asDword = 0;
 }
 
 NTSCFG_INLINE
-bsl::uint8_t& Ipv4Address::operator[](bsl::size_t index)
+bsl::uint8_t& Ipv4Address::operator[](bsl::size_t index) NTSCFG_NOEXCEPT
 {
     BSLS_ASSERT(index < sizeof d_value);
     return d_value.d_asBytes[index];
 }
 
 NTSCFG_INLINE
-bsl::uint32_t Ipv4Address::value() const
+bsl::uint32_t Ipv4Address::value() const NTSCFG_NOEXCEPT
 {
     return d_value.d_asDword;
 }
 
 NTSCFG_INLINE
-bool Ipv4Address::isAny() const
+bool Ipv4Address::isAny() const NTSCFG_NOEXCEPT
 {
     return (*this == Ipv4Address::any());
 }
 
 NTSCFG_INLINE
-bool Ipv4Address::isLoopback() const
+bool Ipv4Address::isLoopback() const NTSCFG_NOEXCEPT
 {
     return (*this == Ipv4Address::loopback());
 }
 
 NTSCFG_INLINE
-bool Ipv4Address::isPrivate() const
+bool Ipv4Address::isPrivate() const NTSCFG_NOEXCEPT
 {
     // 10.x.y.z.
 
@@ -310,19 +362,19 @@ bool Ipv4Address::isPrivate() const
 }
 
 NTSCFG_INLINE
-bool Ipv4Address::isLinkLocal() const
+bool Ipv4Address::isLinkLocal() const NTSCFG_NOEXCEPT
 {
     return (d_value.d_asBytes[0] == 169 && d_value.d_asBytes[1] == 254);
 }
 
 NTSCFG_INLINE
-bool Ipv4Address::equals(const Ipv4Address& other) const
+bool Ipv4Address::equals(const Ipv4Address& other) const NTSCFG_NOEXCEPT
 {
     return d_value.d_asDword == other.d_value.d_asDword;
 }
 
 NTSCFG_INLINE
-bool Ipv4Address::less(const Ipv4Address& other) const
+bool Ipv4Address::less(const Ipv4Address& other) const NTSCFG_NOEXCEPT
 {
     bsl::uint32_t lc0 = BSLS_BYTEORDER_NTOHL(d_value.d_asDword);
     bsl::uint32_t rc0 = BSLS_BYTEORDER_NTOHL(other.d_value.d_asDword);
@@ -330,8 +382,16 @@ bool Ipv4Address::less(const Ipv4Address& other) const
     return lc0 < rc0;
 }
 
+template <typename HASH_ALGORITHM>
 NTSCFG_INLINE
-bsl::uint8_t Ipv4Address::operator[](bsl::size_t index) const
+void Ipv4Address::hash(HASH_ALGORITHM& algorithm) const NTSCFG_NOEXCEPT
+{
+    using bslh::hashAppend;
+    hashAppend(algorithm, BSLS_BYTEORDER_NTOHL(d_value.d_asDword));
+}
+
+NTSCFG_INLINE
+bsl::uint8_t Ipv4Address::operator[](bsl::size_t index) const NTSCFG_NOEXCEPT
 {
     BSLS_ASSERT(index < sizeof d_value);
     return d_value.d_asBytes[index];
@@ -362,10 +422,10 @@ bool operator<(const Ipv4Address& lhs, const Ipv4Address& rhs)
 }
 
 template <typename HASH_ALGORITHM>
+NTSCFG_INLINE
 void hashAppend(HASH_ALGORITHM& algorithm, const Ipv4Address& value)
 {
-    using bslh::hashAppend;
-    hashAppend(algorithm, value.value());
+    value.hash(algorithm);
 }
 
 }  // close package namespace

--- a/groups/nts/ntsa/ntsa_ipv4address.h
+++ b/groups/nts/ntsa/ntsa_ipv4address.h
@@ -70,7 +70,7 @@ class Ipv4Address
     Ipv4Address() NTSCFG_NOEXCEPT;
 
     /// Create a new IPv4 address having the same value as the specified
-    /// 'original' object. Assign an unspecified but valid value to the 
+    /// 'original' object. Assign an unspecified but valid value to the
     /// 'original' original.
     Ipv4Address(bslmf::MovableRef<Ipv4Address> original) NTSCFG_NOEXCEPT;
 
@@ -92,7 +92,7 @@ class Ipv4Address
     /// Assign the value of the specified 'other' object to this object. Assign
     /// an unspecified but valid value to the 'original' original. Return a
     /// reference to this modifiable object.
-    Ipv4Address& operator=(bslmf::MovableRef<Ipv4Address> other) 
+    Ipv4Address& operator=(bslmf::MovableRef<Ipv4Address> other)
         NTSCFG_NOEXCEPT;
 
     /// Assign the value of the specified 'other' object to this object.
@@ -128,13 +128,13 @@ class Ipv4Address
     /// Copy the value of this object to the representation in the specified
     /// 'destination' having the specified 'capacity'. Return the number of
     /// bytes written.
-    bsl::size_t copyTo(void* destination, bsl::size_t capacity) const 
-                       NTSCFG_NOEXCEPT;
+    bsl::size_t copyTo(void*       destination,
+                       bsl::size_t capacity) const NTSCFG_NOEXCEPT;
 
     /// Format the IPv4 address into the specified 'buffer' having the
     /// specified 'capacity'. Return the number of bytes written.
-    bsl::size_t format(char* buffer, bsl::size_t capacity) const 
-                       NTSCFG_NOEXCEPT;
+    bsl::size_t format(char*       buffer,
+                       bsl::size_t capacity) const NTSCFG_NOEXCEPT;
 
     /// Return the value of this object encoded in network byte order.
     bsl::uint32_t value() const NTSCFG_NOEXCEPT;
@@ -256,8 +256,8 @@ Ipv4Address::Ipv4Address() NTSCFG_NOEXCEPT
 }
 
 NTSCFG_INLINE
-Ipv4Address::Ipv4Address(bslmf::MovableRef<Ipv4Address> original) 
-                         NTSCFG_NOEXCEPT
+Ipv4Address::Ipv4Address(bslmf::MovableRef<Ipv4Address> original)
+    NTSCFG_NOEXCEPT
 {
     d_value.d_asDword = NTSCFG_MOVE_FROM(original, d_value.d_asDword);
     NTSCFG_MOVE_RESET(original);
@@ -281,8 +281,8 @@ Ipv4Address::~Ipv4Address() NTSCFG_NOEXCEPT
 }
 
 NTSCFG_INLINE
-Ipv4Address& Ipv4Address::operator=(bslmf::MovableRef<Ipv4Address> other) 
-        NTSCFG_NOEXCEPT
+Ipv4Address& Ipv4Address::operator=(bslmf::MovableRef<Ipv4Address> other)
+    NTSCFG_NOEXCEPT
 {
     d_value.d_asDword = NTSCFG_MOVE_FROM(other, d_value.d_asDword);
     NTSCFG_MOVE_RESET(other);
@@ -383,8 +383,8 @@ bool Ipv4Address::less(const Ipv4Address& other) const NTSCFG_NOEXCEPT
 }
 
 template <typename HASH_ALGORITHM>
-NTSCFG_INLINE
-void Ipv4Address::hash(HASH_ALGORITHM& algorithm) const NTSCFG_NOEXCEPT
+NTSCFG_INLINE void Ipv4Address::hash(HASH_ALGORITHM& algorithm) const
+    NTSCFG_NOEXCEPT
 {
     using bslh::hashAppend;
     hashAppend(algorithm, BSLS_BYTEORDER_NTOHL(d_value.d_asDword));
@@ -422,8 +422,8 @@ bool operator<(const Ipv4Address& lhs, const Ipv4Address& rhs)
 }
 
 template <typename HASH_ALGORITHM>
-NTSCFG_INLINE
-void hashAppend(HASH_ALGORITHM& algorithm, const Ipv4Address& value)
+NTSCFG_INLINE void hashAppend(HASH_ALGORITHM&    algorithm,
+                              const Ipv4Address& value)
 {
     value.hash(algorithm);
 }

--- a/groups/nts/ntsa/ntsa_ipv4address.t.cpp
+++ b/groups/nts/ntsa/ntsa_ipv4address.t.cpp
@@ -14,6 +14,10 @@
 // limitations under the License.
 
 #include <ntsa_ipv4address.h>
+
+#include <bsls_ident.h>
+BSLS_IDENT_RCSID(ntsa_ipv4address_t_cpp, "$Id$ $CSID$")
+
 #include <ntscfg_test.h>
 #include <bslma_testallocator.h>
 #include <bsls_platform.h>
@@ -22,78 +26,248 @@
 #include <bsl_unordered_set.h>
 
 using namespace BloombergLP;
-using namespace ntsa;
 
-//=============================================================================
-//                                 TEST PLAN
-//-----------------------------------------------------------------------------
-//                                 Overview
-//                                 --------
-//
-//-----------------------------------------------------------------------------
+namespace BloombergLP {
+namespace ntsa {
 
-// [ 1]
-//-----------------------------------------------------------------------------
-// [ 1]
-//-----------------------------------------------------------------------------
-
-NTSCFG_TEST_CASE(1)
+// Provide tests for 'ntsa::Ipv4Address'.
+class Ipv4AddressTest
 {
-    // Concern: Value semantics
-    // Plan:
+  public:
+    // Test value semantics: type traits.
+    static void verifyTypeTraits();
 
-    const bool isBitwiseInitializable = 
+    // Test value semantics:default constructor.
+    static void verifyDefaultConstructor();
+
+    // Test value semantics: move constructor.
+    static void verifyMoveConstructor();
+
+    // Test value semantics: copy constructor.
+    static void verifyCopyConstructor();
+
+    // Test value semantics: overload constructor.
+    static void verifyOverloadConstructor();
+
+    // Test value semantics: copy assignment.
+    static void verifyCopyAssignment();
+
+    // Test value semantics: move assignment.
+    static void verifyMoveAssignment();
+
+    // Test value semantics: overload assignment.
+    static void verifyOverloadAssignment();
+
+    // Test value semantics: resetting.
+    static void verifyReset();
+
+    // Test parsing.
+    static void verifyParsing();
+
+    // Test generation.
+    static void verifyGeneration();
+
+    // Test hashing.
+    static void verifyHashing();
+
+    // Test comparison. In particular, comparison must yield consistent results
+    // across different CPUs with different endianness.
+    static void verifyComparison();
+};
+
+void Ipv4AddressTest::verifyTypeTraits()
+{
+    const bool isBitwiseInitializable =
         NTSCFG_TYPE_CHECK_BITWISE_INITIALIZABLE(ntsa::Ipv4Address);
 
     NTSCFG_TEST_TRUE(isBitwiseInitializable);
 
-    const bool isBitwiseMovable = 
+    const bool isBitwiseMovable =
         NTSCFG_TYPE_CHECK_BITWISE_MOVABLE(ntsa::Ipv4Address);
 
     NTSCFG_TEST_TRUE(isBitwiseMovable);
 
-    const bool isBitwiseCopyable = 
+    const bool isBitwiseCopyable =
         NTSCFG_TYPE_CHECK_BITWISE_COPYABLE(ntsa::Ipv4Address);
 
     NTSCFG_TEST_TRUE(isBitwiseCopyable);
 
-    const bool isBitwiseComparable = 
+    const bool isBitwiseComparable =
         NTSCFG_TYPE_CHECK_BITWISE_COMPARABLE(ntsa::Ipv4Address);
 
     NTSCFG_TEST_TRUE(isBitwiseComparable);
+}
 
-    const bool isNothroMoveConstructible = 
-        bsl::is_nothrow_move_constructible<ntsa::Ipv4Address>::value;
+void Ipv4AddressTest::verifyDefaultConstructor()
+{
+    ntsa::Ipv4Address u;
 
-    NTSCFG_TEST_TRUE(isNothroMoveConstructible);
+    NTSCFG_TEST_EQ(u[0], 0);
+    NTSCFG_TEST_EQ(u[1], 0);
+    NTSCFG_TEST_EQ(u[2], 0);
+    NTSCFG_TEST_EQ(u[3], 0);
+}
 
-    ntsa::Ipv4Address a("1.2.3.4");
+void Ipv4AddressTest::verifyMoveConstructor()
+{
+    ntsa::Ipv4Address u("1.2.3.4");
 
-    NTSCFG_TEST_EQ(a[0], 1);
-    NTSCFG_TEST_EQ(a[1], 2);
-    NTSCFG_TEST_EQ(a[2], 3);
-    NTSCFG_TEST_EQ(a[3], 4);
+    NTSCFG_TEST_EQ(u[0], 1);
+    NTSCFG_TEST_EQ(u[1], 2);
+    NTSCFG_TEST_EQ(u[2], 3);
+    NTSCFG_TEST_EQ(u[3], 4);
 
-    ntsa::Ipv4Address b(NTSCFG_MOVE(a));
+    ntsa::Ipv4Address v(NTSCFG_MOVE(u));
 
-    NTSCFG_TEST_EQ(b[0], 1);
-    NTSCFG_TEST_EQ(b[1], 2);
-    NTSCFG_TEST_EQ(b[2], 3);
-    NTSCFG_TEST_EQ(b[3], 4);
+    NTSCFG_TEST_EQ(v[0], 1);
+    NTSCFG_TEST_EQ(v[1], 2);
+    NTSCFG_TEST_EQ(v[2], 3);
+    NTSCFG_TEST_EQ(v[3], 4);
 
 #if NTSCFG_MOVE_RESET_ENABLED
-    NTSCFG_TEST_EQ(a[0], 0);
-    NTSCFG_TEST_EQ(a[1], 0);
-    NTSCFG_TEST_EQ(a[2], 0);
-    NTSCFG_TEST_EQ(a[3], 0);
+    NTSCFG_TEST_EQ(u[0], 0);
+    NTSCFG_TEST_EQ(u[1], 0);
+    NTSCFG_TEST_EQ(u[2], 0);
+    NTSCFG_TEST_EQ(u[3], 0);
 #endif
 }
 
-NTSCFG_TEST_CASE(2)
+void Ipv4AddressTest::verifyCopyConstructor()
 {
-    // Concern: Parsing
-    // Plan:
+    ntsa::Ipv4Address u("1.2.3.4");
 
+    NTSCFG_TEST_EQ(u[0], 1);
+    NTSCFG_TEST_EQ(u[1], 2);
+    NTSCFG_TEST_EQ(u[2], 3);
+    NTSCFG_TEST_EQ(u[3], 4);
+
+    ntsa::Ipv4Address v(u);
+
+    NTSCFG_TEST_EQ(v[0], 1);
+    NTSCFG_TEST_EQ(v[1], 2);
+    NTSCFG_TEST_EQ(v[2], 3);
+    NTSCFG_TEST_EQ(v[3], 4);
+}
+
+void Ipv4AddressTest::verifyOverloadConstructor()
+{
+    {
+        bsl::uint32_t value = 0;
+        {
+            bsl::uint8_t buffer[4]{0x01, 0x02, 0x03, 0x04};
+            NTSCFG_TEST_EQ(sizeof buffer, sizeof value);
+            bsl::memcpy(&value, buffer, sizeof buffer);
+        }
+
+        ntsa::Ipv4Address u(value);
+
+        NTSCFG_TEST_EQ(u[0], 1);
+        NTSCFG_TEST_EQ(u[1], 2);
+        NTSCFG_TEST_EQ(u[2], 3);
+        NTSCFG_TEST_EQ(u[3], 4);
+    }
+
+    {
+        ntsa::Ipv4Address u("1.2.3.4");
+
+        NTSCFG_TEST_EQ(u[0], 1);
+        NTSCFG_TEST_EQ(u[1], 2);
+        NTSCFG_TEST_EQ(u[2], 3);
+        NTSCFG_TEST_EQ(u[3], 4);
+    }
+}
+
+void Ipv4AddressTest::verifyCopyAssignment()
+{
+    ntsa::Ipv4Address u("1.2.3.4");
+
+    NTSCFG_TEST_EQ(u[0], 1);
+    NTSCFG_TEST_EQ(u[1], 2);
+    NTSCFG_TEST_EQ(u[2], 3);
+    NTSCFG_TEST_EQ(u[3], 4);
+
+    ntsa::Ipv4Address v;
+
+    NTSCFG_TEST_EQ(v[0], 0);
+    NTSCFG_TEST_EQ(v[1], 0);
+    NTSCFG_TEST_EQ(v[2], 0);
+    NTSCFG_TEST_EQ(v[3], 0);
+
+    v = u;
+
+    NTSCFG_TEST_EQ(v[0], 1);
+    NTSCFG_TEST_EQ(v[1], 2);
+    NTSCFG_TEST_EQ(v[2], 3);
+    NTSCFG_TEST_EQ(v[3], 4);
+}
+
+void Ipv4AddressTest::verifyMoveAssignment()
+{
+    ntsa::Ipv4Address u("1.2.3.4");
+
+    NTSCFG_TEST_EQ(u[0], 1);
+    NTSCFG_TEST_EQ(u[1], 2);
+    NTSCFG_TEST_EQ(u[2], 3);
+    NTSCFG_TEST_EQ(u[3], 4);
+
+    ntsa::Ipv4Address v;
+
+    NTSCFG_TEST_EQ(v[0], 0);
+    NTSCFG_TEST_EQ(v[1], 0);
+    NTSCFG_TEST_EQ(v[2], 0);
+    NTSCFG_TEST_EQ(v[3], 0);
+
+    v = NTSCFG_MOVE(u);
+
+    NTSCFG_TEST_EQ(v[0], 1);
+    NTSCFG_TEST_EQ(v[1], 2);
+    NTSCFG_TEST_EQ(v[2], 3);
+    NTSCFG_TEST_EQ(v[3], 4);
+
+#if NTSCFG_MOVE_RESET_ENABLED
+    NTSCFG_TEST_EQ(u[0], 0);
+    NTSCFG_TEST_EQ(u[1], 0);
+    NTSCFG_TEST_EQ(u[2], 0);
+    NTSCFG_TEST_EQ(u[3], 0);
+#endif
+}
+
+void Ipv4AddressTest::verifyOverloadAssignment()
+{
+    ntsa::Ipv4Address u;
+
+    NTSCFG_TEST_EQ(u[0], 0);
+    NTSCFG_TEST_EQ(u[1], 0);
+    NTSCFG_TEST_EQ(u[2], 0);
+    NTSCFG_TEST_EQ(u[3], 0);
+
+    u = "1.2.3.4";
+
+    NTSCFG_TEST_EQ(u[0], 1);
+    NTSCFG_TEST_EQ(u[1], 2);
+    NTSCFG_TEST_EQ(u[2], 3);
+    NTSCFG_TEST_EQ(u[3], 4);
+}
+
+void Ipv4AddressTest::verifyReset()
+{
+    ntsa::Ipv4Address u("1.2.3.4");
+
+    NTSCFG_TEST_EQ(u[0], 1);
+    NTSCFG_TEST_EQ(u[1], 2);
+    NTSCFG_TEST_EQ(u[2], 3);
+    NTSCFG_TEST_EQ(u[3], 4);
+
+    u.reset();
+
+    NTSCFG_TEST_EQ(u[0], 0);
+    NTSCFG_TEST_EQ(u[1], 0);
+    NTSCFG_TEST_EQ(u[2], 0);
+    NTSCFG_TEST_EQ(u[3], 0);
+}
+
+void Ipv4AddressTest::verifyParsing()
+{
     // Microsoft Visual Studio 2013 does not compile the array literal
     // initialization.
 #if !defined(BSLS_PLATFORM_OS_WINDOWS)
@@ -153,11 +327,8 @@ NTSCFG_TEST_CASE(2)
 #endif
 }
 
-NTSCFG_TEST_CASE(3)
+void Ipv4AddressTest::verifyGeneration()
 {
-    // Concern: Generating
-    // Plan:
-
     // Microsoft Visual Studio 2013 does not compile the array literal
     // initialization.
 #if !defined(BSLS_PLATFORM_OS_WINDOWS)
@@ -197,11 +368,8 @@ NTSCFG_TEST_CASE(3)
 #endif
 }
 
-NTSCFG_TEST_CASE(4)
+void Ipv4AddressTest::verifyHashing()
 {
-    // Concern:
-    // Plan:
-
     ntsa::Ipv4Address address1("127.0.0.1");
     ntsa::Ipv4Address address2("196.168.0.1");
 
@@ -209,14 +377,34 @@ NTSCFG_TEST_CASE(4)
     addressSet.insert(address1);
     addressSet.insert(address2);
 
-    NTSCFG_TEST_ASSERT(addressSet.size() == 2);
+    NTSCFG_TEST_EQ(addressSet.size(), 2);
 }
 
-NTSCFG_TEST_DRIVER
+void Ipv4AddressTest::verifyComparison()
 {
-    NTSCFG_TEST_REGISTER(1);
-    NTSCFG_TEST_REGISTER(2);
-    NTSCFG_TEST_REGISTER(3);
-    NTSCFG_TEST_REGISTER(4);
+    ntsa::Ipv4Address address1("10.0.0.11");
+    ntsa::Ipv4Address address2("11.0.0.10");
+
+    NTSCFG_TEST_LT(address1, address2);
 }
-NTSCFG_TEST_DRIVER_END;
+
+}  // close namespace ntsa
+}  // close namespace BloombergLP
+
+NTSCFG_TEST_SUITE
+{
+    NTSCFG_TEST_FUNCTION(&ntsa::Ipv4AddressTest::verifyTypeTraits);
+    NTSCFG_TEST_FUNCTION(&ntsa::Ipv4AddressTest::verifyDefaultConstructor);
+    NTSCFG_TEST_FUNCTION(&ntsa::Ipv4AddressTest::verifyMoveConstructor);
+    NTSCFG_TEST_FUNCTION(&ntsa::Ipv4AddressTest::verifyCopyConstructor);
+    NTSCFG_TEST_FUNCTION(&ntsa::Ipv4AddressTest::verifyOverloadConstructor);
+    NTSCFG_TEST_FUNCTION(&ntsa::Ipv4AddressTest::verifyCopyAssignment);
+    NTSCFG_TEST_FUNCTION(&ntsa::Ipv4AddressTest::verifyMoveAssignment);
+    NTSCFG_TEST_FUNCTION(&ntsa::Ipv4AddressTest::verifyOverloadAssignment);
+    NTSCFG_TEST_FUNCTION(&ntsa::Ipv4AddressTest::verifyReset);
+    NTSCFG_TEST_FUNCTION(&ntsa::Ipv4AddressTest::verifyParsing);
+    NTSCFG_TEST_FUNCTION(&ntsa::Ipv4AddressTest::verifyGeneration);
+    NTSCFG_TEST_FUNCTION(&ntsa::Ipv4AddressTest::verifyHashing);
+    NTSCFG_TEST_FUNCTION(&ntsa::Ipv4AddressTest::verifyComparison);
+}
+NTSCFG_TEST_SUITE_END;

--- a/groups/nts/ntsa/ntsa_ipv4address.t.cpp
+++ b/groups/nts/ntsa/ntsa_ipv4address.t.cpp
@@ -39,6 +39,58 @@ using namespace ntsa;
 
 NTSCFG_TEST_CASE(1)
 {
+    // Concern: Value semantics
+    // Plan:
+
+    const bool isBitwiseInitializable = 
+        NTSCFG_TYPE_CHECK_BITWISE_INITIALIZABLE(ntsa::Ipv4Address);
+
+    NTSCFG_TEST_TRUE(isBitwiseInitializable);
+
+    const bool isBitwiseMovable = 
+        NTSCFG_TYPE_CHECK_BITWISE_MOVABLE(ntsa::Ipv4Address);
+
+    NTSCFG_TEST_TRUE(isBitwiseMovable);
+
+    const bool isBitwiseCopyable = 
+        NTSCFG_TYPE_CHECK_BITWISE_COPYABLE(ntsa::Ipv4Address);
+
+    NTSCFG_TEST_TRUE(isBitwiseCopyable);
+
+    const bool isBitwiseComparable = 
+        NTSCFG_TYPE_CHECK_BITWISE_COMPARABLE(ntsa::Ipv4Address);
+
+    NTSCFG_TEST_TRUE(isBitwiseComparable);
+
+    const bool isNothroMoveConstructible = 
+        bsl::is_nothrow_move_constructible<ntsa::Ipv4Address>::value;
+
+    NTSCFG_TEST_TRUE(isNothroMoveConstructible);
+
+    ntsa::Ipv4Address a("1.2.3.4");
+
+    NTSCFG_TEST_EQ(a[0], 1);
+    NTSCFG_TEST_EQ(a[1], 2);
+    NTSCFG_TEST_EQ(a[2], 3);
+    NTSCFG_TEST_EQ(a[3], 4);
+
+    ntsa::Ipv4Address b(NTSCFG_MOVE(a));
+
+    NTSCFG_TEST_EQ(b[0], 1);
+    NTSCFG_TEST_EQ(b[1], 2);
+    NTSCFG_TEST_EQ(b[2], 3);
+    NTSCFG_TEST_EQ(b[3], 4);
+
+#if NTSCFG_MOVE_RESET_ENABLED
+    NTSCFG_TEST_EQ(a[0], 0);
+    NTSCFG_TEST_EQ(a[1], 0);
+    NTSCFG_TEST_EQ(a[2], 0);
+    NTSCFG_TEST_EQ(a[3], 0);
+#endif
+}
+
+NTSCFG_TEST_CASE(2)
+{
     // Concern: Parsing
     // Plan:
 
@@ -101,7 +153,7 @@ NTSCFG_TEST_CASE(1)
 #endif
 }
 
-NTSCFG_TEST_CASE(2)
+NTSCFG_TEST_CASE(3)
 {
     // Concern: Generating
     // Plan:
@@ -145,7 +197,7 @@ NTSCFG_TEST_CASE(2)
 #endif
 }
 
-NTSCFG_TEST_CASE(3)
+NTSCFG_TEST_CASE(4)
 {
     // Concern:
     // Plan:
@@ -165,5 +217,6 @@ NTSCFG_TEST_DRIVER
     NTSCFG_TEST_REGISTER(1);
     NTSCFG_TEST_REGISTER(2);
     NTSCFG_TEST_REGISTER(3);
+    NTSCFG_TEST_REGISTER(4);
 }
 NTSCFG_TEST_DRIVER_END;

--- a/groups/nts/ntsa/ntsa_tcpcongestioncontrol.cpp
+++ b/groups/nts/ntsa/ntsa_tcpcongestioncontrol.cpp
@@ -24,13 +24,27 @@ namespace BloombergLP {
 namespace ntsa {
 
 TcpCongestionControl::TcpCongestionControl(bslma::Allocator* basicAllocator)
-: d_buffer(bslma::Default::allocator(basicAllocator))
+: d_algorithm(bslma::Default::allocator(basicAllocator))
+{
+}
+
+TcpCongestionControl::TcpCongestionControl(const bsl::string_view& algorithm,
+                                           bslma::Allocator* basicAllocator)
+: d_algorithm(algorithm, basicAllocator)
+{
+}
+
+TcpCongestionControl::TcpCongestionControl(
+    TcpCongestionControlAlgorithm::Value algorithm,
+    bslma::Allocator*                    basicAllocator)
+: d_algorithm(TcpCongestionControlAlgorithm::toString(algorithm),
+              basicAllocator)
 {
 }
 
 TcpCongestionControl::TcpCongestionControl(
     bslmf::MovableRef<TcpCongestionControl> original) NTSCFG_NOEXCEPT
-: d_buffer(NTSCFG_MOVE_FROM(original, d_buffer))
+: d_algorithm(NTSCFG_MOVE_FROM(original, d_algorithm))
 {
     NTSCFG_MOVE_RESET(original);
 }
@@ -38,7 +52,7 @@ TcpCongestionControl::TcpCongestionControl(
 TcpCongestionControl::TcpCongestionControl(
     const BloombergLP::ntsa::TcpCongestionControl& original,
     bslma::Allocator*                              basicAllocator)
-: d_buffer(original.d_buffer, basicAllocator)
+: d_algorithm(original.d_algorithm, basicAllocator)
 {
 }
 
@@ -49,7 +63,7 @@ TcpCongestionControl::~TcpCongestionControl()
 TcpCongestionControl& TcpCongestionControl::operator=(
     bslmf::MovableRef<TcpCongestionControl> other)
 {
-    d_buffer = NTSCFG_MOVE_FROM(other, d_buffer);
+    d_algorithm = NTSCFG_MOVE_FROM(other, d_algorithm);
     NTSCFG_MOVE_RESET(other);
 
     return *this;
@@ -59,7 +73,7 @@ TcpCongestionControl& TcpCongestionControl::operator=(
     const BloombergLP::ntsa::TcpCongestionControl& other)
 {
     if (this != &other) {
-        d_buffer = other.d_buffer;
+        d_algorithm = other.d_algorithm;
     }
 
     return *this;
@@ -67,13 +81,13 @@ TcpCongestionControl& TcpCongestionControl::operator=(
 
 void TcpCongestionControl::reset()
 {
-    d_buffer.clear();
+    d_algorithm.clear();
 }
 
 ntsa::Error TcpCongestionControl::setAlgorithmName(
     const bsl::string_view& name)
 {
-    d_buffer = name;
+    d_algorithm = name;
     return ntsa::Error();
 }
 
@@ -82,24 +96,31 @@ ntsa::Error TcpCongestionControl::setAlgorithm(
 {
     const char* name = TcpCongestionControlAlgorithm::toString(value);
     if (name == 0) {
-        return ntsa::Error::invalid();
+        return ntsa::Error(ntsa::Error::e_INVALID);
     }
-    return this->setAlgorithmName(name);
+
+    d_algorithm = name;
+    return ntsa::Error();
 }
 
 const bsl::string& TcpCongestionControl::algorithm() const
 {
-    return d_buffer;
+    return d_algorithm;
+}
+
+bslma::Allocator* TcpCongestionControl::allocator() const
+{
+    return d_algorithm.allocator().mechanism();
 }
 
 bool TcpCongestionControl::equals(const TcpCongestionControl& other) const
 {
-    return d_buffer == other.d_buffer;
+    return d_algorithm == other.d_algorithm;
 }
 
 bool TcpCongestionControl::less(const TcpCongestionControl& other) const
 {
-    return d_buffer < other.d_buffer;
+    return d_algorithm < other.d_algorithm;
 }
 
 bsl::ostream& TcpCongestionControl::print(bsl::ostream& stream,
@@ -109,7 +130,7 @@ bsl::ostream& TcpCongestionControl::print(bsl::ostream& stream,
     NTSCFG_WARNING_UNUSED(level);
     NTSCFG_WARNING_UNUSED(spacesPerLevel);
 
-    return stream << d_buffer;
+    return stream << d_algorithm;
 }
 
 bsl::ostream& operator<<(bsl::ostream&               stream,

--- a/groups/nts/ntsa/ntsa_tcpcongestioncontrol.cpp
+++ b/groups/nts/ntsa/ntsa_tcpcongestioncontrol.cpp
@@ -110,7 +110,7 @@ const bsl::string& TcpCongestionControl::algorithm() const
 
 bslma::Allocator* TcpCongestionControl::allocator() const
 {
-    return d_algorithm.allocator().mechanism();
+    return d_algorithm.get_allocator().mechanism();
 }
 
 bool TcpCongestionControl::equals(const TcpCongestionControl& other) const

--- a/groups/nts/ntsa/ntsa_tcpcongestioncontrol.cpp
+++ b/groups/nts/ntsa/ntsa_tcpcongestioncontrol.cpp
@@ -25,15 +25,20 @@ namespace ntsa {
 
 TcpCongestionControl::TcpCongestionControl(bslma::Allocator* basicAllocator)
 : d_buffer(bslma::Default::allocator(basicAllocator))
-, d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
+}
+
+TcpCongestionControl::TcpCongestionControl(
+    bslmf::MovableRef<TcpCongestionControl> original) NTSCFG_NOEXCEPT
+: d_buffer(NTSCFG_MOVE_FROM(original, d_buffer))
+{
+    NTSCFG_MOVE_RESET(original);
 }
 
 TcpCongestionControl::TcpCongestionControl(
     const BloombergLP::ntsa::TcpCongestionControl& original,
     bslma::Allocator*                              basicAllocator)
 : d_buffer(original.d_buffer, basicAllocator)
-, d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
 }
 
@@ -42,13 +47,27 @@ TcpCongestionControl::~TcpCongestionControl()
 }
 
 TcpCongestionControl& TcpCongestionControl::operator=(
+    bslmf::MovableRef<TcpCongestionControl> other)
+{
+    d_buffer = NTSCFG_MOVE_FROM(other, d_buffer);
+    NTSCFG_MOVE_RESET(other);
+
+    return *this;
+}
+
+TcpCongestionControl& TcpCongestionControl::operator=(
     const BloombergLP::ntsa::TcpCongestionControl& other)
 {
     if (this != &other) {
-        d_buffer      = other.d_buffer;
-        d_allocator_p = other.d_allocator_p;
+        d_buffer = other.d_buffer;
     }
+
     return *this;
+}
+
+void TcpCongestionControl::reset()
+{
+    d_buffer.clear();
 }
 
 ntsa::Error TcpCongestionControl::setAlgorithmName(
@@ -56,11 +75,6 @@ ntsa::Error TcpCongestionControl::setAlgorithmName(
 {
     d_buffer = name;
     return ntsa::Error();
-}
-
-const bsl::string& TcpCongestionControl::algorithm() const
-{
-    return d_buffer;
 }
 
 ntsa::Error TcpCongestionControl::setAlgorithm(
@@ -73,9 +87,9 @@ ntsa::Error TcpCongestionControl::setAlgorithm(
     return this->setAlgorithmName(name);
 }
 
-void TcpCongestionControl::reset()
+const bsl::string& TcpCongestionControl::algorithm() const
 {
-    d_buffer.clear();
+    return d_buffer;
 }
 
 bool TcpCongestionControl::equals(const TcpCongestionControl& other) const
@@ -92,11 +106,10 @@ bsl::ostream& TcpCongestionControl::print(bsl::ostream& stream,
                                           int           level,
                                           int           spacesPerLevel) const
 {
-    bslim::Printer printer(&stream, level, spacesPerLevel);
-    printer.start();
-    printer.printAttribute("d_buffer", d_buffer);
-    printer.end();
-    return stream;
+    NTSCFG_WARNING_UNUSED(level);
+    NTSCFG_WARNING_UNUSED(spacesPerLevel);
+
+    return stream << d_buffer;
 }
 
 bsl::ostream& operator<<(bsl::ostream&               stream,

--- a/groups/nts/ntsa/ntsa_tcpcongestioncontrol.h
+++ b/groups/nts/ntsa/ntsa_tcpcongestioncontrol.h
@@ -19,13 +19,12 @@
 #include <bsls_ident.h>
 BSLS_IDENT("$Id: $")
 
+#include <ntsa_tcpcongestioncontrolalgorithm.h>
 #include <ntsa_error.h>
 #include <ntscfg_platform.h>
 #include <ntsscm_version.h>
 #include <bsl_ostream.h>
 #include <bsl_string.h>
-
-#include <ntsa_tcpcongestioncontrolalgorithm.h>
 
 namespace BloombergLP {
 namespace ntsa {
@@ -46,46 +45,56 @@ namespace ntsa {
 /// This class is not thread safe.
 ///
 /// @ingroup module_ntsa_system
-
 class TcpCongestionControl
 {
-    bsl::string       d_buffer;
-    bslma::Allocator* d_allocator_p;
+    bsl::string d_buffer;
 
   public:
-    /// Create new TcpCongestionControl instance having the default value.
-    /// Optionally specify a 'basicAllocator' used to supply memory. If
+    /// Create a new TCP congestion control specification having the default
+    /// value. Optionally specify a 'basicAllocator' used to supply memory. If
     /// 'basicAllocator' is 0, the currently installed default allocator is
     /// used.
     explicit TcpCongestionControl(bslma::Allocator* basicAllocator = 0);
 
-    /// Create new TcpCongestionControl instance having the same value as the
-    /// specified `original`. Optionally specify a 'basicAllocator' used to
-    /// supply memory. If 'basicAllocator' is 0, the currently installed
-    /// default allocator is used.
+    /// Create a new TCP congestion control specification having the same value
+    /// and allocator as the specified 'original' object. Assign an unspecified
+    /// but valid value to the 'original' original.
+    TcpCongestionControl(bslmf::MovableRef<TcpCongestionControl> original) 
+                         NTSCFG_NOEXCEPT;
+
+    /// Create a new TCP congestion control specification having the same value
+    /// as the specified 'original' object. Optionally specify a
+    /// 'basicAllocator' used to supply memory. If 'basicAllocator' is 0, the
+    /// currently installed default allocator is used.
     TcpCongestionControl(const TcpCongestionControl& original,
-                         bslma::Allocator*           basicAllocator);
+                         bslma::Allocator*           basicAllocator = 0);
 
     /// Destroy this object.
     ~TcpCongestionControl();
+
+    /// Assign the value of the specified 'other' object to this object. Assign
+    /// an unspecified but valid value to the 'original' original. Return a
+    /// reference to this modifiable object.
+    TcpCongestionControl& operator=(
+        bslmf::MovableRef<TcpCongestionControl> other);
 
     /// Assign the value of the specified 'other' object to this object.
     /// Return a reference to this modifiable object.
     TcpCongestionControl& operator=(const TcpCongestionControl& other);
 
-    /// Set algorithm name to the specified `value`. Return the error.
+    /// Reset the value of this object to its value upon default construction.
+    void reset();
+
+    /// Set algorithm name to the specified 'value'. Return the error.
     ntsa::Error setAlgorithmName(const bsl::string_view& value);
+
+    /// Set TCP congestion control algorithm set accordingly to the specified
+    /// 'value'. Return the error.
+    ntsa::Error setAlgorithm(TcpCongestionControlAlgorithm::Value value);
 
     /// Return a reference to a string containing name of the tcp congestion
     /// control algorithm.
     const bsl::string& algorithm() const;
-
-    /// Set TCP congestion control algorithm set accordingly to the specified
-    /// `value`. Return the error.
-    ntsa::Error setAlgorithm(TcpCongestionControlAlgorithm::Value value);
-
-    /// Reset the value of this object to its value upon default construction.
-    void reset();
 
     /// Return true if this object has the same value as the specified 'other'
     /// object, otherwise return false.
@@ -110,10 +119,9 @@ class TcpCongestionControl
                         int           level          = 0,
                         int           spacesPerLevel = 4) const;
 
-    /// Defines the traits of this type. These traits can be used to select,
-    /// at compile-time, the most efficient algorithm to manipulate objects
-    /// of this type.
-    NTSCFG_DECLARE_NESTED_USES_ALLOCATOR_TRAITS(TcpCongestionControl);
+    /// This type accepts an allocator argument to its constructors and may
+    /// dynamically allocate memory during its operation.
+    NTSCFG_TYPE_TRAIT_ALLOCATOR_AWARE(TcpCongestionControl);
 };
 
 /// Write the specified 'object' to the specified 'stream'. Return a modifiable

--- a/groups/nts/ntsa/ntsa_tcpcongestioncontrol.h
+++ b/groups/nts/ntsa/ntsa_tcpcongestioncontrol.h
@@ -19,8 +19,8 @@
 #include <bsls_ident.h>
 BSLS_IDENT("$Id: $")
 
-#include <ntsa_tcpcongestioncontrolalgorithm.h>
 #include <ntsa_error.h>
+#include <ntsa_tcpcongestioncontrolalgorithm.h>
 #include <ntscfg_platform.h>
 #include <ntsscm_version.h>
 #include <bsl_ostream.h>
@@ -29,17 +29,13 @@ BSLS_IDENT("$Id: $")
 namespace BloombergLP {
 namespace ntsa {
 
-/// Provide a value identifying tcp congestion control algorithm.
-///
-/// @details
-/// Provide a value-semantic type that identifies tcp congestion control
-/// algorithm.
+/// Describe a TCP congestion control strategy.
 ///
 /// @par Attributes
 /// This class is composed of the following attributes.
 ///
-/// @li d_buffer:
-/// Buffer which contains name of the tcp congestion control algorithm.
+/// @li @b algorithm:
+/// The name of the TCP congestion control algorithm.
 ///
 /// @par Thread Safety
 /// This class is not thread safe.
@@ -47,7 +43,7 @@ namespace ntsa {
 /// @ingroup module_ntsa_system
 class TcpCongestionControl
 {
-    bsl::string d_buffer;
+    bsl::string d_algorithm;
 
   public:
     /// Create a new TCP congestion control specification having the default
@@ -56,11 +52,26 @@ class TcpCongestionControl
     /// used.
     explicit TcpCongestionControl(bslma::Allocator* basicAllocator = 0);
 
+    /// Create a new TCP congestion control specification using the specified
+    /// 'algorithm'. Optionally specify a 'basicAllocator' used to supply
+    /// memory. If 'basicAllocator' is 0, the currently installed default
+    /// allocator is used.
+    explicit TcpCongestionControl(const bsl::string_view& algorithm,
+                                  bslma::Allocator*       basicAllocator = 0);
+
+    /// Create a new TCP congestion control specification using the specified
+    /// 'algorithm'. Optionally specify a 'basicAllocator' used to supply
+    /// memory. If 'basicAllocator' is 0, the currently installed default
+    /// allocator is used.
+    explicit TcpCongestionControl(
+        TcpCongestionControlAlgorithm::Value algorithm,
+        bslma::Allocator*                    basicAllocator = 0);
+
     /// Create a new TCP congestion control specification having the same value
     /// and allocator as the specified 'original' object. Assign an unspecified
     /// but valid value to the 'original' original.
-    TcpCongestionControl(bslmf::MovableRef<TcpCongestionControl> original) 
-                         NTSCFG_NOEXCEPT;
+    TcpCongestionControl(bslmf::MovableRef<TcpCongestionControl> original)
+        NTSCFG_NOEXCEPT;
 
     /// Create a new TCP congestion control specification having the same value
     /// as the specified 'original' object. Optionally specify a
@@ -95,6 +106,9 @@ class TcpCongestionControl
     /// Return a reference to a string containing name of the tcp congestion
     /// control algorithm.
     const bsl::string& algorithm() const;
+
+    /// Return the allocator used to supply memory.
+    bslma::Allocator* allocator() const;
 
     /// Return true if this object has the same value as the specified 'other'
     /// object, otherwise return false.

--- a/groups/nts/ntsa/ntsa_tcpcongestioncontrol.t.cpp
+++ b/groups/nts/ntsa/ntsa_tcpcongestioncontrol.t.cpp
@@ -15,54 +15,264 @@
 
 #include <ntsa_tcpcongestioncontrol.h>
 
+#include <bsls_ident.h>
+BSLS_IDENT_RCSID(ntsa_tcpcongestioncontrol_t_cpp, "$Id$ $CSID$")
+
 #include <ntscfg_test.h>
 
 using namespace BloombergLP;
-using namespace ntsa;
 
-NTSCFG_TEST_CASE(1)
+namespace BloombergLP {
+namespace ntsa {
+
+// Provide tests for 'ntsa::TcpCongestionControl'.
+class TcpCongestionControlTest
 {
-    ntscfg::TestAllocator ta;
+  public:
+    // Test value semantics: type traits.
+    static void verifyTypeTraits();
+
+    // Test value semantics:default constructor.
+    static void verifyDefaultConstructor();
+
+    // Test value semantics: move constructor.
+    static void verifyMoveConstructor();
+
+    // Test value semantics: copy constructor.
+    static void verifyCopyConstructor();
+
+    // Test value semantics: overload constructor.
+    static void verifyOverloadConstructor();
+
+    // Test value semantics: copy assignment.
+    static void verifyCopyAssignment();
+
+    // Test value semantics: move assignment.
+    static void verifyMoveAssignment();
+
+    // Test value semantics: overload assignment.
+    static void verifyOverloadAssignment();
+
+    // Test value semantics: resetting.
+    static void verifyReset();
+
+    // Test setting the congestion control from well-known algorithms behaves
+    // as expected.
+    static void verifyWellKnownEnumerators();
+};
+
+void TcpCongestionControlTest::verifyTypeTraits()
+{
+    const bool isAllocatorAware =
+        NTSCFG_TYPE_CHECK_ALLOCATOR_AWARE(ntsa::TcpCongestionControl);
+
+    NTSCFG_TEST_TRUE(isAllocatorAware);
+}
+
+void TcpCongestionControlTest::verifyDefaultConstructor()
+{
+    ntsa::TcpCongestionControl congestionControl(NTSCFG_TEST_ALLOCATOR);
+
+    NTSCFG_TEST_TRUE(congestionControl.algorithm().empty());
+    NTSCFG_TEST_EQ(congestionControl.allocator(), NTSCFG_TEST_ALLOCATOR);
+}
+
+void TcpCongestionControlTest::verifyMoveConstructor()
+{
+    ntsa::TcpCongestionControl source(NTSCFG_TEST_ALLOCATOR);
+
+    source.setAlgorithmName("debug");
+    NTSCFG_TEST_EQ(source.algorithm(), "debug");
+    NTSCFG_TEST_EQ(source.allocator(), NTSCFG_TEST_ALLOCATOR);
+
+    ntsa::TcpCongestionControl destination(NTSCFG_MOVE(source));
+    NTSCFG_TEST_EQ(destination.algorithm(), "debug");
+    NTSCFG_TEST_EQ(destination.allocator(), NTSCFG_TEST_ALLOCATOR);
+
+#if NTSCFG_MOVE_RESET_ENABLED
+    NTSCFG_TEST_TRUE(source.algorithm().empty());
+    NTSCFG_TEST_EQ(source.allocator(), NTSCFG_TEST_ALLOCATOR);
+#endif
+}
+
+void TcpCongestionControlTest::verifyCopyConstructor()
+{
+    ntsa::TcpCongestionControl source(NTSCFG_TEST_ALLOCATOR);
+
+    source.setAlgorithmName("debug");
+    NTSCFG_TEST_EQ(source.algorithm(), "debug");
+    NTSCFG_TEST_EQ(source.allocator(), NTSCFG_TEST_ALLOCATOR);
+
+    ntsa::TcpCongestionControl destination(source, NTSCFG_TEST_ALLOCATOR);
+    NTSCFG_TEST_EQ(destination.algorithm(), "debug");
+    NTSCFG_TEST_EQ(destination.allocator(), NTSCFG_TEST_ALLOCATOR);
+}
+
+void TcpCongestionControlTest::verifyOverloadConstructor()
+{
     {
-        TcpCongestionControl cc(&ta);
-        NTSCFG_TEST_EQ(cc.algorithm(), "");
-
-        {
-            const char* name = "some_long_name_here";
-            NTSCFG_TEST_OK(cc.setAlgorithmName(name));
-            NTSCFG_TEST_EQ(cc.algorithm(), name);
-        }
-        {
-            NTSCFG_TEST_OK(
-                cc.setAlgorithm(TcpCongestionControlAlgorithm::e_BBR));
-            NTSCFG_TEST_EQ(cc.algorithm(), "bbr");
-        }
-        {
-            cc.reset();
-            NTSCFG_TEST_EQ(cc.algorithm(), "");
-        }
-        {
-            TcpCongestionControl cc2(&ta);
-            NTSCFG_TEST_OK(
-                cc2.setAlgorithm(TcpCongestionControlAlgorithm::e_HYBLA));
-            NTSCFG_TEST_NE(cc2, cc);
-            NTSCFG_TEST_OK(
-                cc.setAlgorithm(TcpCongestionControlAlgorithm::e_HYBLA));
-            NTSCFG_TEST_EQ(cc2, cc);
-        }
-        {
-            TcpCongestionControl cc2(&ta);
-            NTSCFG_TEST_OK(
-                cc2.setAlgorithm(TcpCongestionControlAlgorithm::e_WESTWOOD));
-            cc = cc2;
-            NTSCFG_TEST_EQ(cc.algorithm(), "westwood");
-        }
+        ntsa::TcpCongestionControl source("debug", NTSCFG_TEST_ALLOCATOR);
+        NTSCFG_TEST_EQ(source.algorithm(), "debug");
+        NTSCFG_TEST_EQ(source.allocator(), NTSCFG_TEST_ALLOCATOR);
     }
-    NTSCFG_TEST_EQ(ta.numBlocksInUse(), 0);
+
+    {
+        ntsa::TcpCongestionControl source(
+            ntsa::TcpCongestionControlAlgorithm::e_VEGAS,
+            NTSCFG_TEST_ALLOCATOR);
+        NTSCFG_TEST_EQ(source.algorithm(), "vegas");
+        NTSCFG_TEST_EQ(source.allocator(), NTSCFG_TEST_ALLOCATOR);
+    }
 }
 
-NTSCFG_TEST_DRIVER
+void TcpCongestionControlTest::verifyCopyAssignment()
 {
-    NTSCFG_TEST_REGISTER(1);
+    ntsa::TcpCongestionControl source("debug", NTSCFG_TEST_ALLOCATOR);
+    NTSCFG_TEST_EQ(source.algorithm(), "debug");
+    NTSCFG_TEST_EQ(source.allocator(), NTSCFG_TEST_ALLOCATOR);
+
+    ntsa::TcpCongestionControl destination;
+    NTSCFG_TEST_TRUE(destination.algorithm().empty());
+    NTSCFG_TEST_EQ(destination.allocator(), bslma::Default::allocator());
+
+    destination = source;
+
+    NTSCFG_TEST_EQ(destination.algorithm(), "debug");
+    NTSCFG_TEST_EQ(destination.allocator(), bslma::Default::allocator());
 }
-NTSCFG_TEST_DRIVER_END;
+
+void TcpCongestionControlTest::verifyMoveAssignment()
+{
+    {
+        ntsa::TcpCongestionControl source("debug", NTSCFG_TEST_ALLOCATOR);
+        NTSCFG_TEST_EQ(source.algorithm(), "debug");
+        NTSCFG_TEST_EQ(source.allocator(), NTSCFG_TEST_ALLOCATOR);
+
+        ntsa::TcpCongestionControl destination;
+        NTSCFG_TEST_TRUE(destination.algorithm().empty());
+        NTSCFG_TEST_EQ(destination.allocator(), bslma::Default::allocator());
+
+        destination = NTSCFG_MOVE(source);
+
+        NTSCFG_TEST_EQ(destination.algorithm(), "debug");
+        NTSCFG_TEST_EQ(destination.allocator(), bslma::Default::allocator());
+
+#if NTSCFG_MOVE_RESET_ENABLED
+        NTSCFG_TEST_TRUE(source.algorithm().empty());
+        NTSCFG_TEST_EQ(source.allocator(), NTSCFG_TEST_ALLOCATOR);
+#endif
+    }
+
+    {
+        ntsa::TcpCongestionControl source("debug", NTSCFG_TEST_ALLOCATOR);
+        NTSCFG_TEST_EQ(source.algorithm(), "debug");
+        NTSCFG_TEST_EQ(source.allocator(), NTSCFG_TEST_ALLOCATOR);
+
+        ntsa::TcpCongestionControl destination(NTSCFG_TEST_ALLOCATOR);
+        NTSCFG_TEST_TRUE(destination.algorithm().empty());
+        NTSCFG_TEST_EQ(destination.allocator(), NTSCFG_TEST_ALLOCATOR);
+
+        destination = NTSCFG_MOVE(source);
+
+        NTSCFG_TEST_EQ(destination.algorithm(), "debug");
+        NTSCFG_TEST_EQ(destination.allocator(), NTSCFG_TEST_ALLOCATOR);
+
+#if NTSCFG_MOVE_RESET_ENABLED
+        NTSCFG_TEST_TRUE(source.algorithm().empty());
+        NTSCFG_TEST_EQ(source.allocator(), NTSCFG_TEST_ALLOCATOR);
+#endif
+    }
+}
+
+void TcpCongestionControlTest::verifyOverloadAssignment()
+{
+}
+
+void TcpCongestionControlTest::verifyReset()
+{
+    ntsa::TcpCongestionControl source("debug", NTSCFG_TEST_ALLOCATOR);
+    NTSCFG_TEST_EQ(source.algorithm(), "debug");
+    NTSCFG_TEST_EQ(source.allocator(), NTSCFG_TEST_ALLOCATOR);
+
+    source.reset();
+
+    NTSCFG_TEST_TRUE(source.algorithm().empty());
+    NTSCFG_TEST_EQ(source.allocator(), NTSCFG_TEST_ALLOCATOR);
+}
+
+void TcpCongestionControlTest::verifyWellKnownEnumerators()
+{
+    ntsa::Error error;
+
+    TcpCongestionControl cc(NTSCFG_TEST_ALLOCATOR);
+    NTSCFG_TEST_EQ(cc.algorithm(), "");
+
+    {
+        const char* name = "some_long_name_here";
+
+        error = cc.setAlgorithmName(name);
+        NTSCFG_TEST_OK(error);
+
+        NTSCFG_TEST_EQ(cc.algorithm(), name);
+    }
+
+    {
+        error = cc.setAlgorithm(TcpCongestionControlAlgorithm::e_BBR);
+        NTSCFG_TEST_OK(error);
+
+        NTSCFG_TEST_EQ(cc.algorithm(), "bbr");
+    }
+
+    {
+        cc.reset();
+        NTSCFG_TEST_EQ(cc.algorithm(), "");
+    }
+
+    {
+        TcpCongestionControl cc2(NTSCFG_TEST_ALLOCATOR);
+
+        error = cc2.setAlgorithm(TcpCongestionControlAlgorithm::e_HYBLA);
+        NTSCFG_TEST_OK(error);
+        NTSCFG_TEST_NE(cc2, cc);
+
+        NTSCFG_TEST_OK(
+            cc.setAlgorithm(TcpCongestionControlAlgorithm::e_HYBLA));
+        NTSCFG_TEST_EQ(cc2, cc);
+    }
+
+    {
+        TcpCongestionControl cc2(NTSCFG_TEST_ALLOCATOR);
+
+        error = cc2.setAlgorithm(TcpCongestionControlAlgorithm::e_WESTWOOD);
+        NTSCFG_TEST_OK(error);
+
+        cc = cc2;
+        NTSCFG_TEST_EQ(cc.algorithm(), "westwood");
+    }
+}
+
+}  // close namespace ntsa
+}  // close namespace BloombergLP
+
+NTSCFG_TEST_SUITE
+{
+    NTSCFG_TEST_FUNCTION(&ntsa::TcpCongestionControlTest::verifyTypeTraits);
+    NTSCFG_TEST_FUNCTION(
+        &ntsa::TcpCongestionControlTest::verifyDefaultConstructor);
+    NTSCFG_TEST_FUNCTION(
+        &ntsa::TcpCongestionControlTest::verifyMoveConstructor);
+    NTSCFG_TEST_FUNCTION(
+        &ntsa::TcpCongestionControlTest::verifyCopyConstructor);
+    NTSCFG_TEST_FUNCTION(
+        &ntsa::TcpCongestionControlTest::verifyOverloadConstructor);
+    NTSCFG_TEST_FUNCTION(
+        &ntsa::TcpCongestionControlTest::verifyCopyAssignment);
+    NTSCFG_TEST_FUNCTION(
+        &ntsa::TcpCongestionControlTest::verifyMoveAssignment);
+    NTSCFG_TEST_FUNCTION(
+        &ntsa::TcpCongestionControlTest::verifyOverloadAssignment);
+    NTSCFG_TEST_FUNCTION(&ntsa::TcpCongestionControlTest::verifyReset);
+    NTSCFG_TEST_FUNCTION(
+        &ntsa::TcpCongestionControlTest::verifyWellKnownEnumerators);
+}
+NTSCFG_TEST_SUITE_END;

--- a/groups/nts/ntscfg/ntscfg_platform.h
+++ b/groups/nts/ntscfg/ntscfg_platform.h
@@ -21,10 +21,15 @@ BSLS_IDENT("$Id: $")
 
 #include <ntscfg_config.h>
 #include <ntsscm_version.h>
+#include <bsla_annotations.h>
+#include <bsla_deprecated.h>
 #include <bslalg_typetraits.h>
+#include <bslmf_nestedtraitdeclaration.h>
+#include <bslmf_movableref.h>
 #include <bslmt_lockguard.h>
 #include <bslmt_mutex.h>
 #include <bsls_assert.h>
+#include <bsls_compilerfeatures.h>
 #include <bsls_keyword.h>
 #include <bsls_log.h>
 #include <bsls_performancehint.h>
@@ -41,7 +46,7 @@ BSLS_IDENT("$Id: $")
 namespace BloombergLP {
 namespace ntscfg {
 
-#if NTS_BUILD_WITH_INLINING_FORCED 
+#if NTS_BUILD_WITH_INLINING_FORCED
 
 #if defined(NDEBUG) || defined(BDE_BUILD_TARGET_OPT)
 #if defined(BSLS_PLATFORM_CMP_GNU) || defined(BSLS_PLATFORM_CMP_CLANG)
@@ -115,20 +120,185 @@ namespace ntscfg {
 
 #endif
 
+/// @internal @brief
+/// Fail to compile unless the caller reads the value of the return type.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_NODISCARD BSLA_NODISCARD
+
+/// @internal @brief
+/// The function never throws an exception.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_NOEXCEPT BSLS_KEYWORD_NOEXCEPT
+
+/// @internal @brief
+/// No other class may derive from this class.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_FINAL BSLS_KEYWORD_FINAL
+
+/// @internal @brief
+/// The function may be overriden by a derived class.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_VIRTUAL virtual
+
+/// @internal @brief
+/// The function overrides a function in a base class.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_OVERRIDE BSLS_KEYWORD_OVERRIDE
+
+/// @internal @brief
+/// The function must be overriden by a derived class.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_PURE = 0
+
+/// @internal @brief
+/// Return a movable reference to the specified 'x'.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_MOVE(x) bslmf::MovableRefUtil::move(x)
+
+/// @internal @brief
+/// Access the movable reference 'x'.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_MOVE_ACCESS(x) bslmf::MovableRefUtil::access(x)
+
+/// @internal @brief
+/// Return a movable reference to 'object.member'.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_MOVE_FROM(object, member) \
+    NTSCFG_MOVE(NTSCFG_MOVE_ACCESS(object).member)
+
+#if defined(BDE_BUILD_TARGET_OPT)
+
+/// Reset the value of 'x' after its value has been moved elsewhere to a valid
+/// but unspecified value.
+#define NTSCFG_MOVE_RESET(x)
+
+/// Return true if NTSCFG_MOVE_RESET is *not* a no-op, otherwise return false.
+#define NTSCFG_MOVE_RESET_ENABLED false
+
+#else
+
+/// Reset the value of 'x' after its value has been moved elsewhere to a valid
+/// but unspecified value.
+#define NTSCFG_MOVE_RESET(x) NTSCFG_MOVE_ACCESS(x).reset();
+
+/// Return true if NTSCFG_MOVE_RESET is *not* a no-op, otherwise return false.
+#define NTSCFG_MOVE_RESET_ENABLED true
+
+#endif
+
 /// Declare the specified 'TYPE' is bitwise-movable.
+///
 /// @ingroup module_ntscfg
 #define NTSCFG_DECLARE_NESTED_BITWISE_MOVABLE_TRAITS(TYPE)                    \
-    BSLALG_DECLARE_NESTED_TRAITS4(                                            \
+    BSLALG_DECLARE_NESTED_TRAITS(                                             \
         TYPE,                                                                 \
-        bslalg::TypeTraitBitwiseMoveable,                                     \
-        bslalg::TypeTraitBitwiseCopyable,                                     \
-        bslalg::TypeTraitBitwiseEqualityComparable,                           \
-        bslalg::TypeTraitHasTrivialDefaultConstructor)
+        bslalg::TypeTraitBitwiseMoveable)
 
 /// Declare the specified 'TYPE' uses an allocator to supply memory.
+///
 /// @ingroup module_ntscfg
 #define NTSCFG_DECLARE_NESTED_USES_ALLOCATOR_TRAITS(TYPE)                     \
     BSLALG_DECLARE_NESTED_TRAITS(TYPE, bslalg::TypeTraitUsesBslmaAllocator)
+
+/// Declare a type trait for the specified 'type' to indicate its default
+/// constructor is equivalent to setting each byte of the object's footprint to
+/// zero. Note that traits, such that this one, can be used to select, at
+/// compile-time, the correct and/or most efficient algorithm for objects of
+/// this type.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_TYPE_TRAIT_BITWISE_INITIALIZABLE(Type) \
+    BSLMF_NESTED_TRAIT_DECLARATION( \
+        Type, bsl::is_trivially_default_constructible)
+
+/// Declare a type trait for the specified 'type' to indicate its
+/// copy-constructor and copy-assignment operator is equivalent to copying each
+/// byte of the source object's footprint to each corresponding byte of the
+/// destination object's footprint. Note that traits, such that this one, can
+/// be used to select, at compile-time, the correct and/or most efficient
+/// algorithm for objects of this type. Also note that this trait implies an
+/// object of this type has a trivial destructor.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_TYPE_TRAIT_BITWISE_COPYABLE(Type) \
+    BSLMF_NESTED_TRAIT_DECLARATION(Type, bslmf::IsBitwiseCopyable)
+
+/// Declare a type trait for the specified 'type' to indicate its
+/// move-constructor and move-assignment operator is equivalent to copying each
+/// byte of the source object's footprint to each corresponding byte of the
+/// destination object's footprint. These traits can be used to select, at
+/// compile-time, the most efficient algorithm to manipulate objects of this
+/// type.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_TYPE_TRAIT_BITWISE_MOVABLE(Type) \
+    BSLMF_NESTED_TRAIT_DECLARATION(Type, bslmf::IsBitwiseMoveable)
+
+/// Declare a type trait for the specified 'type' to indicate its
+/// equality-comparison operator is equivalent to comparing each byte of one
+/// comparand's footprint to each corresponding byte of the other comparand's
+/// footprint. Note that traits, such that this one, can be used to select, at
+/// compile-time, the correct and/or most efficient algorithm for objects of
+/// this type. Also note that this trait implies that an object of this type
+/// has no padding bytes between data members.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_TYPE_TRAIT_BITWISE_COMPARABLE(Type) \
+    BSLMF_NESTED_TRAIT_DECLARATION(Type, bslmf::IsBitwiseEqualityComparable)
+
+/// Declare a type trait for the specified 'type' to indicate it accepts an
+/// allocator argument to its constructors and may dynamically allocate memory
+/// during its operation. Note that traits, such that this one, can be used to
+/// select, at compile-time, the correct and/or most efficient algorithm for
+/// objects of this type.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_TYPE_TRAIT_ALLOCATOR_AWARE(Type) \
+    BSLALG_DECLARE_NESTED_TRAITS(Type, bslalg::TypeTraitUsesBslmaAllocator)
+
+/// Return true if the specified 'type' is bitwise-initializable, otherwise
+/// return false.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_TYPE_CHECK_BITWISE_INITIALIZABLE(Type) \
+    bsl::is_trivially_default_constructible<Type>::value
+
+/// Return true if the specified 'type' is bitwise-movable, otherwise return
+/// false.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_TYPE_CHECK_BITWISE_MOVABLE(Type) \
+    bslmf::IsBitwiseMoveable<Type>::value
+
+/// Return true if the specified 'type' is bitwise-copyable, otherwise return
+/// false.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_TYPE_CHECK_BITWISE_COPYABLE(Type) \
+    bslmf::IsBitwiseCopyable<Type>::value
+
+/// Return true if the specified 'type' is bitwise-comparable, otherwise return
+/// false.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_TYPE_CHECK_BITWISE_COMPARABLE(Type) \
+    bslmf::IsBitwiseEqualityComparable<Type>::value
+
+/// Return true if the specified 'type' accepts an allocator argument to its
+/// constructors, otherwise return false.
+///
+/// @ingroup module_ntscfg
+#define NTSCFG_TYPE_CHECK_ALLOCATOR_AWARE(Type) \
+    bslalg::TypeTraitUsesBslmaAllocator<Type>::Value
 
 /// @internal @brief
 /// Throw an exception having the specified string 'description'.
@@ -246,11 +416,11 @@ struct Platform {
     static bool hasPortDatabase();
 
     /// Return the build branch, or the version string if the build branch
-    /// is unknown. 
+    /// is unknown.
     static bsl::string buildBranch();
 
     /// Return the build commit hash, or the empty string if the build commit
-    /// hash is unknown. 
+    /// hash is unknown.
     static bsl::string buildCommitHash();
 
     /// Return the build commit hash, abbreviated, or the empty string if the

--- a/groups/nts/ntscfg/ntscfg_platform.h
+++ b/groups/nts/ntscfg/ntscfg_platform.h
@@ -277,7 +277,8 @@ namespace ntscfg {
 ///
 /// @ingroup module_ntscfg
 #define NTSCFG_TYPE_CHECK_BITWISE_MOVABLE(Type) \
-    bslmf::IsBitwiseMoveable<Type>::value
+    ((bslmf::IsBitwiseMoveable<Type>::value) && \
+     (bsl::is_nothrow_move_constructible<ntsa::Ipv4Address>::value))
 
 /// Return true if the specified 'type' is bitwise-copyable, otherwise return
 /// false.
@@ -298,7 +299,7 @@ namespace ntscfg {
 ///
 /// @ingroup module_ntscfg
 #define NTSCFG_TYPE_CHECK_ALLOCATOR_AWARE(Type) \
-    bslalg::TypeTraitUsesBslmaAllocator<Type>::Value
+    bslalg::HasTrait<Type, bslalg::TypeTraitUsesBslmaAllocator>::VALUE
 
 /// @internal @brief
 /// Throw an exception having the specified string 'description'.

--- a/groups/nts/ntscfg/ntscfg_platform.h
+++ b/groups/nts/ntscfg/ntscfg_platform.h
@@ -24,6 +24,17 @@ BSLS_IDENT("$Id: $")
 #include <bsla_annotations.h>
 #include <bsla_deprecated.h>
 #include <bslalg_typetraits.h>
+#include <bslalg_hastrait.h>
+#include <bslalg_typetraitbitwisecopyable.h>
+#include <bslalg_typetraitbitwisemoveable.h>
+#include <bslalg_typetraitbitwiseequalitycomparable.h>
+#include <bslalg_typetraithastrivialdefaultconstructor.h>
+#include <bslalg_typetraitusesbslmaallocator.h>
+#include <bslmf_isbitwisecopyable.h>
+#include <bslmf_isbitwisemoveable.h>
+#include <bslmf_isbitwiseequalitycomparable.h>
+#include <bslmf_isnothrowmoveconstructible.h>
+#include <bslmf_isnothrowswappable.h>
 #include <bslmf_nestedtraitdeclaration.h>
 #include <bslmf_movableref.h>
 #include <bslmt_lockguard.h>


### PR DESCRIPTION
This PR defines move constructors and move assignment operators for `ntsa::Ipv4Address` and `ntsa::TcpCongestionControl`, with no-throw attributes as appropriate. This PR also introduces a new, finer-grained type trait macro system and a new, streamlined test case registration system. Move constructors and move assignment operators will be similarly added to other types in subsequent PRs, adopting the same new test case registration system.