### PR TITLE
Avoid sorting timers in ntcs::Chronology::load during potential timer rescheduling

### DIFF
--- a/groups/ntc/ntcs/ntcs_chronology.cpp
+++ b/groups/ntc/ntcs/ntcs_chronology.cpp
@@ -840,18 +840,6 @@ bsl::string Chronology::convertToDateTime(Microseconds timeInMicroseconds)
     return bsl::string(buffer);
 }
 
-bool Chronology::sortTimers(const bsl::shared_ptr<ntci::Timer>& lhs, 
-                            const bsl::shared_ptr<ntci::Timer>& rhs)
-{
-    const bdlb::NullableValue<bsls::TimeInterval> lhsDeadline = 
-        lhs->deadline();
-
-    const bdlb::NullableValue<bsls::TimeInterval> rhsDeadline = 
-        rhs->deadline();
-
-    return lhsDeadline < rhsDeadline;
-}
-
 Chronology::Chronology(ntcs::Interruptor* interruptor, 
                        bslma::Allocator*  basicAllocator)
 : d_object("ntcs::Chronology")
@@ -1406,12 +1394,6 @@ void Chronology::load(TimerVector* result) const
 
     if (d_parent_sp) {
         d_parent_sp->load(result);
-    }
-
-    if (!result->empty()) {
-        bsl::sort(result->begin(), 
-                  result->end(), 
-                  &Chronology::sortTimers);
     }
 }
 

--- a/groups/ntc/ntcs/ntcs_chronology.h
+++ b/groups/ntc/ntcs/ntcs_chronology.h
@@ -451,11 +451,6 @@ class Chronology NTSCFG_FINAL : public ntci::Chronology
     /// the Unix epoch in a date/time format.
     static bsl::string convertToDateTime(Microseconds timeInMicroseconds);
 
-    /// Return true if the deadline of the specified 'lhs' timer is less than 
-    /// the deadline of the specified 'rhs' timer.
-    static bool sortTimers(const bsl::shared_ptr<ntci::Timer>& lhs, 
-                           const bsl::shared_ptr<ntci::Timer>& rhs);
-
   public:
     /// The time interval that is LLONG_MAX microseconds from the Unix
     /// epoch.


### PR DESCRIPTION
The contract for `ntci::Chronology::load` does not demand that the timers are returned in scheduled order. Avoid sorting them in the implementation of `ntcs::Chronology::load` to avoid unstable strict weak ordering comparisons.