### PR TITLE
Support MCAST_JOIN_SOURCE_GROUP on Linux

### DIFF
--- a/groups/nts/ntsb/ntsb_datagramsocket.cpp
+++ b/groups/nts/ntsb/ntsb_datagramsocket.cpp
@@ -196,6 +196,24 @@ ntsa::Error DatagramSocket::joinMulticastGroup(
                                                       group);
 }
 
+ntsa::Error DatagramSocket::joinMulticastGroupSource(
+        const ntsa::IpAddress& interface,
+        const ntsa::IpAddress& group,
+        const ntsa::IpAddress& source)
+{
+    return ntsu::SocketOptionUtil::joinMulticastGroupSource(
+        d_handle, interface, group, source);
+}
+
+ntsa::Error DatagramSocket::leaveMulticastGroupSource(
+        const ntsa::IpAddress& interface,
+        const ntsa::IpAddress& group,
+        const ntsa::IpAddress& source)
+{
+    return ntsu::SocketOptionUtil::leaveMulticastGroupSource(
+        d_handle, interface, group, source);
+}
+
 ntsa::Error DatagramSocket::leaveMulticastGroup(
     const ntsa::IpAddress& interface,
     const ntsa::IpAddress& group)

--- a/groups/nts/ntsb/ntsb_datagramsocket.h
+++ b/groups/nts/ntsb/ntsb_datagramsocket.h
@@ -193,6 +193,27 @@ class DatagramSocket : public ntsi::DatagramSocket
                                     const ntsa::IpAddress& group)
         BSLS_KEYWORD_OVERRIDE;
 
+    /// Join the specified source-specific multicast 'group' on the adapter
+    /// identified by the specified 'interface' and allow receiving datagrams
+    /// only from the specified 'source'. Return the error. Note that this
+    /// function may be called multiple times to allow receiving multicast
+    /// datagrams only from a particular set of source addresses.
+    ntsa::Error joinMulticastGroupSource(
+        const ntsa::IpAddress& interface,
+        const ntsa::IpAddress& group,
+        const ntsa::IpAddress& source) BSLS_KEYWORD_OVERRIDE;
+
+    /// Leave the specified source-specific multicast 'group' on the adapter
+    /// identified by the specified 'interface', disallowing datagrams sent by
+    /// the specified 'source'. Return the error. If the 'socket' has
+    /// subscribed to multiple sources within the same group, data from the
+    /// remaining sources will still be delivered. To stop receiving data from
+    /// all sources at once, use 'leaveMulticastGroup'.
+    ntsa::Error leaveMulticastGroupSource(
+        const ntsa::IpAddress& interface,
+        const ntsa::IpAddress& group,
+        const ntsa::IpAddress& source) BSLS_KEYWORD_OVERRIDE;
+
     // *** Socket Options ***
 
     /// Set the option for the 'socket' that controls its blocking mode

--- a/groups/nts/ntsf/ntsf_system.cpp
+++ b/groups/nts/ntsf/ntsf_system.cpp
@@ -829,6 +829,26 @@ ntsa::Error System::leaveMulticastGroup(ntsa::Handle           socket,
                                                        group);
 }
 
+ntsa::Error System::joinMulticastGroupSource(
+    ntsa::Handle           socket,
+    const ntsa::IpAddress& interface,
+    const ntsa::IpAddress& group,
+    const ntsa::IpAddress& source)
+{
+    return ntsu::SocketOptionUtil::joinMulticastGroupSource(
+        socket, interface, group, source);
+}
+
+ntsa::Error System::leaveMulticastGroupSource(
+    ntsa::Handle           socket,
+    const ntsa::IpAddress& interface,
+    const ntsa::IpAddress& group,
+    const ntsa::IpAddress& source)
+{
+    return ntsu::SocketOptionUtil::leaveMulticastGroupSource(
+        socket, interface, group, source);
+}
+
 ntsa::Error System::setBlocking(ntsa::Handle socket, bool blocking)
 {
     return ntsu::SocketOptionUtil::setBlocking(socket, blocking);

--- a/groups/nts/ntsf/ntsf_system.h
+++ b/groups/nts/ntsf/ntsf_system.h
@@ -1193,6 +1193,31 @@ struct System {
                                            const ntsa::IpAddress& interface,
                                            const ntsa::IpAddress& group);
 
+    /// Issue an IGMP message to add the specified 'socket' to the specified
+    /// source-specific multicast 'group' on the adapter identified by the
+    /// specified 'interface' and allow receiving datagrams only from the
+    /// specified 'source'. Return the error. Note that this function may be
+    /// called multiple times to allow receiving multicast datagrams only from
+    /// a particular set of source addresses.
+    static ntsa::Error joinMulticastGroupSource(
+        ntsa::Handle           socket,
+        const ntsa::IpAddress& interface,
+        const ntsa::IpAddress& group,
+        const ntsa::IpAddress& source);
+
+    /// Issue an IGMP message to remove the specified 'socket' from the
+    /// specified source-specific multicast 'group' on the adapter identified
+    /// by the specified 'interface', disallowing datagrams sent by the
+    /// specified 'source'. Return the error. If the 'socket' has subscribed to
+    /// multiple sources within the same group, data from the remaining sources
+    /// will still be delivered.  To stop receiving data from all sources at
+    /// once, use 'leaveMulticastGroup'.
+    static ntsa::Error leaveMulticastGroupSource(
+        ntsa::Handle           socket,
+        const ntsa::IpAddress& interface,
+        const ntsa::IpAddress& group,
+        const ntsa::IpAddress& source);
+
     /// Set the option for the 'socket' that controls its blocking mode
     /// according to the specified 'blocking' flag. Return the error.
     static ntsa::Error setBlocking(ntsa::Handle socket, bool blocking);

--- a/groups/nts/ntsi/ntsi_datagramsocket.cpp
+++ b/groups/nts/ntsi/ntsi_datagramsocket.cpp
@@ -186,6 +186,30 @@ ntsa::Error DatagramSocket::leaveMulticastGroup(
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 
+ntsa::Error DatagramSocket::joinMulticastGroupSource(
+        const ntsa::IpAddress& interface,
+        const ntsa::IpAddress& group,
+        const ntsa::IpAddress& source)
+{
+    NTSCFG_WARNING_UNUSED(interface);
+    NTSCFG_WARNING_UNUSED(group);
+    NTSCFG_WARNING_UNUSED(source);
+
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error DatagramSocket::leaveMulticastGroupSource(
+        const ntsa::IpAddress& interface,
+        const ntsa::IpAddress& group,
+        const ntsa::IpAddress& source)
+{
+    NTSCFG_WARNING_UNUSED(interface);
+    NTSCFG_WARNING_UNUSED(group);
+    NTSCFG_WARNING_UNUSED(source);
+
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
 ntsa::Error DatagramSocket::setBlocking(bool blocking)
 {
     NTSCFG_WARNING_UNUSED(blocking);

--- a/groups/nts/ntsi/ntsi_datagramsocket.h
+++ b/groups/nts/ntsi/ntsi_datagramsocket.h
@@ -565,6 +565,27 @@ class DatagramSocket : public ntsi::Channel
     virtual ntsa::Error leaveMulticastGroup(const ntsa::IpAddress& interface,
                                             const ntsa::IpAddress& group);
 
+    /// Join the specified source-specific multicast 'group' on the adapter
+    /// identified by the specified 'interface' and allow receiving datagrams
+    /// only from the specified 'source'. Return the error. Note that this
+    /// function may be called multiple times to allow receiving multicast
+    /// datagrams only from a particular set of source addresses.
+    virtual ntsa::Error joinMulticastGroupSource(
+        const ntsa::IpAddress& interface,
+        const ntsa::IpAddress& group,
+        const ntsa::IpAddress& source);
+
+    /// Leave the specified source-specific multicast 'group' on the adapter
+    /// identified by the specified 'interface', disallowing datagrams sent by
+    /// the specified 'source'. Return the error. If the 'socket' has
+    /// subscribed to multiple sources within the same group, data from the
+    /// remaining sources will still be delivered. To stop receiving data from
+    /// all sources at once, use 'leaveMulticastGroup'.
+    virtual ntsa::Error leaveMulticastGroupSource(
+        const ntsa::IpAddress& interface,
+        const ntsa::IpAddress& group,
+        const ntsa::IpAddress& source);
+
     // *** Socket Options ***
 
     /// Set the option for the 'socket' that controls its blocking mode

--- a/groups/nts/ntsu/ntsu_adapterutil.cpp
+++ b/groups/nts/ntsu/ntsu_adapterutil.cpp
@@ -850,6 +850,44 @@ bool AdapterUtil::discoverAdapter(ntsa::Adapter*             result,
 }
 
 bsl::uint32_t AdapterUtil::discoverInterfaceIndex(
+    const ntsa::IpAddress& address)
+{
+    if (address.isV4()) {
+        return AdapterUtil::discoverInterfaceIndex(address.v4());
+    }
+    else if (address.isV6()) {
+        return AdapterUtil::discoverInterfaceIndex(address.v6());
+    }
+    else {
+        return 0;
+    }
+}
+
+bsl::uint32_t AdapterUtil::discoverInterfaceIndex(
+    const ntsa::Ipv4Address& address)
+{
+    bsl::uint32_t interfaceIndex = 0;
+
+    bsl::vector<ntsa::Adapter> adapters;
+    ntsu::AdapterUtil::discoverAdapterList(&adapters);
+
+    for (bsl::vector<ntsa::Adapter>::const_iterator it = adapters.begin();
+         it != adapters.end();
+         ++it)
+    {
+        const ntsa::Adapter& adapter = *it;
+        if (!adapter.ipv4Address().isNull()) {
+            if (adapter.ipv4Address().value() == address) {
+                interfaceIndex = adapter.index();
+                break;
+            }
+        }
+    }
+
+    return interfaceIndex;
+}
+
+bsl::uint32_t AdapterUtil::discoverInterfaceIndex(
     const ntsa::Ipv6Address& address)
 {
     bsl::uint32_t interfaceIndex = 0;

--- a/groups/nts/ntsu/ntsu_adapterutil.h
+++ b/groups/nts/ntsu/ntsu_adapterutil.h
@@ -92,7 +92,17 @@ struct AdapterUtil {
                                 bool                       multicast);
 
     /// Return the interface index for the adapter assigned the specified
-    /// 'address'.
+    /// 'address', or 0 if no such adapter is assigned the address.
+    static bsl::uint32_t discoverInterfaceIndex(
+        const ntsa::IpAddress& address);
+
+    /// Return the interface index for the adapter assigned the specified
+    /// 'address', or 0 if no such adapter is assigned the address.
+    static bsl::uint32_t discoverInterfaceIndex(
+        const ntsa::Ipv4Address& address);
+
+    /// Return the interface index for the adapter assigned the specified
+    /// 'address', or 0 if no such adapter is assigned the address.
     static bsl::uint32_t discoverInterfaceIndex(
         const ntsa::Ipv6Address& address);
 

--- a/groups/nts/ntsu/ntsu_socketoptionutil.h
+++ b/groups/nts/ntsu/ntsu_socketoptionutil.h
@@ -300,6 +300,31 @@ struct SocketOptionUtil {
                                            const ntsa::IpAddress& interface,
                                            const ntsa::IpAddress& group);
 
+    /// Issue an IGMP message to add the specified 'socket' to the specified
+    /// source-specific multicast 'group' on the adapter identified by the
+    /// specified 'interface' and allow receiving datagrams only from the
+    /// specified 'source'. Return the error. Note that this function may be
+    /// called multiple times to allow receiving multicast datagrams only from
+    /// a particular set of source addresses.
+    static ntsa::Error joinMulticastGroupSource(
+        ntsa::Handle           socket,
+        const ntsa::IpAddress& interface,
+        const ntsa::IpAddress& group,
+        const ntsa::IpAddress& source);
+
+    /// Issue an IGMP message to remove the specified 'socket' from the
+    /// specified source-specific multicast 'group' on the adapter identified
+    /// by the specified 'interface', disallowing datagrams sent by the
+    /// specified 'source'. Return the error. If the 'socket' has subscribed to
+    /// multiple sources within the same group, data from the remaining sources
+    /// will still be delivered.  To stop receiving data from all sources at
+    /// once, use 'leaveMulticastGroup'.
+    static ntsa::Error leaveMulticastGroupSource(
+        ntsa::Handle           socket,
+        const ntsa::IpAddress& interface,
+        const ntsa::IpAddress& group,
+        const ntsa::IpAddress& source);    
+
     /// Load into the specified 'result' the flag that indicates if the
     /// socket type is a stream socket. Return the error.
     static ntsa::Error isStream(bool* result, ntsa::Handle socket);

--- a/groups/nts/ntsu/ntsu_socketoptionutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketoptionutil.t.cpp
@@ -1367,6 +1367,62 @@ NTSCFG_TEST_CASE(3)
                 }
             }
 
+            // Test join source-specific multicast group.
+
+            {
+                if (transport == ntsa::Transport::e_UDP_IPV4_DATAGRAM) {
+                    error = ntsu::SocketOptionUtil::joinMulticastGroupSource(
+                        socket,
+                        ntsa::IpAddress(adapter.ipv4Address().value()),
+                        ntsa::IpAddress("224.0.0.0"),
+                        ntsa::IpAddress(ntsa::Ipv4Address::loopback()));
+                }
+                else {
+                    error = ntsu::SocketOptionUtil::joinMulticastGroupSource(
+                        socket,
+                        ntsa::IpAddress(adapter.ipv6Address().value()),
+                        ntsa::IpAddress(
+                            "ff00:0000:0000:0000:0000:0000:0000:0000"),
+                        ntsa::IpAddress(ntsa::Ipv6Address::loopback()));
+                }
+
+                BSLS_LOG_INFO("joinMulticastGroupSource: %s",
+                              error.text().c_str());
+
+                if (error) {
+                    NTSCFG_TEST_TRUE(error == ntsa::Error::e_INVALID ||
+                                     error == ntsa::Error::e_NOT_IMPLEMENTED);
+                }
+            }
+
+            // Test leave source-specific multicast group.
+
+            {
+                if (transport == ntsa::Transport::e_UDP_IPV4_DATAGRAM) {
+                    error = ntsu::SocketOptionUtil::leaveMulticastGroupSource(
+                        socket,
+                        ntsa::IpAddress(adapter.ipv4Address().value()),
+                        ntsa::IpAddress("224.0.0.0"),
+                        ntsa::IpAddress(ntsa::Ipv4Address::loopback()));
+                }
+                else {
+                    error = ntsu::SocketOptionUtil::leaveMulticastGroupSource(
+                        socket,
+                        ntsa::IpAddress(adapter.ipv6Address().value()),
+                        ntsa::IpAddress(
+                            "ff00:0000:0000:0000:0000:0000:0000:0000"),
+                        ntsa::IpAddress(ntsa::Ipv6Address::loopback()));
+                }
+
+                BSLS_LOG_INFO("leaveMulticastGroupSource: %s",
+                              error.text().c_str());
+
+                if (error) {
+                    NTSCFG_TEST_TRUE(error == ntsa::Error::e_INVALID ||
+                                     error == ntsa::Error::e_NOT_IMPLEMENTED);
+                }
+            }
+
             // Close the socket.
 
             ntsu::SocketUtil::close(socket);


### PR DESCRIPTION
This PR adds support for `MCAST_JOIN_SOURCE_GROUP` and `MCAST_LEAVE_SOURCE_GROUP` on Linux. Support for joining and leaving source-specific multicast groups on other platforms will be forthcoming.