### PR TITLE
ntci_log.cpp: add missing #include for syscall(2) and getpid(2)

### DIFF
--- a/groups/ntc/ntci/ntci_log.cpp
+++ b/groups/ntc/ntci/ntci_log.cpp
@@ -37,6 +37,7 @@ BSLS_IDENT_RCSID(ntci_log_cpp, "$Id$ $CSID$")
 
 #if defined(BSLS_PLATFORM_OS_LINUX)
 #include <sys/syscall.h>
+#include <unistd.h>
 #endif
 
 #define NTCI_LOG_UNSET_CONTEXT 0


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
An additional include is required to build on Ubuntu 24.04.1 LTS

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
