### PR TITLE
ntsu_socketutil.cpp: correct use of `ferror(3)`

### DIFF
--- a/groups/nts/ntsu/ntsu_socketutil.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.cpp
@@ -4998,7 +4998,7 @@ ntsa::Error reportInfoProcNetTcp(bsl::vector<ntsa::SocketInfo>* result,
 
     FILE* file = bsl::fopen(fileName, "r");
     if (file == 0) {
-        error = ntsa::Error(bsl::ferror(file));
+        error = ntsa::Error(errno);
         BSLS_LOG_ERROR("Failed to open '%s': %s",
                        fileName,
                        error.text().c_str());
@@ -5008,7 +5008,8 @@ ntsa::Error reportInfoProcNetTcp(bsl::vector<ntsa::SocketInfo>* result,
     char line[256];
 
     if (bsl::fgets(line, sizeof(line), file) == 0) {
-        error = ntsa::Error(bsl::ferror(file));
+        error = bsl::ferror(file) ? ntsa::Error(errno)
+                                  : ntsa::Error(ntsa::Error::e_EOF);
         BSLS_LOG_ERROR("Failed to read '%s': "
                        "failed to read header line: %s",
                        fileName,
@@ -5061,7 +5062,7 @@ ntsa::Error reportInfoProcNetUdp(bsl::vector<ntsa::SocketInfo>* result,
 
     FILE* file = bsl::fopen(fileName, "r");
     if (file == 0) {
-        error = ntsa::Error(bsl::ferror(file));
+        error = ntsa::Error(errno);
         BSLS_LOG_ERROR("Failed to open '%s': %s",
                        fileName,
                        error.text().c_str());
@@ -5071,7 +5072,8 @@ ntsa::Error reportInfoProcNetUdp(bsl::vector<ntsa::SocketInfo>* result,
     char line[256];
 
     if (bsl::fgets(line, sizeof(line), file) == 0) {
-        error = ntsa::Error(bsl::ferror(file));
+        error = bsl::ferror(file) ? ntsa::Error(errno)
+                                  : ntsa::Error(ntsa::Error::e_EOF);
         BSLS_LOG_ERROR("Failed to read '%s': "
                        "failed to read header line: %s",
                        fileName,


### PR DESCRIPTION
1. don't call ferror(3) on invalid (NULL) stream
2. don't use the flag returned by `ferror(3)` to create an `ntsa::Error` as it only indicates that an error occurred, and we should get it from `errno`

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
