### PR TITLE
Gihub actions: increase bde version & set CPP standard to CPP20 for building BDE

### DIFF
--- a/.github/workflows/docker/build_deps.sh
+++ b/.github/workflows/docker/build_deps.sh
@@ -21,8 +21,8 @@ fetch_git() {
 }
 
 fetch_deps() {
-    fetch_git bloomberg bde-tools 3.117.0.0
-    fetch_git bloomberg bde 3.117.0.0
+    fetch_git bloomberg bde-tools 4.8.0.0
+    fetch_git bloomberg bde 4.8.0.0
 }
 
 configure() {

--- a/.github/workflows/docker/build_deps.sh
+++ b/.github/workflows/docker/build_deps.sh
@@ -28,7 +28,7 @@ fetch_deps() {
 configure() {
     PATH="$PATH:$(realpath srcs/bde-tools/bin)"
     export PATH
-    eval "$(bbs_build_env -u opt_64_cpp17)"
+    eval "$(bbs_build_env -u opt_64_cpp20)"
 }
 
 build_bde() {


### PR DESCRIPTION
Otherwise CI is failing with 

> /workspace/ntf-core/groups/nts/ntscfg/ntscfg_platform.h:33:10: fatal error: bslmf_isbitwisecopyable.h: No such file or directory