### PR TITLE
Define secure defaults for ntca::EncryptionAuthentication and ntca::EncryptionMethod

### DIFF
--- a/groups/ntc/ntca/ntca_encryptionauthentication.cpp
+++ b/groups/ntc/ntca/ntca_encryptionauthentication.cpp
@@ -29,6 +29,7 @@ int EncryptionAuthentication::fromInt(EncryptionAuthentication::Value* result,
                                       int                              number)
 {
     switch (number) {
+    case EncryptionAuthentication::e_DEFAULT:
     case EncryptionAuthentication::e_NONE:
     case EncryptionAuthentication::e_VERIFY:
         *result = static_cast<EncryptionAuthentication::Value>(number);
@@ -42,6 +43,10 @@ int EncryptionAuthentication::fromString(
     EncryptionAuthentication::Value* result,
     const bslstl::StringRef&         string)
 {
+    if (bdlb::String::areEqualCaseless(string, "DEFAULT")) {
+        *result = e_DEFAULT;
+        return 0;
+    }
     if (bdlb::String::areEqualCaseless(string, "NONE")) {
         *result = e_NONE;
         return 0;
@@ -58,6 +63,9 @@ const char* EncryptionAuthentication::toString(
     EncryptionAuthentication::Value value)
 {
     switch (value) {
+    case e_DEFAULT: {
+        return "DEFAULT";
+    } break;
     case e_NONE: {
         return "NONE";
     } break;

--- a/groups/ntc/ntca/ntca_encryptionauthentication.h
+++ b/groups/ntc/ntca/ntca_encryptionauthentication.h
@@ -35,6 +35,13 @@ struct EncryptionAuthentication {
   public:
     /// Enumerate the authentication modes.
     enum Value {
+        /// If the socket context is operating in server mode, the server will
+        /// not request a certificate from the client.  If the socket is
+        /// operating in client mode, the handshake will fail if there is no
+        /// trusted certificate authority through which to verify the server's
+        /// identity.
+        e_DEFAULT,
+
         /// If the socket context is operating in server mode, the server
         /// will not request a certificate from the client.  If the socket
         /// context is operating in client mode, the handshake will succeed
@@ -44,9 +51,9 @@ struct EncryptionAuthentication {
         /// If the socket context is operating in server mode, the server
         /// will request a certificate from the client, and the handshake
         /// will fail if either the client does not return a certificate or
-        /// if there is no matching certificate authority through which to
-        /// verify the client's identity.  If the socket is operating in
-        /// client mode, the handshake will fail if there is not matching
+        /// if there is no trusted certificate authority through which to
+        /// verify the client's identity. If the socket is operating in
+        /// client mode, the handshake will fail if there is no trusted
         /// certificate authority through which to verify the server's
         /// identity.
         e_VERIFY

--- a/groups/ntc/ntca/ntca_encryptionmethod.cpp
+++ b/groups/ntc/ntca/ntca_encryptionmethod.cpp
@@ -28,6 +28,7 @@ namespace ntca {
 int EncryptionMethod::fromInt(EncryptionMethod::Value* result, int number)
 {
     switch (number) {
+    case EncryptionMethod::e_DEFAULT:
     case EncryptionMethod::e_TLS_V1_X:
     case EncryptionMethod::e_TLS_V1_0:
     case EncryptionMethod::e_TLS_V1_1:
@@ -43,6 +44,10 @@ int EncryptionMethod::fromInt(EncryptionMethod::Value* result, int number)
 int EncryptionMethod::fromString(EncryptionMethod::Value* result,
                                  const bslstl::StringRef& string)
 {
+    if (bdlb::String::areEqualCaseless(string, "DEFAULT")) {
+        *result = e_DEFAULT;
+        return 0;
+    }
     if (bdlb::String::areEqualCaseless(string, "TLS_V1_X")) {
         *result = e_TLS_V1_X;
         return 0;
@@ -70,6 +75,9 @@ int EncryptionMethod::fromString(EncryptionMethod::Value* result,
 const char* EncryptionMethod::toString(EncryptionMethod::Value value)
 {
     switch (value) {
+    case e_DEFAULT: {
+        return "DEFAULT";
+    } break;
     case e_TLS_V1_X: {
         return "TLS_V1_X";
     } break;

--- a/groups/ntc/ntca/ntca_encryptionmethod.h
+++ b/groups/ntc/ntca/ntca_encryptionmethod.h
@@ -35,24 +35,31 @@ struct EncryptionMethod {
   public:
     /// Enumerate the methods of encryption.
     enum Value {
-        // A TLS/SSL connection established with these methods will only
-        // understand the TLSv1 protocol.
+        /// When specified as a minimum version, the minimum version is
+        /// interpreted as the minimum version suggested by the current
+        /// standards of cryptography. When specified as a maximum version, the
+        /// maximum version is interpreted as the maximum version supported by
+        /// the implementation.
+        e_DEFAULT,
+
+        /// A TLS/SSL connection established with these methods will only
+        /// understand the TLSv1 protocol.
         e_TLS_V1_0,
 
-        // A TLS/SSL connection established with these methods will only
-        // understand the TLSv1.1 protocol.
+        /// A TLS/SSL connection established with these methods will only
+        /// understand the TLSv1.1 protocol.
         e_TLS_V1_1,
 
-        // A TLS/SSL connection established with these methods will only
-        // understand the TLSv1.2 protocol.
+        /// A TLS/SSL connection established with these methods will only
+        /// understand the TLSv1.2 protocol.
         e_TLS_V1_2,
 
-        // A TLS/SSL connection established with these methods will only
-        // understand the TLSv1.3 protocol.
+        /// A TLS/SSL connection established with these methods will only
+        /// understand the TLSv1.3 protocol.
         e_TLS_V1_3,
 
-        // A TLS/SSL connection established with these methods may
-        // understand the TLSv1, TLSv1.1 and TLSv1.2 protocols.
+        /// A TLS/SSL connection established with these methods may understand
+        /// the TLSv1, TLSv1.1 and TLSv1.2 protocols.
         e_TLS_V1_X
     };
 

--- a/groups/ntc/ntca/ntca_encryptionoptions.cpp
+++ b/groups/ntc/ntca/ntca_encryptionoptions.cpp
@@ -48,9 +48,9 @@ bool sortResource(const ntca::EncryptionResource& lhs,
 }  // close unnamed namespace
 
 EncryptionOptions::EncryptionOptions(bslma::Allocator* basicAllocator)
-: d_minMethod(ntca::EncryptionMethod::e_TLS_V1_X)
-, d_maxMethod(ntca::EncryptionMethod::e_TLS_V1_X)
-, d_authentication(ntca::EncryptionAuthentication::e_NONE)
+: d_minMethod(ntca::EncryptionMethod::e_DEFAULT)
+, d_maxMethod(ntca::EncryptionMethod::e_DEFAULT)
+, d_authentication(ntca::EncryptionAuthentication::e_DEFAULT)
 , d_validation(basicAllocator)
 , d_resourceVector(basicAllocator)
 , d_authorityDirectory(basicAllocator)
@@ -91,9 +91,9 @@ EncryptionOptions& EncryptionOptions::operator=(const EncryptionOptions& other)
 
 void EncryptionOptions::reset()
 {
-    d_minMethod      = ntca::EncryptionMethod::e_TLS_V1_X;
-    d_maxMethod      = ntca::EncryptionMethod::e_TLS_V1_X;
-    d_authentication = ntca::EncryptionAuthentication::e_NONE;
+    d_minMethod      = ntca::EncryptionMethod::e_DEFAULT;
+    d_maxMethod      = ntca::EncryptionMethod::e_DEFAULT;
+    d_authentication = ntca::EncryptionAuthentication::e_DEFAULT;
     d_validation.reset();
     d_resourceVector.clear();
     d_authorityDirectory.reset();


### PR DESCRIPTION
This PR adds new 'e_DEFAULT` enumerators to `ntca::EncryptionAuthentication` and `ntca::EncryptionMethod`. These enumerators are interpreted differently whether the context is in the role of a TLS client or server, and apply an (expected) secure-by-default implementation policy.