### PR TITLE
Provide a default ntci::EncryptionDriver implemented using OpenSSL

### DIFF
--- a/cmake/templates/ntccfg_config.h
+++ b/cmake/templates/ntccfg_config.h
@@ -106,6 +106,9 @@ namespace ntccfg {
 // driver for a proactor. This driver is available on Linux.
 #define NTC_BUILD_WITH_IORING @NTF_BUILD_WITH_IORING@
 
+// Build with support for OpenSSL as the driver for TLS.
+#define NTC_BUILD_WITH_OPENSSL @NTF_BUILD_WITH_OPENSSL@
+
 // Build with support for being able to configure a processing model where
 // any thread can process I/O for a socket, rather than just a particular
 // thread chosen at the time the socket was created.

--- a/configure
+++ b/configure
@@ -299,6 +299,10 @@ else
     NTF_CONFIGURE_WITH_IORING=0
 fi
 
+if [[ -z "${NTF_CONFIGURE_WITH_OPENSSL}" ]]; then
+    NTF_CONFIGURE_WITH_OPENSSL=1
+fi
+
 if [[ -z "${NTF_CONFIGURE_WITH_DYNAMIC_LOAD_BALANCING}" ]]; then
     NTF_CONFIGURE_WITH_DYNAMIC_LOAD_BALANCING=1
 fi
@@ -477,6 +481,8 @@ usage()
     echo "    --with-iocp                        Enable the proactor driver implemented with I/O completion ports (Windows only) [${NTF_CONFIGURE_WITH_IOCP}]"
     echo "    --with-ioring                      Enable the proactor driver implemented with 'io_uring' (Linux only) [${NTF_CONFIGURE_WITH_IORING}]"
 
+    echo "    --with-openssl                     Enable the encryption driver implemented with OpenSSL [${NTF_CONFIGURE_WITH_OPENSSL}]"
+
     echo "    --with-dynamic-load-balancing      Enable processing I/O on any thread, rather than a single thread [${NTF_CONFIGURE_WITH_DYNAMIC_LOAD_BALANCING}]"
     echo "    --with-thread-scaling              Enable automatic scaling of thread pools [${NTF_CONFIGURE_WITH_THREAD_SCALING}]"
     echo "    --with-deprecated-features         Enable deprecated features [${NTF_CONFIGURE_WITH_DEPRECATED_FEATURES}]"
@@ -648,6 +654,9 @@ while true ; do
         --with-ioring)
             NTF_CONFIGURE_WITH_IORING=1 ; shift ;;
 
+        --with-openssl)
+            NTF_CONFIGURE_WITH_OPENSSL=1 ; shift ;;
+
         --with-dynamic-load-balancing)
             NTF_CONFIGURE_WITH_DYNAMIC_LOAD_BALANCING=1 ; shift ;;
         --with-thread-scaling)
@@ -756,6 +765,9 @@ while true ; do
             NTF_CONFIGURE_WITH_IOCP=0 ; shift ;;
         --without-ioring)
             NTF_CONFIGURE_WITH_IORING=0 ; shift ;;
+
+        --without-openssl)
+            NTF_CONFIGURE_WITH_OPENSSL=0 ; shift ;;
 
         --without-dynamic-load-balancing)
             NTF_CONFIGURE_WITH_DYNAMIC_LOAD_BALANCING=0 ; shift ;;
@@ -878,6 +890,8 @@ export NTF_CONFIGURE_WITH_POLLSET
 export NTF_CONFIGURE_WITH_KQUEUE
 export NTF_CONFIGURE_WITH_IOCP
 export NTF_CONFIGURE_WITH_IORING
+
+export NTF_CONFIGURE_WITH_OPENSSL
 
 export NTF_CONFIGURE_WITH_DYNAMIC_LOAD_BALANCING
 export NTF_CONFIGURE_WITH_THREAD_SCALING

--- a/configure.cmd
+++ b/configure.cmd
@@ -105,6 +105,10 @@ IF NOT DEFINED NTF_CONFIGURE_WITH_IOCP (
     set NTF_CONFIGURE_WITH_IOCP=1
 )
 
+IF NOT DEFINED NTF_CONFIGURE_WITH_OPENSSL (
+    set NTF_CONFIGURE_WITH_OPENSSL=1
+)
+
 IF NOT DEFINED NTF_CONFIGURE_WITH_DYNAMIC_LOAD_BALANCING (
     set NTF_CONFIGURE_WITH_DYNAMIC_LOAD_BALANCING=1
 )
@@ -322,6 +326,10 @@ if not "%1"=="" (
         set NTF_CONFIGURE_WITH_IOCP=1
     )
 
+    if "%1"=="--with-openssl" (
+        set NTF_CONFIGURE_WITH_OPENSSL=1
+    )
+
     if "%1"=="--with-dynamic-load-balancing" (
         set NTF_CONFIGURE_WITH_DYNAMIC_LOAD_BALANCING=1
     )
@@ -448,6 +456,10 @@ if not "%1"=="" (
     )
     if "%1"=="--without-iocp" (
         set NTF_CONFIGURE_WITH_IOCP=0
+    )
+
+    if "%1"=="--without-openssl" (
+        set NTF_CONFIGURE_WITH_OPENSSL=0
     )
 
     if "%1"=="--without-dynamic-load-balancing" (
@@ -839,6 +851,8 @@ echo     --with-ntc                       Enable and build features that depend 
 echo     --with-select                    Enable the reactor driver implemented with 'select'
 echo     --with-poll                      Enable the reactor driver implemented with 'poll'
 echo     --with-iocp                      Enable the proactor driver that depends on I/O completion ports
+
+echo     --with-openssl                   Enable the encryption driver implemented with OpenSSL
 
 echo     --with-dynamic-load-balancing    Enable processing I/O on any thread, rather than a single thread
 echo     --with-thread-scaling            Enable automatic scaling of thread pools

--- a/groups/ntc/CMakeLists.txt
+++ b/groups/ntc/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(ntc STATIC)
 bbs_setup_target_uor(
     ntc
     NO_EMIT_PKG_CONFIG_FILE
-    PRIVATE_PACKAGES ntcm ntcs ntcq ntcd ntcdns ntcu ntcr ntcp ntco)
+    PRIVATE_PACKAGES ntcm ntcs ntcq ntcd ntcdns ntctls ntcu ntcr ntcp ntco)
 
 target_include_directories(
     ntc

--- a/groups/ntc/group/ntc.dep
+++ b/groups/ntc/group/ntc.dep
@@ -2,3 +2,4 @@ nts
 bal
 bdl
 bsl
+openssl

--- a/groups/ntc/group/ntc.mem
+++ b/groups/ntc/group/ntc.mem
@@ -11,4 +11,5 @@ ntcu
 ntcr
 ntcp
 ntco
+ntctls
 ntcf

--- a/groups/ntc/ntcf/ntcf_system.cpp
+++ b/groups/ntc/ntcf/ntcf_system.cpp
@@ -59,6 +59,8 @@ BSLS_IDENT_RCSID(ntcf_system_cpp, "$Id$ $CSID$")
 #include <ntco_pollset.h>
 #include <ntco_select.h>
 
+#include <ntctls_plugin.h>
+
 #include <bdlbb_pooledblobbufferfactory.h>
 
 #include <bslma_allocator.h>
@@ -1339,6 +1341,10 @@ ntsa::Error System::createEncryptionClient(
     error = ntcf::System::initialize();
     BSLS_ASSERT_OPT(!error);
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1360,6 +1366,10 @@ ntsa::Error System::createEncryptionClient(
 
     error = ntcf::System::initialize();
     BSLS_ASSERT_OPT(!error);
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1384,6 +1394,10 @@ ntsa::Error System::createEncryptionClient(
     error = ntcf::System::initialize();
     BSLS_ASSERT_OPT(!error);
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1406,6 +1420,10 @@ ntsa::Error System::createEncryptionServer(
     error = ntcf::System::initialize();
     BSLS_ASSERT_OPT(!error);
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1426,6 +1444,10 @@ ntsa::Error System::createEncryptionResource(
     error = ntcf::System::initialize();
     BSLS_ASSERT_OPT(!error);
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1445,6 +1467,10 @@ ntsa::Error System::createEncryptionServer(
 
     error = ntcf::System::initialize();
     BSLS_ASSERT_OPT(!error);
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1468,6 +1494,10 @@ ntsa::Error System::createEncryptionServer(
 
     error = ntcf::System::initialize();
     BSLS_ASSERT_OPT(!error);
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);

--- a/groups/ntc/ntcf/package/ntcf.dep
+++ b/groups/ntc/ntcf/package/ntcf.dep
@@ -7,6 +7,7 @@ ntcs
 ntcq
 ntcd
 ntcdns
+ntctls
 ntcu
 ntcr
 ntcp

--- a/groups/ntc/ntco/package/ntco.dep
+++ b/groups/ntc/ntco/package/ntco.dep
@@ -7,6 +7,7 @@ ntcs
 ntcq
 ntcd
 ntcdns
+ntctls
 ntcu
 ntcr
 ntcp

--- a/groups/ntc/ntcp/ntcp_interface.cpp
+++ b/groups/ntc/ntcp/ntcp_interface.cpp
@@ -32,6 +32,8 @@ BSLS_IDENT_RCSID(ntcp_interface_cpp, "$Id$ $CSID$")
 #include <ntcs_threadutil.h>
 #include <ntcs_user.h>
 
+#include <ntctls_plugin.h>
+
 #include <bdlt_currenttime.h>
 #include <bslma_allocator.h>
 #include <bslma_default.h>
@@ -952,6 +954,10 @@ ntsa::Error Interface::createEncryptionClient(
 
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -974,6 +980,10 @@ ntsa::Error Interface::createEncryptionClient(
     NTCI_LOG_CONTEXT_GUARD_OWNER(d_config.metricName().c_str());
 
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -999,6 +1009,10 @@ ntsa::Error Interface::createEncryptionClient(
 
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1022,6 +1036,10 @@ ntsa::Error Interface::createEncryptionServer(
 
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1044,6 +1062,10 @@ ntsa::Error Interface::createEncryptionServer(
     NTCI_LOG_CONTEXT_GUARD_OWNER(d_config.metricName().c_str());
 
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1069,6 +1091,10 @@ ntsa::Error Interface::createEncryptionServer(
 
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1085,7 +1111,15 @@ ntsa::Error Interface::createEncryptionResource(
     bsl::shared_ptr<ntci::EncryptionResource>* result,
     bslma::Allocator*                          basicAllocator)
 {
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_CONTEXT_GUARD_OWNER(d_config.metricName().c_str());
+
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1108,6 +1142,10 @@ ntsa::Error Interface::generateCertificate(
     NTCI_LOG_CONTEXT_GUARD_OWNER(d_config.metricName().c_str());
 
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1137,6 +1175,10 @@ ntsa::Error Interface::generateCertificate(
 
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1164,6 +1206,10 @@ ntsa::Error Interface::generateCertificate(
     NTCI_LOG_CONTEXT_GUARD_OWNER(d_config.metricName().c_str());
 
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1193,6 +1239,10 @@ ntsa::Error Interface::generateCertificate(
 
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1216,6 +1266,10 @@ ntsa::Error Interface::loadCertificate(
 {
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1235,6 +1289,10 @@ ntsa::Error Interface::saveCertificate(
 {
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1250,6 +1308,10 @@ ntsa::Error Interface::encodeCertificate(
     const ntca::EncryptionResourceOptions&              options)
 {
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1269,6 +1331,10 @@ ntsa::Error Interface::decodeCertificate(
     bslma::Allocator*                             basicAllocator)
 {
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1292,6 +1358,10 @@ ntsa::Error Interface::generateKey(ntca::EncryptionKey*              result,
 
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1312,6 +1382,10 @@ ntsa::Error Interface::generateKey(
 
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1327,6 +1401,10 @@ ntsa::Error Interface::loadKey(bsl::shared_ptr<ntci::EncryptionKey>*  result,
                                bslma::Allocator* basicAllocator)
 {
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1344,6 +1422,10 @@ ntsa::Error Interface::saveKey(
 {
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1359,6 +1441,10 @@ ntsa::Error Interface::encodeKey(
     const ntca::EncryptionResourceOptions&      options)
 {
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1376,6 +1462,10 @@ ntsa::Error Interface::decodeKey(
     bslma::Allocator*                      basicAllocator)
 {
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);

--- a/groups/ntc/ntcp/package/ntcp.dep
+++ b/groups/ntc/ntcp/package/ntcp.dep
@@ -7,4 +7,5 @@ ntcs
 ntcq
 ntcd
 ntcdns
+ntctls
 ntcu

--- a/groups/ntc/ntcr/ntcr_interface.cpp
+++ b/groups/ntc/ntcr/ntcr_interface.cpp
@@ -32,6 +32,8 @@ BSLS_IDENT_RCSID(ntcr_interface_cpp, "$Id$ $CSID$")
 #include <ntcs_threadutil.h>
 #include <ntcs_user.h>
 
+#include <ntctls_plugin.h>
+
 #include <bdlt_currenttime.h>
 #include <bslma_allocator.h>
 #include <bslma_default.h>
@@ -961,6 +963,10 @@ ntsa::Error Interface::createEncryptionClient(
 
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -983,6 +989,10 @@ ntsa::Error Interface::createEncryptionClient(
     NTCI_LOG_CONTEXT_GUARD_OWNER(d_config.metricName().c_str());
 
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1008,6 +1018,10 @@ ntsa::Error Interface::createEncryptionClient(
 
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1031,6 +1045,10 @@ ntsa::Error Interface::createEncryptionServer(
 
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1053,6 +1071,10 @@ ntsa::Error Interface::createEncryptionServer(
     NTCI_LOG_CONTEXT_GUARD_OWNER(d_config.metricName().c_str());
 
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1078,6 +1100,10 @@ ntsa::Error Interface::createEncryptionServer(
 
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1094,7 +1120,15 @@ ntsa::Error Interface::createEncryptionResource(
     bsl::shared_ptr<ntci::EncryptionResource>* result,
     bslma::Allocator*                          basicAllocator)
 {
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_CONTEXT_GUARD_OWNER(d_config.metricName().c_str());
+
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1117,6 +1151,10 @@ ntsa::Error Interface::generateCertificate(
     NTCI_LOG_CONTEXT_GUARD_OWNER(d_config.metricName().c_str());
 
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1146,6 +1184,10 @@ ntsa::Error Interface::generateCertificate(
 
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1173,6 +1215,10 @@ ntsa::Error Interface::generateCertificate(
     NTCI_LOG_CONTEXT_GUARD_OWNER(d_config.metricName().c_str());
 
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1202,6 +1248,10 @@ ntsa::Error Interface::generateCertificate(
 
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1225,6 +1275,10 @@ ntsa::Error Interface::loadCertificate(
 {
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1244,6 +1298,10 @@ ntsa::Error Interface::saveCertificate(
 {
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1259,6 +1317,10 @@ ntsa::Error Interface::encodeCertificate(
     const ntca::EncryptionResourceOptions&              options)
 {
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1278,6 +1340,10 @@ ntsa::Error Interface::decodeCertificate(
     bslma::Allocator*                             basicAllocator)
 {
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1301,6 +1367,10 @@ ntsa::Error Interface::generateKey(ntca::EncryptionKey*              result,
 
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1321,6 +1391,10 @@ ntsa::Error Interface::generateKey(
 
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1336,6 +1410,10 @@ ntsa::Error Interface::loadKey(bsl::shared_ptr<ntci::EncryptionKey>*  result,
                                bslma::Allocator* basicAllocator)
 {
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1353,6 +1431,10 @@ ntsa::Error Interface::saveKey(
 {
     ntsa::Error error;
 
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
+
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
     if (error) {
@@ -1368,6 +1450,10 @@ ntsa::Error Interface::encodeKey(
     const ntca::EncryptionResourceOptions&      options)
 {
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);
@@ -1385,6 +1471,10 @@ ntsa::Error Interface::decodeKey(
     bslma::Allocator*                      basicAllocator)
 {
     ntsa::Error error;
+
+#if NTC_BUILD_WITH_OPENSSL
+    ntctls::Plugin::initialize();
+#endif
 
     bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver;
     error = ntcs::Plugin::lookupEncryptionDriver(&encryptionDriver);

--- a/groups/ntc/ntcr/package/ntcr.dep
+++ b/groups/ntc/ntcr/package/ntcr.dep
@@ -7,4 +7,5 @@ ntcs
 ntcq
 ntcd
 ntcdns
+ntctls
 ntcu

--- a/groups/ntc/ntctls/ntctls_plugin.cpp
+++ b/groups/ntc/ntctls/ntctls_plugin.cpp
@@ -1,0 +1,10548 @@
+// Copyright 2020-2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ntctls_plugin.h>
+
+#include <bsls_ident.h>
+BSLS_IDENT_RCSID(ntctls_plugin_cpp, "$Id$ $CSID$")
+
+#if NTC_BUILD_WITH_OPENSSL
+
+#include <ntca_encryptionauthentication.h>
+#include <ntca_encryptioncertificate.h>
+#include <ntca_encryptioncertificateoptions.h>
+#include <ntca_encryptionclientoptions.h>
+#include <ntca_encryptionkey.h>
+#include <ntca_encryptionkeyoptions.h>
+#include <ntca_encryptionkeytype.h>
+#include <ntca_encryptionmethod.h>
+#include <ntca_encryptionoptions.h>
+#include <ntca_encryptionresource.h>
+#include <ntca_encryptionresourcedescriptor.h>
+#include <ntca_encryptionresourceoptions.h>
+#include <ntca_encryptionresourcetype.h>
+#include <ntca_encryptionrole.h>
+#include <ntca_encryptionsecret.h>
+#include <ntca_encryptionserveroptions.h>
+#include <ntca_encryptionvalidation.h>
+#include <ntci_encryption.h>
+#include <ntci_encryptioncertificate.h>
+#include <ntci_encryptioncertificategenerator.h>
+#include <ntci_encryptioncertificatestorage.h>
+#include <ntci_encryptionclient.h>
+#include <ntci_encryptionclientfactory.h>
+#include <ntci_encryptiondriver.h>
+#include <ntci_encryptionkey.h>
+#include <ntci_encryptionkeygenerator.h>
+#include <ntci_encryptionkeystorage.h>
+#include <ntci_encryptionserver.h>
+#include <ntci_encryptionserverfactory.h>
+#include <ntci_log.h>
+#include <ntci_mutex.h>
+#include <ntcs_plugin.h>
+#include <ntsf_system.h>
+
+#include <bdlb_chartype.h>
+#include <bdlb_print.h>
+#include <bdlb_string.h>
+#include <bdlbb_blob.h>
+#include <bdlbb_blobstreambuf.h>
+#include <bdlbb_blobutil.h>
+#include <bdlbb_pooledblobbufferfactory.h>
+#include <bdlf_bind.h>
+#include <bdlf_memfn.h>
+#include <bdlf_placeholder.h>
+#include <bdlsb_fixedmeminstreambuf.h>
+#include <bdlsb_memoutstreambuf.h>
+#include <bdlt_datetime.h>
+#include <bdlt_datetimetz.h>
+#include <bdlt_epochutil.h>
+#include <bdlt_iso8601util.h>
+
+#include <bslim_printer.h>
+#include <bslma_allocator.h>
+#include <bslma_default.h>
+#include <bslma_managedptr.h>
+#include <bslmt_lockguard.h>
+#include <bslmt_mutex.h>
+#include <bslmt_once.h>
+#include <bslmt_threadutil.h>
+#include <bsls_annotation.h>
+#include <bsls_assert.h>
+#include <bsls_atomic.h>
+#include <bsls_keyword.h>
+#include <bsls_platform.h>
+#include <bsls_spinlock.h>
+#include <bsls_stopwatch.h>
+
+#include <bsl_cstdio.h>
+#include <bsl_cstdlib.h>
+#include <bsl_cstring.h>
+#include <bsl_fstream.h>
+#include <bsl_functional.h>
+#include <bsl_iomanip.h>
+#include <bsl_iosfwd.h>
+#include <bsl_iostream.h>
+#include <bsl_memory.h>
+#include <bsl_ostream.h>
+#include <bsl_sstream.h>
+#include <bsl_streambuf.h>
+#include <bsl_string.h>
+#include <bsl_utility.h>
+#include <bsl_vector.h>
+
+#include <bsl_fstream.h>
+#include <bsl_memory.h>
+#include <bsl_sstream.h>
+#include <bsl_string.h>
+#include <bsl_vector.h>
+
+#include <openssl/bio.h>
+#include <openssl/bn.h>
+#include <openssl/dh.h>
+#include <openssl/ec.h>
+#include <openssl/engine.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/opensslconf.h>
+#include <openssl/opensslv.h>
+#include <openssl/pem.h>
+#include <openssl/pkcs12.h>
+#include <openssl/rsa.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#error OpenSSL 1.1.0 or greater is required
+#endif
+
+#if !defined(OPENSSL_THREADS)
+#error OpenSSL with thread support is required
+#endif
+
+#if defined(BSLS_PLATFORM_CMP_MSVC)
+#pragma warning(disable : 4996)
+#endif
+
+#if defined(BSLS_PLATFORM_OS_WINDOWS)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <wincrypt.h>
+#include <windows.h>
+#ifdef X509
+#undef X509
+#endif
+#ifdef X509_NAME
+#undef X509_NAME
+#endif
+#ifdef X509_EXTENSIONS
+#undef X509_EXTENSIONS
+#endif
+#pragma comment(lib, "crypt32")
+#endif
+
+namespace BloombergLP {
+namespace ntctls {
+
+class Environment;
+class Key;
+class Certificate;
+class Resource;
+class Session;
+class SessionContext;
+class SessionManager;
+class Driver;
+
+/// Provide a handle to an object deleted with a function with a canonical
+/// signature.
+///
+/// @par Thread Safety
+/// This class is not thread safe.
+///
+/// @ingroup module_ntctls
+template <typename TYPE>
+class Handle
+{
+  public:
+    /// Declare a type alias for the underlying type.
+    typedef TYPE Type;
+
+    /// Declare a type alias for the deleter to the type.
+    typedef void (*Deleter)(Type*);
+
+  private:
+    Type*   d_ptr_p;
+    Deleter d_deleter;
+
+  private:
+    Handle(const Handle&) BSLS_KEYWORD_DELETED;
+    Handle& operator=(const Handle&) BSLS_KEYWORD_DELETED;
+
+  public:
+    /// Create a new handle to a null object.
+    Handle();
+
+    /// Create a new handle to the specified 'object' that frees the object
+    /// by calling the standard deleter function for 'object'.
+    explicit Handle(Type* object);
+
+    /// Create a new handle to the specified 'object' that frees the object
+    /// by calling the specified 'deleter' function.
+    Handle(Type* object, Deleter deleter);
+
+    /// Destroy this object.
+    ~Handle();
+
+    /// Delete the managed object, if any, and reset the managed object to
+    /// null.
+    void reset();
+
+    /// Delete the managed object, if any, and reset the managed object to the
+    /// specified 'object' and free the object with the standard deleter
+    /// function for the 'object'.
+    void reset(Type* object);
+
+    /// Delete the managed object, if any, and reset the managed object to the
+    /// specified 'object' and free the object with the specified 'deleter'.
+    void reset(Type* object, Deleter deleter);
+
+    /// Release and return the managed object. The managed object will not
+    /// be deleted by this handle when this handle is destroyed.
+    Type* release();
+
+    /// Return a pointer to the modifiable object.
+    Type* get() const;
+
+    /// Return true if the managed object is not null, otherwise return false.
+    operator bool() const;
+};
+
+/// Provide utilities for handles.
+///
+/// @par Thread Safety
+/// This class is not thread safe.
+///
+/// @ingroup module_ntctls
+class HandleUtil
+{
+  private:
+    /// Delete the specified 'object'.
+    static void deleteBio(BIO* object);
+
+  public:
+    /// Provide a type alias to a type-erased deleter.
+    typedef void (*Deleter)(void*);
+
+    /// The behavior is undefined if this function is called.
+    template <typename TYPE>
+    static Deleter deleter(TYPE*);
+
+    /// Return the deleter for an object of type 'BIO'.
+    static Deleter deleter(BIO*);
+
+    /// Return the deleter for an object of type 'BIGNUM'.
+    static Deleter deleter(BIGNUM*);
+
+    /// Return the deleter for an object of type 'DH'.
+    static Deleter deleter(DH*);
+
+    /// Return the deleter for an object of type 'DSA'.
+    static Deleter deleter(DSA*);
+
+    /// Return the deleter for an object of type 'RSA'.
+    static Deleter deleter(RSA*);
+
+    /// Return the deleter for an object of type 'EVP_PKEY'.
+    static Deleter deleter(EVP_PKEY*);
+
+    /// Return the deleter for an object of type 'EVP_PKEY_CTX'.
+    static Deleter deleter(EVP_PKEY_CTX*);
+
+    /// Return the deleter for an object of type 'X509'.
+    static Deleter deleter(X509*);
+
+    /// Return the deleter for an object of type 'X509_NAME'.
+    static Deleter deleter(X509_NAME*);
+
+    /// Return the deleter for an object of type 'X509_EXTENSION'.
+    static Deleter deleter(X509_EXTENSION*);
+
+    /// Return the deleter for an object of type 'X509_ALGOR'.
+    static Deleter deleter(X509_ALGOR*);
+
+    /// Return the deleter for an object of type 'X509_SIG'.
+    static Deleter deleter(X509_SIG*);
+
+    /// Return the deleter for an object of type 'X509_STORE'.
+    static Deleter deleter(X509_STORE*);
+
+    /// Return the deleter for an object of type 'X509_STORE_CTX'.
+    static Deleter deleter(X509_STORE_CTX*);
+
+    /// Return the deleter for an object of type 'SSL'.
+    static Deleter deleter(SSL*);
+
+    /// Return the deleter for an object of type 'SSL_CTX'.
+    static Deleter deleter(SSL_CTX*);
+
+    /// Return the deleter for an object of type 'PKCS12'.
+    static Deleter deleter(PKCS12*);
+
+    /// Return the deleter for an object of type 'PKCS7'.
+    static Deleter deleter(PKCS7*);
+
+    /// Return the deleter for an object of type 'PKCS8_PRIV_KEY_INFO'.
+    static Deleter deleter(PKCS8_PRIV_KEY_INFO*);
+};
+
+/// Define a type alias for the integer type that represents an error number.
+typedef unsigned long ErrorNumber;
+
+/// Provide error information.
+///
+/// @par Thread Safety
+/// This class is not thread safe.
+///
+/// @ingroup module_ntctls
+class ErrorInfo
+{
+    ntctls::ErrorNumber d_number;
+    bsl::string         d_description;
+
+  public:
+    /// Create new error information with a default value. Optionally specify a
+    /// 'basicAllocator' used to supply memory. If 'basicAllocator' is 0, the
+    /// currently installed default allocator is used.
+    explicit ErrorInfo(bslma::Allocator* basicAllocator = 0);
+
+    /// Create new error information having the same value as the specified
+    /// 'original' object. Optionally specify a 'basicAllocator' used to supply
+    /// memory. If 'basicAllocator' is 0, the currently installed default
+    /// allocator is used.
+    ErrorInfo(const ErrorInfo& original, bslma::Allocator* basicAllocator = 0);
+
+    /// Destroy this object.
+    ~ErrorInfo();
+
+    /// Assign the value of the specified 'other' object to this object. Return
+    /// a reference to this modifiable object.
+    ErrorInfo& operator=(const ErrorInfo& other);
+
+    /// Reset the value of this object to its value upon default construction.
+    void reset();
+
+    /// Set the error number to the specified 'value'.
+    void setNumber(ntctls::ErrorNumber value);
+
+    /// Set the error description to the specified 'value'.
+    void setDescription(const bsl::string& value);
+
+    /// Return the error number.
+    ntctls::ErrorNumber number() const;
+
+    // Return the code that identifies the library in which the error occurred.
+    int library() const;
+
+    // Return the code that identifies the function in which the error occurred.
+    int function() const;
+
+    // Return the code that identifies the reason in which the error occurred.
+    int reason() const;
+
+    /// Return true if the error occurred in the specified in the 'library' for
+    /// the specified 'reason', otherwise return false.
+    bool match(int library, int reason) const;
+
+    /// Return the error description.
+    const bsl::string& description() const;
+
+    /// Return true if this object has the same value as the specified
+    /// 'other' object, otherwise return false.
+    bool equals(const ErrorInfo& other) const;
+
+    /// Format this object to the specified output 'stream' at the
+    /// optionally specified indentation 'level' and return a reference to
+    /// the modifiable 'stream'.  If 'level' is specified, optionally
+    /// specify 'spacesPerLevel', the number of spaces per indentation level
+    /// for this and all of its nested objects.  Each line is indented by
+    /// the absolute value of 'level * spacesPerLevel'.  If 'level' is
+    /// negative, suppress indentation of the first line.  If
+    /// 'spacesPerLevel' is negative, suppress line breaks and format the
+    /// entire output on one line.  If 'stream' is initially invalid, this
+    /// operation has no effect.  Note that a trailing newline is provided
+    /// in multiline mode only.
+    bsl::ostream& print(bsl::ostream& stream,
+                        int           level          = 0,
+                        int           spacesPerLevel = 4) const;
+
+    /// Defines the traits of this type. These traits can be used to select,
+    /// at compile-time, the most efficient algorithm to manipulate objects
+    /// of this type.
+    NTCCFG_DECLARE_NESTED_USES_ALLOCATOR_TRAITS(ErrorInfo);
+};
+
+/// Format the specified 'object' to the specified output 'stream' and
+/// return a reference to the modifiable 'stream'.
+///
+/// @related ntctls::ErrorInfo
+bsl::ostream& operator<<(bsl::ostream& stream, const ErrorInfo& object);
+
+/// Return 'true' if the specified 'lhs' and 'rhs' attribute objects have
+/// the same value, and 'false' otherwise.  Two attribute objects have the
+/// same value if each respective attribute has the same value.
+///
+/// @related ntctls::ErrorInfo
+bool operator==(const ErrorInfo& lhs, const ErrorInfo& rhs);
+
+/// Return 'true' if the specified 'lhs' and 'rhs' attribute objects do not
+/// have the same value, and 'false' otherwise.  Two attribute objects do
+/// not have the same value if one or more respective attributes differ in
+/// values.
+///
+/// @related ntctls::ErrorInfo
+bool operator!=(const ErrorInfo& lhs, const ErrorInfo& rhs);
+
+/// Provide a stack of errors.
+///
+/// @par Thread Safety
+/// This class is not thread safe.
+///
+/// @ingroup module_ntctls
+class ErrorStack
+{
+    typedef bsl::vector<ntctls::ErrorInfo> Container;
+
+    Container         d_container;
+    ntctls::ErrorInfo d_sentinel;
+
+  public:
+    /// Create a new, initially empty error stack. Optionally specify a
+    /// 'basicAllocator' used to supply memory. If 'basicAllocator' is 0, the
+    /// currently installed default allocator is used.
+    explicit ErrorStack(bslma::Allocator* basicAllocator = 0);
+
+    /// Create a new error stack having the same value as the specified
+    /// 'original' object. Optionally specify a 'basicAllocator' used to supply
+    /// memory. If 'basicAllocator' is 0, the currently installed default
+    /// allocator is used.
+    ErrorStack(const ErrorStack& original,
+               bslma::Allocator* basicAllocator = 0);
+
+    /// Destroy this object.
+    ~ErrorStack();
+
+    // Assign the value of the specified 'other' object to this object. Return
+    // a reference to this modifiable object.
+    ErrorStack& operator=(const ErrorStack& other);
+
+    // Reset the value of this object to its value upon default construction.
+    void reset();
+
+    /// Push the specified 'errorInfo' onto the stack.
+    void push(const ntctls::ErrorInfo& errorInfo);
+
+    /// Push the specified 'errorStack' onto the stack.
+    void push(const ntctls::ErrorStack& errorStack);
+
+    /// Return the last error information.
+    const ntctls::ErrorInfo& last() const;
+
+    /// Return true if any error occurred in the specified in the specified
+    /// 'library' for the specified 'reason', otherwise return false.
+    bool find(int library, int reason) const;
+
+    /// Return the string description of the error stack.
+    bsl::string text() const;
+
+    /// Return true if there are no errors on the stack, otherwise return
+    /// false.
+    bool empty() const;
+
+    /// Return true if this object has the same value as the specified
+    /// 'other' object, otherwise return false.
+    bool equals(const ErrorStack& other) const;
+
+    /// Format this object to the specified output 'stream' at the
+    /// optionally specified indentation 'level' and return a reference to
+    /// the modifiable 'stream'.  If 'level' is specified, optionally
+    /// specify 'spacesPerLevel', the number of spaces per indentation level
+    /// for this and all of its nested objects.  Each line is indented by
+    /// the absolute value of 'level * spacesPerLevel'.  If 'level' is
+    /// negative, suppress indentation of the first line.  If
+    /// 'spacesPerLevel' is negative, suppress line breaks and format the
+    /// entire output on one line.  If 'stream' is initially invalid, this
+    /// operation has no effect.  Note that a trailing newline is provided
+    /// in multiline mode only.
+    bsl::ostream& print(bsl::ostream& stream,
+                        int           level          = 0,
+                        int           spacesPerLevel = 4) const;
+
+    /// Defines the traits of this type. These traits can be used to select,
+    /// at compile-time, the most efficient algorithm to manipulate objects
+    /// of this type.
+    NTCCFG_DECLARE_NESTED_USES_ALLOCATOR_TRAITS(ErrorStack);
+};
+
+/// Format the specified 'object' to the specified output 'stream' and
+/// return a reference to the modifiable 'stream'.
+///
+/// @related ntctls::ErrorStack
+bsl::ostream& operator<<(bsl::ostream& stream, const ErrorStack& object);
+
+/// Return 'true' if the specified 'lhs' and 'rhs' attribute objects have
+/// the same value, and 'false' otherwise.  Two attribute objects have the
+/// same value if each respective attribute has the same value.
+///
+/// @related ntctls::ErrorStack
+bool operator==(const ErrorStack& lhs, const ErrorStack& rhs);
+
+/// Return 'true' if the specified 'lhs' and 'rhs' attribute objects do not
+/// have the same value, and 'false' otherwise.  Two attribute objects do
+/// not have the same value if one or more respective attributes differ in
+/// values.
+///
+/// @related ntctls::ErrorStack
+bool operator!=(const ErrorStack& lhs, const ErrorStack& rhs);
+
+/// Provide internal utilities.
+///
+/// @par Thread Safety
+/// This class is thread safe.
+///
+/// @ingroup module_ntctls
+struct Internal {
+    /// Initialize the internal state.
+    static void initialize();
+
+    /// Return the handle to a new stream that operates on the specified
+    /// 'buffer'. Optionally specify a 'basicAllocator' used to supply memory.
+    /// If 'basicAllocator' is 0, the currently installed default allocator is
+    /// used.
+    static bsl::shared_ptr<BIO> createStream(
+        bsl::streambuf*   buffer,
+        bslma::Allocator* basicAllocator = 0);
+
+    /// Return the handle to a new stream that operates on the specified
+    /// 'buffer'. The handle must be explicitly destroyed by the caller.
+    static BIO* createStreamRaw(bsl::streambuf* buffer);
+
+    /// Return the handle to a new stream that operates on the specified
+    /// 'blob'. Optionally specify a 'basicAllocator' used to supply memory. If
+    /// 'basicAllocator' is 0, the currently installed default allocator is
+    /// used.
+    static bsl::shared_ptr<BIO> createStream(
+        bdlbb::Blob*      blob,
+        bslma::Allocator* basicAllocator = 0);
+
+    /// Return the handle to a new stream that operates on the specified
+    /// 'blob'. The handle must be explicitly destroyed by the caller.
+    static BIO* createStreamRaw(bdlbb::Blob* blob);
+
+    /// Destroy the stream identified by the specified 'bio'.
+    static void destroyStream(BIO* bio);
+
+    /// Drain the OpenSSL error queue, pushing a description of each error to
+    /// the specified 'errorQueue'. Note that the errors appear in the queue
+    /// in the chronological order in which they occurred.
+    static void drainErrorQueue(bsl::vector<bsl::string>* errorQueue);
+
+    /// Drain the OpenSSL error queue, appending a formatted, human-readable
+    /// description of each error to the specified 'description'. Note that the
+    /// errors appear in the queue in the chronological order in which they
+    /// occurred.
+    static void drainErrorQueue(bsl::string* description);
+
+    /// Drain the OpenSSL error queue, appending a formatted, human-readable
+    /// description of each error to the specified 'description'. Note that the
+    /// errors appear in the queue in the chronological order in which they
+    /// occurred.
+    static void drainErrorQueue(bsl::streambuf* description);
+
+    /// Drain the OpenSSL error queue, appending a formatted, human-readable
+    /// description of each error to the specified 'errorStack'. Note that the
+    /// errors appear in the stack in the chronological order in which they
+    /// occurred: the bottom is the oldest, the top is the newest.
+    static void drainErrorQueue(ntctls::ErrorStack* errorStack);
+
+    /// Load into the specified 'result' the specified 'dateTime' in the
+    /// "YYYYMMDDHHMMSSZ" format.
+    static void convertDatetimeToAsn1TimeString(
+        bsl::string*          result,
+        const bdlt::Datetime& dateTime);
+
+    /// Clean up the internal state.
+    static void exit();
+};
+
+template <typename TYPE>
+NTCCFG_INLINE Handle<TYPE>::Handle()
+: d_ptr_p(0)
+, d_deleter(reinterpret_cast<Deleter>(0))
+{
+}
+
+template <typename TYPE>
+NTCCFG_INLINE Handle<TYPE>::Handle(Type* object)
+: d_ptr_p(object)
+, d_deleter(reinterpret_cast<Deleter>(HandleUtil::deleter(object)))
+{
+    BSLS_ASSERT_OPT(d_deleter);
+}
+
+template <typename TYPE>
+NTCCFG_INLINE Handle<TYPE>::Handle(Type* object, Deleter deleter)
+: d_ptr_p(object)
+, d_deleter(deleter)
+{
+    BSLS_ASSERT_OPT(d_deleter);
+}
+
+template <typename TYPE>
+NTCCFG_INLINE Handle<TYPE>::~Handle()
+{
+    if (d_ptr_p) {
+        if (d_deleter) {
+            d_deleter(d_ptr_p);
+        }
+    }
+}
+
+template <typename TYPE>
+NTCCFG_INLINE void Handle<TYPE>::reset()
+{
+    if (d_ptr_p) {
+        if (d_deleter) {
+            d_deleter(d_ptr_p);
+            d_deleter = 0;
+        }
+
+        d_ptr_p = 0;
+    }
+}
+
+template <typename TYPE>
+NTCCFG_INLINE void Handle<TYPE>::reset(Type* object)
+{
+    if (d_ptr_p) {
+        if (d_deleter) {
+            d_deleter(d_ptr_p);
+        }
+    }
+
+    d_ptr_p   = object;
+    d_deleter = reinterpret_cast<Deleter>(HandleUtil::deleter(object));
+
+    BSLS_ASSERT_OPT(d_deleter);
+}
+
+template <typename TYPE>
+NTCCFG_INLINE void Handle<TYPE>::reset(Type* object, Deleter deleter)
+{
+    if (d_ptr_p) {
+        if (d_deleter) {
+            d_deleter(d_ptr_p);
+        }
+    }
+
+    d_ptr_p   = object;
+    d_deleter = deleter;
+
+    BSLS_ASSERT_OPT(d_deleter);
+}
+
+template <typename TYPE>
+NTCCFG_INLINE typename Handle<TYPE>::Type* Handle<TYPE>::release()
+{
+    Type* result = d_ptr_p;
+    d_ptr_p      = 0;
+    return result;
+}
+
+template <typename TYPE>
+NTCCFG_INLINE typename Handle<TYPE>::Type* Handle<TYPE>::get() const
+{
+    return d_ptr_p;
+}
+
+template <typename TYPE>
+NTCCFG_INLINE Handle<TYPE>::operator bool() const
+{
+    return d_ptr_p != 0;
+}
+
+NTCCFG_INLINE
+void HandleUtil::deleteBio(BIO* object)
+{
+    int rc = BIO_free(object);
+    NTCCFG_WARNING_UNUSED(rc);
+}
+
+template <typename TYPE>
+NTCCFG_INLINE HandleUtil::Deleter HandleUtil::deleter(TYPE*)
+{
+    BSLS_ASSERT_OPT(!"Not implemented");
+    return 0;
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(BIO*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&HandleUtil::deleteBio);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(BIGNUM*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&BN_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(DH*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&DH_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(DSA*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&DSA_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(RSA*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&RSA_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(EVP_PKEY*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&EVP_PKEY_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(EVP_PKEY_CTX*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&EVP_PKEY_CTX_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(X509*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&X509_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(X509_NAME*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&X509_NAME_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(X509_EXTENSION*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&X509_EXTENSION_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(X509_ALGOR*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&X509_ALGOR_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(X509_SIG*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&X509_SIG_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(X509_STORE*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&X509_STORE_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(X509_STORE_CTX*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&X509_STORE_CTX_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(SSL*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&SSL_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(SSL_CTX*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&SSL_CTX_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(PKCS12*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&PKCS12_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(PKCS7*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&PKCS7_free);
+}
+
+NTCCFG_INLINE
+HandleUtil::Deleter HandleUtil::deleter(PKCS8_PRIV_KEY_INFO*)
+{
+    return reinterpret_cast<HandleUtil::Deleter>(&PKCS8_PRIV_KEY_INFO_free);
+}
+
+namespace {
+
+static int bio_blob_new(BIO* bio)
+{
+    BIO_set_init(bio, 1);
+    return 1;
+}
+
+static int bio_blob_free(BIO* bio)
+{
+    if (bio == 0) {
+        return 0;
+    }
+
+    BIO_set_init(bio, 0);
+    BIO_set_data(bio, 0);
+
+    return 1;
+}
+
+static int bio_blob_write(BIO* bio, const char* data, int size)
+{
+    bdlbb::Blob* blob = reinterpret_cast<bdlbb::Blob*>(BIO_get_data(bio));
+
+    BIO_clear_retry_flags(bio);
+
+    if (size < 0) {
+        return -1;
+    }
+
+    if (size == 0) {
+        return 0;
+    }
+
+    bdlbb::BlobUtil::append(blob, data, size);
+
+    return size;
+}
+
+static int bio_blob_read(BIO* bio, char* data, int size)
+{
+    bdlbb::Blob* blob = reinterpret_cast<bdlbb::Blob*>(BIO_get_data(bio));
+
+    BIO_clear_retry_flags(bio);
+
+    if (size < 0) {
+        return -1;
+    }
+
+    if (size == 0) {
+        return 0;
+    }
+
+    const int available = blob->length();
+
+    if (available == 0) {
+        BIO_set_retry_read(bio);
+        return -1;
+    }
+
+    int n = size;
+    if (n > available) {
+        n = available;
+    }
+
+    bdlbb::BlobUtil::copy(data, *blob, 0, n);
+    bdlbb::BlobUtil::erase(blob, 0, n);
+
+    BSLS_ASSERT(n > 0);
+    return n;
+}
+
+static int bio_blob_puts(BIO* bio, const char* data)
+{
+    bdlbb::Blob* blob = reinterpret_cast<bdlbb::Blob*>(BIO_get_data(bio));
+    const int    size = static_cast<int>(bsl::strlen(data));
+
+    bdlbb::BlobUtil::append(blob, data, 0, size);
+
+    return size;
+}
+
+static int bio_blob_gets(BIO* bio, char* data, int size)
+{
+    bdlbb::Blob* blob = reinterpret_cast<bdlbb::Blob*>(BIO_get_data(bio));
+
+    if (size == 0) {
+        return 0;
+    }
+
+    if (size == 1) {
+        *data = 0;
+        return 0;
+    }
+
+    if (blob->length() == 0) {
+        *data = 0;
+        return 0;
+    }
+
+    char* current = data;
+    char* end     = data + size - 1;
+
+    int bufferIndex  = 0;
+    int bufferOffset = 0;
+
+    const bdlbb::BlobBuffer* buffer = &blob->buffer(bufferIndex);
+
+    while (true) {
+        if (current == end) {
+            break;
+        }
+
+        if (bufferOffset == buffer->size()) {
+            bufferOffset = 0;
+            ++bufferIndex;
+            if (bufferIndex == blob->numDataBuffers()) {
+                break;
+            }
+            buffer = &blob->buffer(bufferIndex);
+        }
+
+        const char ch = buffer->data()[bufferOffset];
+        ++bufferOffset;
+
+        *current = ch;
+        ++current;
+
+        if (ch == '\n') {
+            break;
+        }
+    }
+
+    BSLS_ASSERT(current < data + size);
+    *current = 0;
+
+    int n = static_cast<int>(current - data);
+    BSLS_ASSERT(n >= 0);
+
+    bdlbb::BlobUtil::erase(blob, 0, n);
+
+    return n;
+}
+
+static long bio_blob_ctrl(BIO* bio, int cmd, long num, void* ptr)
+{
+    NTCCFG_WARNING_UNUSED(num);
+    NTCCFG_WARNING_UNUSED(ptr);
+
+    if (cmd == BIO_CTRL_FLUSH) {
+        return 1;
+    }
+
+    if (cmd == BIO_CTRL_RESET) {
+        return 1;
+    }
+
+    if (cmd == BIO_CTRL_DUP) {
+        return 1;
+    }
+
+    if (cmd == BIO_CTRL_PUSH) {
+        return 0;
+    }
+
+    if (cmd == BIO_CTRL_POP) {
+        return 0;
+    }
+
+    if (cmd == BIO_CTRL_EOF) {
+        return 0;
+    }
+
+    if (cmd == BIO_CTRL_GET_CLOSE) {
+        return BIO_CLOSE;
+    }
+
+    if (cmd == BIO_CTRL_SET_CLOSE) {
+        return 1;
+    }
+
+    if (cmd == BIO_CTRL_WPENDING) {
+        return 0;
+    }
+
+    if (cmd == BIO_CTRL_PENDING) {
+        bdlbb::Blob* blob = reinterpret_cast<bdlbb::Blob*>(BIO_get_data(bio));
+        return static_cast<long>(blob->length());
+    }
+
+    return 1;
+}
+
+static int bio_streambuf_new(BIO* bio)
+{
+    BIO_set_init(bio, 1);
+    return 1;
+}
+
+static int bio_streambuf_free(BIO* bio)
+{
+    if (bio == 0) {
+        return 0;
+    }
+
+    BIO_set_init(bio, 0);
+    BIO_set_data(bio, 0);
+    return 1;
+}
+
+static int bio_streambuf_write(BIO* bio, const char* data, int size)
+{
+    bsl::streambuf* sb = reinterpret_cast<bsl::streambuf*>(BIO_get_data(bio));
+
+    BIO_clear_retry_flags(bio);
+
+    if (size < 0) {
+        return -1;
+    }
+
+    if (size == 0) {
+        return 0;
+    }
+
+    bsl::streamsize n = sb->sputn(data, size);
+    if (n <= 0) {
+        return -1;
+    }
+
+    return static_cast<int>(n);
+}
+
+static int bio_streambuf_read(BIO* bio, char* data, int size)
+{
+    bsl::streambuf* sb = reinterpret_cast<bsl::streambuf*>(BIO_get_data(bio));
+
+    BIO_clear_retry_flags(bio);
+
+    if (size < 0) {
+        return -1;
+    }
+
+    if (size == 0) {
+        return 0;
+    }
+
+    bsl::streamsize n = sb->sgetn(data, size);
+    if (n == 0) {
+        BIO_set_retry_read(bio);
+        return -1;
+    }
+
+    return static_cast<int>(n);
+}
+
+static int bio_streambuf_puts(BIO* bio, const char* data)
+{
+    bsl::streambuf* sb = reinterpret_cast<bsl::streambuf*>(BIO_get_data(bio));
+
+    const int size = static_cast<int>(bsl::strlen(data));
+
+    bsl::streamsize n = sb->sputn(data, size);
+    if (n < 0) {
+        return -1;
+    }
+
+    return static_cast<int>(n);
+}
+
+static int bio_streambuf_gets(BIO* bio, char* data, int size)
+{
+    bsl::streambuf* sb = reinterpret_cast<bsl::streambuf*>(BIO_get_data(bio));
+
+    if (size == 0) {
+        return 0;
+    }
+
+    if (size == 1) {
+        *data = 0;
+        return 0;
+    }
+
+    char* current = data;
+    char* end     = data + size - 1;
+
+    while (true) {
+        if (current == end) {
+            break;
+        }
+
+        bsl::streambuf::int_type meta = sb->sbumpc();
+
+        if (bsl::streambuf::traits_type::eq_int_type(
+                meta,
+                bsl::streambuf::traits_type::eof()))
+        {
+            break;
+        }
+
+        char ch = bsl::streambuf::traits_type::to_char_type(meta);
+
+        if (ch == '\r') {
+            continue;
+        }
+
+        *current = ch;
+        ++current;
+
+        if (ch == '\n') {
+            break;
+        }
+    }
+
+    BSLS_ASSERT(current < data + size);
+    *current = 0;
+
+    int n = static_cast<int>(current - data);
+    BSLS_ASSERT(n >= 0);
+
+    return n;
+}
+
+static long bio_streambuf_ctrl(BIO* bio, int cmd, long num, void* ptr)
+{
+    NTCCFG_WARNING_UNUSED(num);
+    NTCCFG_WARNING_UNUSED(ptr);
+
+    bsl::streambuf* sb = reinterpret_cast<bsl::streambuf*>(BIO_get_data(bio));
+
+    if (cmd == BIO_CTRL_FLUSH) {
+        int rc = sb->pubsync();
+        if (rc != 0) {
+            return 0;
+        }
+        return 1;
+    }
+
+    if (cmd == BIO_CTRL_RESET) {
+        return 1;
+    }
+
+    if (cmd == BIO_CTRL_DUP) {
+        return 1;
+    }
+
+    if (cmd == BIO_CTRL_PUSH) {
+        return 0;
+    }
+
+    if (cmd == BIO_CTRL_POP) {
+        return 0;
+    }
+
+    if (cmd == BIO_CTRL_EOF) {
+        return 0;
+    }
+
+    if (cmd == BIO_CTRL_GET_CLOSE) {
+        return BIO_CLOSE;
+    }
+
+    if (cmd == BIO_CTRL_SET_CLOSE) {
+        return 1;
+    }
+
+    if (cmd == BIO_CTRL_WPENDING) {
+        return 0;
+    }
+
+    if (cmd == BIO_CTRL_PENDING) {
+        return static_cast<long>(sb->in_avail());
+    }
+
+    return 1;
+}
+
+struct StreamState {
+    BIO_METHOD* d_blobMethods;
+    BIO_METHOD* d_streambufMethods;
+};
+
+StreamState s_streamState;
+
+BIO* BIO_new_blob(bdlbb::Blob* blob)
+{
+    BIO* bio = BIO_new(s_streamState.d_blobMethods);
+    BSLS_ASSERT_OPT(bio);
+
+    BIO_set_data(bio, blob);
+
+    return bio;
+}
+
+BIO* BIO_new_streambuf(bsl::streambuf* buffer)
+{
+    BIO* bio = BIO_new(s_streamState.d_streambufMethods);
+    BSLS_ASSERT_OPT(bio);
+
+    BIO_set_data(bio, buffer);
+
+    return bio;
+}
+
+}  // close unnamed namespace
+
+ErrorInfo::ErrorInfo(bslma::Allocator* basicAllocator)
+: d_number(0)
+, d_description(basicAllocator)
+{
+}
+
+ErrorInfo::ErrorInfo(const ErrorInfo&  original,
+                     bslma::Allocator* basicAllocator)
+: d_number(original.d_number)
+, d_description(original.d_description, basicAllocator)
+{
+}
+
+ErrorInfo::~ErrorInfo()
+{
+}
+
+ErrorInfo& ErrorInfo::operator=(const ErrorInfo& other)
+{
+    if (this != &other) {
+        d_number      = other.d_number;
+        d_description = other.d_description;
+    }
+
+    return *this;
+}
+
+void ErrorInfo::reset()
+{
+    d_number = 0;
+    d_description.clear();
+}
+
+void ErrorInfo::setNumber(ntctls::ErrorNumber value)
+{
+    d_number = value;
+}
+
+void ErrorInfo::setDescription(const bsl::string& value)
+{
+    d_description = value;
+}
+
+ntctls::ErrorNumber ErrorInfo::number() const
+{
+    return d_number;
+}
+
+int ErrorInfo::library() const
+{
+    return ERR_GET_LIB(d_number);
+}
+
+int ErrorInfo::function() const
+{
+    return ERR_GET_FUNC(d_number);
+}
+
+int ErrorInfo::reason() const
+{
+    return ERR_GET_REASON(d_number);
+}
+
+bool ErrorInfo::match(int library, int reason) const
+{
+    const int sourceLibrary = ERR_GET_LIB(d_number);
+    const int sourceReason  = ERR_GET_REASON(d_number);
+
+    return library == sourceLibrary && reason == sourceReason;
+}
+
+const bsl::string& ErrorInfo::description() const
+{
+    return d_description;
+}
+
+bool ErrorInfo::equals(const ErrorInfo& other) const
+{
+    return d_number == other.d_number && d_description == other.d_description;
+}
+
+bsl::ostream& ErrorInfo::print(bsl::ostream& stream,
+                               int           level,
+                               int           spacesPerLevel) const
+{
+    bslim::Printer printer(&stream, level, spacesPerLevel);
+    printer.start();
+
+    if (d_number != 0) {
+        const int library  = ERR_GET_LIB(d_number);
+        const int function = ERR_GET_FUNC(d_number);
+        const int reason   = ERR_GET_REASON(d_number);
+
+        printer.printAttribute("library", library);
+        printer.printAttribute("function", function);
+        printer.printAttribute("reason", reason);
+    }
+
+    if (!d_description.empty()) {
+        printer.printAttribute("description", d_description);
+    }
+
+    printer.end();
+    return stream;
+}
+
+bsl::ostream& operator<<(bsl::ostream& stream, const ErrorInfo& object)
+{
+    return object.print(stream, 0, -1);
+}
+
+bool operator==(const ErrorInfo& lhs, const ErrorInfo& rhs)
+{
+    return lhs.equals(rhs);
+}
+
+bool operator!=(const ErrorInfo& lhs, const ErrorInfo& rhs)
+{
+    return !operator==(lhs, rhs);
+}
+
+ErrorStack::ErrorStack(bslma::Allocator* basicAllocator)
+: d_container(basicAllocator)
+, d_sentinel(basicAllocator)
+{
+}
+
+ErrorStack::ErrorStack(const ErrorStack& original,
+                       bslma::Allocator* basicAllocator)
+: d_container(original.d_container, basicAllocator)
+, d_sentinel(basicAllocator)
+{
+}
+
+ErrorStack::~ErrorStack()
+{
+}
+
+ErrorStack& ErrorStack::operator=(const ErrorStack& other)
+{
+    if (this != &other) {
+        d_container = other.d_container;
+    }
+
+    return *this;
+}
+
+void ErrorStack::reset()
+{
+    d_container.clear();
+}
+
+void ErrorStack::push(const ntctls::ErrorInfo& errorInfo)
+{
+    d_container.push_back(errorInfo);
+}
+
+void ErrorStack::push(const ntctls::ErrorStack& errorStack)
+{
+    d_container.insert(d_container.end(),
+                       errorStack.d_container.begin(),
+                       errorStack.d_container.end());
+}
+
+const ntctls::ErrorInfo& ErrorStack::last() const
+{
+    if (!d_container.empty()) {
+        return d_container.back();
+    }
+    else {
+        return d_sentinel;
+    }
+}
+
+bool ErrorStack::find(int library, int reason) const
+{
+    if (!d_container.empty()) {
+        for (Container::const_iterator it = d_container.begin();
+             it != d_container.end();
+             ++it)
+        {
+            const bool match = it->match(library, reason);
+            if (match) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+bsl::string ErrorStack::text() const
+{
+    bsl::stringstream ss;
+    this->print(ss, 0, -1);
+    ss.flush();
+    return ss.str();
+}
+
+bool ErrorStack::empty() const
+{
+    return d_container.empty();
+}
+
+bool ErrorStack::equals(const ErrorStack& other) const
+{
+    return d_container == other.d_container;
+}
+
+bsl::ostream& ErrorStack::print(bsl::ostream& stream,
+                                int           level,
+                                int           spacesPerLevel) const
+{
+    bslim::Printer printer(&stream, level, spacesPerLevel);
+    printer.start();
+
+    if (!d_container.empty()) {
+        printer.printAttribute("error", d_container);
+    }
+
+    printer.end();
+    return stream;
+}
+
+bsl::ostream& operator<<(bsl::ostream& stream, const ErrorStack& object)
+{
+    return object.print(stream, 0, -1);
+}
+
+bool operator==(const ErrorStack& lhs, const ErrorStack& rhs)
+{
+    return lhs.equals(rhs);
+}
+
+bool operator!=(const ErrorStack& lhs, const ErrorStack& rhs)
+{
+    return !operator==(lhs, rhs);
+}
+
+/// Provide a mechanism to initializer and clean up the process-wide resources
+/// required by this implementation.
+class Initializer
+{
+  public:
+    // Initialize the process-wide resources required by this implemention.
+    Initializer();
+
+    // Clean up the process-wide resources required by this implemention.
+    ~Initializer();
+};
+
+void Internal::initialize()
+{
+    BSLMT_ONCE_DO
+    {
+        static ntctls::Initializer initializer;
+    }
+}
+
+void Internal::exit()
+{
+}
+
+void Internal::drainErrorQueue(bsl::vector<bsl::string>* errorQueue)
+{
+    unsigned long rc;
+    while (0 != (rc = ERR_get_error())) {
+        char buffer[512];
+        buffer[0] = 0;
+
+        ERR_error_string_n(rc, buffer, sizeof(buffer));
+
+        errorQueue->push_back(buffer);
+    }
+}
+
+void Internal::drainErrorQueue(bsl::string* description)
+{
+    unsigned long rc;
+    while (0 != (rc = ERR_get_error())) {
+        char buffer[512];
+        buffer[0] = 0;
+
+        ERR_error_string_n(rc, buffer, sizeof(buffer));
+
+        description->append("[ ", 2);
+        description->append(buffer);
+        description->append(" ]", 2);
+    }
+}
+
+void Internal::drainErrorQueue(bsl::streambuf* description)
+{
+    unsigned long rc;
+    while (0 != (rc = ERR_get_error())) {
+        char buffer[512];
+        buffer[0] = 0;
+
+        ERR_error_string_n(rc, buffer, sizeof(buffer));
+
+        description->sputn("[ ", 2);
+        description->sputn(buffer, bsl::strlen(buffer));
+        description->sputn(" ]", 2);
+    }
+}
+
+void Internal::drainErrorQueue(ntctls::ErrorStack* errorStack)
+{
+    while (true) {
+        unsigned long rc = ERR_get_error();
+        if (rc == 0) {
+            break;
+        }
+
+        char buffer[512];
+        buffer[0] = 0;
+
+        ERR_error_string_n(rc, buffer, sizeof(buffer));
+
+        ntctls::ErrorInfo errorInfo;
+        errorInfo.setNumber(rc);
+        errorInfo.setDescription(buffer);
+
+        errorStack->push(errorInfo);
+    }
+}
+
+void Internal::convertDatetimeToAsn1TimeString(bsl::string*          result,
+                                               const bdlt::Datetime& dateTime)
+{
+    bsl::stringstream ss;
+
+    ss << bsl::setw(4);
+    ss << bsl::setfill('0');
+    ss << dateTime.year();
+
+    ss << bsl::setw(2);
+    ss << bsl::setfill('0');
+    ss << dateTime.month();
+
+    ss << bsl::setw(2);
+    ss << bsl::setfill('0');
+    ss << dateTime.day();
+
+    ss << bsl::setw(2);
+    ss << bsl::setfill('0');
+    ss << dateTime.hour();
+
+    ss << bsl::setw(2);
+    ss << bsl::setfill('0');
+    ss << dateTime.minute();
+
+    ss << bsl::setw(2);
+    ss << bsl::setfill('0');
+    ss << dateTime.second();
+
+    ss << "Z";
+
+    *result = ss.str();
+}
+
+bsl::shared_ptr<BIO> Internal::createStream(bsl::streambuf*   buffer,
+                                            bslma::Allocator* basicAllocator)
+{
+    ntctls::Internal::initialize();
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<BIO> bio_sp;
+
+    BIO* bio = BIO_new_streambuf(buffer);
+    if (bio) {
+        bio_sp.reset(bio, &BIO_free, allocator);
+    }
+
+    return bio_sp;
+}
+
+BIO* Internal::createStreamRaw(bsl::streambuf* buffer)
+{
+    ntctls::Internal::initialize();
+    return BIO_new_streambuf(buffer);
+}
+
+bsl::shared_ptr<BIO> Internal::createStream(bdlbb::Blob*      blob,
+                                            bslma::Allocator* basicAllocator)
+{
+    ntctls::Internal::initialize();
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<BIO> bio_sp;
+
+    BIO* bio = BIO_new_blob(blob);
+    if (bio) {
+        bio_sp.reset(bio, &BIO_free, allocator);
+    }
+
+    return bio_sp;
+}
+
+BIO* Internal::createStreamRaw(bdlbb::Blob* blob)
+{
+    ntctls::Internal::initialize();
+    return BIO_new_blob(blob);
+}
+
+void Internal::destroyStream(BIO* bio)
+{
+    BIO_free(bio);
+}
+
+/// Provide a container for a private key.
+///
+/// @par Thread Safety
+/// This class is not thread safe.
+///
+/// @ingroup module_ntctls
+class Key : public ntci::EncryptionKey, public ntccfg::Shared<Key>
+{
+    ntctls::Handle<EVP_PKEY> d_pkey;
+    ntca::EncryptionKey      d_record;
+    bslma::Allocator*        d_allocator_p;
+
+  private:
+    Key(const Key&) BSLS_KEYWORD_DELETED;
+    Key& operator=(const Key& other) BSLS_KEYWORD_DELETED;
+
+  private:
+    /// Load into the specified 'result' a new DSA key. Return the error.
+    static ntsa::Error generateDsa(ntctls::Handle<EVP_PKEY>* result);
+
+    /// Load into the specified 'result' a new RSA key. Return the error.
+    static ntsa::Error generateRsa(ntctls::Handle<EVP_PKEY>* result);
+
+    /// Load into the specified 'result' a new elliptic curve key having the
+    /// well-known parameters identified by the specified 'parameterId'. Return
+    /// the error.
+    static ntsa::Error generateEllipticCurve(ntctls::Handle<EVP_PKEY>* result,
+                                             int parameterId);
+
+    /// Load into the specified 'result' a new Edwards curve key whose curve
+    /// type is identified by the specified 'typeId'. Return the error.
+    static ntsa::Error generateEdwardsCurve(ntctls::Handle<EVP_PKEY>* result,
+                                            int                       typeId);
+
+  public:
+    /// Create a new, initially empty private key. Optionally specify a
+    /// 'basicAllocator' used to supply memory.  If 'basicAllocator' is 0, the
+    /// currently installed default allocator is used.
+    explicit Key(bslma_Allocator* basicAllocator = 0);
+
+    /// Create a new private key implemented using the specified 'pkey'.
+    /// Optionally specify a 'basicAllocator' used to supply memory.  If
+    /// 'basicAllocator' is 0, the currently installed default allocator is
+    /// used.
+    explicit Key(EVP_PKEY* pkey, bslma_Allocator* basicAllocator = 0);
+
+    /// Destroy this object.
+    ~Key() BSLS_KEYWORD_OVERRIDE;
+
+    /// Generate a new key according to the specified 'configuration'.
+    ntsa::Error generate(const ntca::EncryptionKeyOptions& configuration);
+
+    /// Decode the key according to the specified 'options' from the specified
+    /// 'source'.
+    ntsa::Error decode(bsl::streambuf*                        source,
+                       const ntca::EncryptionResourceOptions& options)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Encode the key according to the specified 'options' to the specified
+    /// 'destination'.
+    ntsa::Error encode(bsl::streambuf*                        destination,
+                       const ntca::EncryptionResourceOptions& options) const
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Load the value-semantic representation of the certificate into the
+    /// specified 'result'.
+    ntsa::Error unwrap(ntca::EncryptionKey* result) const
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Print the public key parameters to the specified stream in an
+    /// unspecified but human-readable form.
+    void print(bsl::ostream& stream) const BSLS_KEYWORD_OVERRIDE;
+
+    /// Return a handle to the private implementation.
+    void* handle() const BSLS_KEYWORD_OVERRIDE;
+
+    /// Return a handle to the private implementation.
+    EVP_PKEY* native() const;
+
+    /// Return the value-semantic representation.
+    const ntca::EncryptionKey& record() const;
+
+    /// Return true if the specified 'other' key has the same public key
+    /// components and parameters, otherwise return false.
+    bool equals(const ntci::EncryptionKey& other) const BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified result a newly-generated key according to the
+    /// specified 'options'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used.
+    static ntsa::Error generateKey(
+        bsl::shared_ptr<ntci::EncryptionKey>* result,
+        const ntca::EncryptionKeyOptions&     options,
+        bslma::Allocator*                     basicAllocator);
+
+    /// Load into the specified result a newly-generated key according to the
+    /// specified 'options'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used.
+    static ntsa::Error generateKey(ntca::EncryptionKey*              result,
+                                   const ntca::EncryptionKeyOptions& options,
+                                   bslma::Allocator* basicAllocator);
+};
+
+/// Define a type alias for a vector of keys.
+typedef bsl::vector<bsl::shared_ptr<ntctls::Key> > KeyVector;
+
+/// Provide a container for an X.509 digital certificate.
+///
+/// @par Thread Safety
+/// This class is not thread safe.
+///
+/// @ingroup module_ntctls
+class Certificate : public ntci::EncryptionCertificate,
+                    public ntccfg::Shared<Certificate>
+{
+    ntctls::Handle<X509>        d_x509;
+    ntca::EncryptionCertificate d_record;
+    ntsa::DistinguishedName     d_subject;
+    ntsa::DistinguishedName     d_issuer;
+    bslma::Allocator*           d_allocator_p;
+
+  private:
+    Certificate(const Certificate&) BSLS_KEYWORD_DELETED;
+    Certificate& operator=(const Certificate& other) BSLS_KEYWORD_DELETED;
+
+  public:
+    /// Create a new, initially empty certificate. Optionally specify a
+    /// 'basicAllocator' used to supply memory.  If 'basicAllocator' is 0, the
+    /// currently installed default allocator is used.
+    explicit Certificate(bslma_Allocator* basicAllocator = 0);
+
+    /// Create a new certificate implemented using the specified 'x509'.
+    /// Optionally specify a 'basicAllocator' used to supply memory.  If
+    /// 'basicAllocator' is 0, the currently installed default allocator is
+    /// used.
+    explicit Certificate(X509* x509, bslma_Allocator* basicAllocator = 0);
+
+    /// Destroy this object.
+    ~Certificate() BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into this object a newly-generated certificate for the specified
+    /// 'userIdentity' and 'userPrivateKey' signed by itself. Return the error.
+    /// Optionally specify a 'basicAllocator' used to supply memory. If
+    /// 'basicAllocator' is 0, the currently installed default allocator is
+    /// used.
+    ntsa::Error generate(
+        const ntsa::DistinguishedName&            userIdentity,
+        const bsl::shared_ptr<Key>&               userPrivateKey,
+        const ntca::EncryptionCertificateOptions& configuration);
+
+    /// Load into this object a newly-generated certificate for the specified
+    /// 'userIdentity' and 'userPrivateKey' signed by the certificate authority
+    /// identified by the specified 'authorityCertificate' that uses the
+    /// specified 'authorityPrivateKey'. Return the error. Optionally specify a
+    /// 'basicAllocator' used to supply memory. If 'basicAllocator' is 0, the
+    /// currently installed default allocator is used.
+    ntsa::Error generate(
+        const ntsa::DistinguishedName&            userIdentity,
+        const bsl::shared_ptr<Key>&               userPrivateKey,
+        const bsl::shared_ptr<Certificate>&       authorityCertificate,
+        const bsl::shared_ptr<Key>&               authorityPrivateKey,
+        const ntca::EncryptionCertificateOptions& configuration);
+
+    /// Decode the certificate according to the specified 'options' from the
+    /// specified 'source'.
+    ntsa::Error decode(bsl::streambuf*                        source,
+                       const ntca::EncryptionResourceOptions& options)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Encode the certificate according to the specified 'options' to the
+    /// specified 'destination'.
+    ntsa::Error encode(bsl::streambuf*                        destination,
+                       const ntca::EncryptionResourceOptions& options) const
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Load the value-semantic representation of the certificate into the
+    /// specified 'result'.
+    ntsa::Error unwrap(ntca::EncryptionCertificate* result) const
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Print the certificate to the specified stream in an unspecified but
+    /// human-readable form.
+    void print(bsl::ostream& stream) const BSLS_KEYWORD_OVERRIDE;
+
+    /// Return the subject of the certificate.
+    const ntsa::DistinguishedName& subject() const BSLS_KEYWORD_OVERRIDE;
+
+    /// Return the issuer of the certificate.
+    const ntsa::DistinguishedName& issuer() const BSLS_KEYWORD_OVERRIDE;
+
+    /// Return true if this certificate is a certificate authority, otherwise
+    /// return false.
+    bool isAuthority() const;
+
+    /// Return a handle to the private implementation.
+    void* handle() const BSLS_KEYWORD_OVERRIDE;
+
+    /// Return a handle to the native implementation.
+    X509* native() const;
+
+    /// Return the value-semantic representation.
+    const ntca::EncryptionCertificate& record() const;
+
+    /// Return true if the specified 'other' certificate has the same value,
+    /// otherwise return false.
+    bool equals(const ntci::EncryptionCertificate& other) const
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a newly-generated certificate for the
+    /// specified 'userIdentity' and 'userPrivateKey' signed by itself.
+    /// Optionally specify a 'basicAllocator' used to supply memory. If
+    /// 'basicAllocator' is 0, the currently installed default allocator is
+    /// used.
+    static ntsa::Error generateCertificate(
+        bsl::shared_ptr<ntci::EncryptionCertificate>* result,
+        const ntsa::DistinguishedName&                userIdentity,
+        const bsl::shared_ptr<ntci::EncryptionKey>&   userPrivateKey,
+        const ntca::EncryptionCertificateOptions&     options,
+        bslma::Allocator*                             basicAllocator);
+
+    /// Load into the specified 'result' a newly-generated certificate for the
+    /// specified 'userIdentity' and 'userPrivateKey' signed by the certificate
+    /// authority identified by the specified 'authorityCertificate' that uses
+    /// the specified 'authorityPrivateKey'.  Return 0 on success and a
+    /// non-zero value otherwise. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used.
+    static ntsa::Error generateCertificate(
+        bsl::shared_ptr<ntci::EncryptionCertificate>* result,
+        const ntsa::DistinguishedName&                userIdentity,
+        const bsl::shared_ptr<ntci::EncryptionKey>&   userPrivateKey,
+        const bsl::shared_ptr<ntci::EncryptionCertificate>&
+                                                    authorityCertificate,
+        const bsl::shared_ptr<ntci::EncryptionKey>& authorityPrivateKey,
+        const ntca::EncryptionCertificateOptions&   options,
+        bslma::Allocator*                           basicAllocator);
+
+    /// Load into the specified 'result' a newly-generated certificate for the
+    /// specified 'userIdentity' and 'userPrivateKey' signed by itself.
+    /// Optionally specify a 'basicAllocator' used to supply memory. If
+    /// 'basicAllocator' is 0, the currently installed default allocator is
+    /// used.
+    static ntsa::Error generateCertificate(
+        ntca::EncryptionCertificate*              result,
+        const ntsa::DistinguishedName&            userIdentity,
+        const ntca::EncryptionKey&                userPrivateKey,
+        const ntca::EncryptionCertificateOptions& options,
+        bslma::Allocator*                         basicAllocator);
+
+    /// Load into the specified 'result' a newly-generated certificate for the
+    /// specified 'userIdentity' and 'userPrivateKey' signed by the certificate
+    /// authority identified by the specified 'authorityCertificate' that uses
+    /// the specified 'authorityPrivateKey'.  Return 0 on success and a
+    /// non-zero value otherwise. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used.
+    static ntsa::Error generateCertificate(
+        ntca::EncryptionCertificate*              result,
+        const ntsa::DistinguishedName&            userIdentity,
+        const ntca::EncryptionKey&                userPrivateKey,
+        const ntca::EncryptionCertificate&        authorityCertificate,
+        const ntca::EncryptionKey&                authorityPrivateKey,
+        const ntca::EncryptionCertificateOptions& options,
+        bslma::Allocator*                         basicAllocator);
+};
+
+/// Define a type alias for a vector of certificates.
+typedef bsl::vector<bsl::shared_ptr<ntctls::Certificate> > CertificateVector;
+
+/// Provide a storage of private keys and certificates as used
+/// in public key cryptography.
+///
+/// @par Thread Safety
+/// This class is thread safe.
+///
+/// @ingroup module_ntctls
+class Resource : public ntci::EncryptionResource
+{
+    bsl::shared_ptr<ntctls::Key>         d_privateKey_sp;
+    bsl::shared_ptr<ntctls::Certificate> d_certificate_sp;
+    ntctls::CertificateVector            d_caList;
+    bslma::Allocator*                    d_allocator_p;
+
+  private:
+    Resource(const Resource&) BSLS_KEYWORD_DELETED;
+    Resource& operator=(const Resource&) BSLS_KEYWORD_DELETED;
+
+  public:
+    /// Create a new resource. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used.
+    explicit Resource(bslma::Allocator* basicAllocator = 0);
+
+    /// Destroy this object.
+    ~Resource() BSLS_KEYWORD_OVERRIDE;
+
+    /// Set the private key to the specified 'key'. Return the error.
+    ntsa::Error setPrivateKey(const ntca::EncryptionKey& key);
+
+    /// Set the private key to the specified 'key'. Return the error.
+    ntsa::Error setPrivateKey(const bsl::shared_ptr<ntci::EncryptionKey>& key)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Set the user's certificate to the specified 'certificate'. Return the
+    /// error.
+    ntsa::Error setCertificate(const ntca::EncryptionCertificate& certificate);
+
+    /// Set the user's certificate to the specified 'certificate'. Return the
+    /// error.
+    ntsa::Error setCertificate(
+        const bsl::shared_ptr<ntci::EncryptionCertificate>& certificate)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Add the specified 'certificate' to the list of trusted certificates.
+    /// Return the error.
+    ntsa::Error addCertificateAuthority(
+        const ntca::EncryptionCertificate& certificate);
+
+    /// Add the specified 'certificate' to the list of trusted certificates.
+    /// Return the error.
+    ntsa::Error addCertificateAuthority(
+        const bsl::shared_ptr<ntci::EncryptionCertificate>& certificate)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Decode the resource according to the specified 'options' from the
+    /// specified 'source'. Return the error.
+    ntsa::Error decode(bsl::streambuf*                        source,
+                       const ntca::EncryptionResourceOptions& options)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Encode the resource according to the specified 'options' to the
+    /// specified 'destination'. Return the error.
+    ntsa::Error encode(bsl::streambuf*                        destination,
+                       const ntca::EncryptionResourceOptions& options) const
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' the private key stored in the
+    /// resource. Return the error.
+    ntsa::Error getPrivateKey(bsl::shared_ptr<ntci::EncryptionKey>* result)
+        const BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' the user's certificate stored in the
+    /// resource. Return the error.
+    ntsa::Error getCertificate(bsl::shared_ptr<ntci::EncryptionCertificate>*
+                                   result) const BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' the user's certificate stored in the
+    /// resource. Return the error.
+    ntsa::Error getCertificateAuthoritySet(
+        bsl::vector<bsl::shared_ptr<ntci::EncryptionCertificate> >* result)
+        const BSLS_KEYWORD_OVERRIDE;
+
+    /// Return true if the specified 'other' resource has the same value,
+    /// otherwise return false.
+    bool equals(const Resource& other) const;
+
+    /// Return true if this resource contains the keys of the specified 'other'
+    /// resource (if the specified 'includePrivateKeys' flag is true) and
+    /// this resource contains the certificate and certificate authorities of
+    /// the 'other' resource (if the specified 'includeCertificates' flag is
+    /// true.
+    bool contains(const Resource& other,
+                  bool            includePrivateKeys,
+                  bool            includeCertificates) const;
+
+    /// Load into the specified 'result' the driver representation of the
+    /// specified 'certificate'. Return the error.
+    static ntsa::Error convert(
+        bsl::shared_ptr<ntctls::Certificate>*               result,
+        const bsl::shared_ptr<ntci::EncryptionCertificate>& certificate);
+
+    /// Load into the specified 'result' the driver representation of the
+    /// specified 'certificate'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    static ntsa::Error convert(
+        bsl::shared_ptr<ntci::EncryptionCertificate>* result,
+        const ntca::EncryptionCertificate&            certificate,
+        bslma::Allocator*                             basicAllocator = 0);
+
+    /// Load into the specified 'result' the driver representation of the
+    /// specified 'certificate'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    static ntsa::Error convert(bsl::shared_ptr<ntctls::Certificate>* result,
+                               const ntca::EncryptionCertificate& certificate,
+                               bslma::Allocator* basicAllocator = 0);
+
+    /// Load into the specified 'result' the driver representation of the
+    /// specified 'certificate'. Return the error.
+    static ntsa::Error convert(ntctls::Handle<X509>*              result,
+                               const ntca::EncryptionCertificate& certificate);
+
+    /// Load into the specified 'result' the description of the specified
+    /// 'certificate'. Return the error.
+    static ntsa::Error convert(
+        ntca::EncryptionCertificate*                result,
+        const bsl::shared_ptr<ntctls::Certificate>& certificate);
+
+    /// Load into the specified 'result' the description of the specified
+    /// 'certificate'. Return the error.
+    static ntsa::Error convert(ntca::EncryptionCertificate* result,
+                               const ntctls::Handle<X509>&  certificate);
+
+    /// Load into the specified 'result' the driver representation of the
+    /// specified 'key'. Return the error.
+    static ntsa::Error convert(
+        bsl::shared_ptr<ntctls::Key>*               result,
+        const bsl::shared_ptr<ntci::EncryptionKey>& key);
+
+    /// Load into the specified 'result' the driver representation of the
+    /// specified 'key'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    static ntsa::Error convert(bsl::shared_ptr<ntci::EncryptionKey>* result,
+                               const ntca::EncryptionKey&            key,
+                               bslma::Allocator* basicAllocator = 0);
+
+    /// Load into the specified 'result' the driver representation of the
+    /// specified 'key'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    static ntsa::Error convert(bsl::shared_ptr<ntctls::Key>* result,
+                               const ntca::EncryptionKey&    key,
+                               bslma::Allocator* basicAllocator = 0);
+
+    /// Load into the specified 'result' the driver representation of the
+    /// specified 'key'. Return the error.
+    static ntsa::Error convert(ntctls::Handle<EVP_PKEY>*  result,
+                               const ntca::EncryptionKey& key);
+
+    /// Load into the specified 'result' the description of the specified
+    /// 'key'. Return the error.
+    static ntsa::Error convert(ntca::EncryptionKey*                result,
+                               const bsl::shared_ptr<ntctls::Key>& key);
+
+    /// Load into the specified 'result' the description of the specified
+    /// 'key'. Return the error.
+    static ntsa::Error convert(ntca::EncryptionKey*            result,
+                               const ntctls::Handle<EVP_PKEY>& key);
+};
+
+#define NTCTLS_KEY_LOG_GENERAL_ERROR(reason)                                  \
+    do {                                                                      \
+        bsl::string description;                                              \
+        ntctls::Internal::drainErrorQueue(&description);                      \
+        BSLS_LOG_DEBUG("%s: %s", reason, description.c_str());                \
+    } while (false)
+
+#define NTCTLS_KEY_LOG_ENCODE_ERROR()                                         \
+    NTCTLS_KEY_LOG_GENERAL_ERROR("Failed to encode private key")
+
+#define NTCTLS_KEY_LOG_DECODE_ERROR()                                         \
+    NTCTLS_KEY_LOG_GENERAL_ERROR("Failed to decode private key")
+
+#define NTCTLS_KEY_LOG_BN_ERROR_ALLOCATE()                                    \
+    NTCTLS_KEY_LOG_GENERAL_ERROR("Failed to allocate big number")
+
+#define NTCTLS_KEY_LOG_BN_ERROR_SET_EXPONENT()                                \
+    NTCTLS_KEY_LOG_GENERAL_ERROR("Failed to set exponent")
+
+#define NTCTLS_KEY_LOG_DSA_ERROR_ALLOCATE()                                   \
+    NTCTLS_KEY_LOG_GENERAL_ERROR("Failed to allocate DSA key")
+
+#define NTCTLS_KEY_LOG_DSA_ERROR_GENERATE()                                   \
+    NTCTLS_KEY_LOG_GENERAL_ERROR("Failed to generate DSA key")
+
+#define NTCTLS_KEY_LOG_RSA_ERROR_ALLOCATE()                                   \
+    NTCTLS_KEY_LOG_GENERAL_ERROR("Failed to allocate RSA key")
+
+#define NTCTLS_KEY_LOG_RSA_ERROR_GENERATE()                                   \
+    NTCTLS_KEY_LOG_GENERAL_ERROR("Failed to generate RSA key")
+
+#define NTCTLS_KEY_LOG_EV_PKEY_ERROR_ALLOCATE()                               \
+    NTCTLS_KEY_LOG_GENERAL_ERROR("Failed to allocate private key")
+
+#define NTCTLS_KEY_LOG_EV_PKEY_ERROR_ASSIGN()                                 \
+    NTCTLS_KEY_LOG_GENERAL_ERROR("Failed to assign private key")
+
+#define NTCTLS_KEY_LOG_EV_PKEY_CTX_ERROR_ALLOCATE()                           \
+    NTCTLS_KEY_LOG_GENERAL_ERROR("Failed to allocate private key context")
+
+#define NTCTLS_KEY_LOG_EV_PKEY_CTX_ERROR_KEYGEN_INIT()                        \
+    NTCTLS_KEY_LOG_GENERAL_ERROR(                                             \
+        "Failed to initialize private key context generator")
+
+#define NTCTLS_KEY_LOG_EV_PKEY_CTX_ERROR_KEYGEN_SET_CURVE()                   \
+    NTCTLS_KEY_LOG_GENERAL_ERROR("Failed to set private key context type")
+
+#define NTCTLS_KEY_LOG_EV_PKEY_CTX_ERROR_KEYGEN_GENERATE()                    \
+    NTCTLS_KEY_LOG_GENERAL_ERROR("Failed to generate private key")
+
+#define NTCTLS_KEY_LOG_PASSPHRASE_INVALID()                                   \
+    NTCTLS_KEY_LOG_GENERAL_ERROR("Invalid passphrase")
+
+#define NTCTLS_CERTIFICATE_LOG_GENERAL_ERROR(reason)                          \
+    do {                                                                      \
+        bsl::string description;                                              \
+        ntctls::Internal::drainErrorQueue(&description);                      \
+        BSLS_LOG_DEBUG("%s: %s", reason, description.c_str());                \
+    } while (false)
+
+#define NTCTLS_CERTIFICATE_LOG_X509_EXTENSION_ERROR(nid, text)                \
+    do {                                                                      \
+        bsl::string description;                                              \
+        ntctls::Internal::drainErrorQueue(&description);                      \
+        BSLS_LOG_DEBUG("Failed to set extension '%s': %s",                    \
+                       bsl::string(text).c_str(),                             \
+                       description.c_str());                                  \
+    } while (false)
+
+#define NTCTLS_CERTIFICATE_LOG_PRINT_ERROR()                                  \
+    NTCTLS_CERTIFICATE_LOG_GENERAL_ERROR("Failed to print certificate")
+
+#define NTCTLS_CERTIFICATE_LOG_ENCODE_ERROR()                                 \
+    NTCTLS_CERTIFICATE_LOG_GENERAL_ERROR("Failed to encode "                  \
+                                         "certificate")
+
+#define NTCTLS_CERTIFICATE_LOG_DECODE_ERROR()                                 \
+    NTCTLS_CERTIFICATE_LOG_GENERAL_ERROR("Failed to decode "                  \
+                                         "certificate")
+
+#define NTCTLS_CERTIFICATE_LOG_X509_NAME_ERROR_ALLOCATE()                     \
+    NTCTLS_CERTIFICATE_LOG_GENERAL_ERROR("Failed to allocate certificate "    \
+                                         "name")
+
+#define NTCTLS_CERTIFICATE_LOG_X509_NAME_ERROR_GENERATE()                     \
+    NTCTLS_CERTIFICATE_LOG_GENERAL_ERROR("Failed to generate certificate "    \
+                                         "name")
+
+#define NTCTLS_CERTIFICATE_LOG_X509_ERROR_ALLOCATE()                          \
+    NTCTLS_CERTIFICATE_LOG_GENERAL_ERROR("Failed to allocate certificate")
+
+#define NTCTLS_CERTIFICATE_LOG_X509_ERROR_SET_SUBJECT_NAME()                  \
+    NTCTLS_CERTIFICATE_LOG_GENERAL_ERROR("Failed to set subject name")
+
+#define NTCTLS_CERTIFICATE_LOG_X509_ERROR_SET_ISSUER_NAME()                   \
+    NTCTLS_CERTIFICATE_LOG_GENERAL_ERROR("Failed to set issuer name")
+
+#define NTCTLS_CERTIFICATE_LOG_X509_ERROR_SET_PUBLIC_KEY()                    \
+    NTCTLS_CERTIFICATE_LOG_GENERAL_ERROR("Failed to set public key")
+
+#define NTCTLS_CERTIFICATE_LOG_X509_ERROR_SIGN()                              \
+    NTCTLS_CERTIFICATE_LOG_GENERAL_ERROR("Failed to sign certificate")
+
+#define NTCTLS_CERTIFICATE_LOG_PASSPHRASE_INVALID()                           \
+    NTCTLS_CERTIFICATE_LOG_GENERAL_ERROR("Invalid passphrase")
+
+#if 0
+#define NTCTLS_RESOURCE_LOG_ERROR_STACK(errorStack)                           \
+    do {                                                                      \
+        bsl::string errorDescription = (errorStack).text();                   \
+        if (!errorDescription.empty()) {                                      \
+            BSLS_LOG_ERROR("Codec failure in %s: %s",                         \
+                           __FUNCTION__,                                      \
+                           errorDescription.c_str());                         \
+        }                                                                     \
+    } while (false)
+#else
+#define NTCTLS_RESOURCE_LOG_ERROR_STACK(errorStack)
+#endif
+
+#define NTCTLS_RESOURCE_LOG_ENCODER_ERROR(diagnostics)                        \
+    do {                                                                      \
+        bsl::string errorDescription = (diagnostics).text();                  \
+        if (!errorDescription.empty()) {                                      \
+            BSLS_LOG_DEBUG("Failed to encode resource: %s",                   \
+                           errorDescription.c_str());                         \
+        }                                                                     \
+    } while (false)
+
+#define NTCTLS_RESOURCE_LOG_DECODER_ERROR(diagnostics)                        \
+    do {                                                                      \
+        bsl::string errorDescription = (diagnostics).text();                  \
+        if (!errorDescription.empty()) {                                      \
+            BSLS_LOG_DEBUG("Failed to decode resource: %s",                   \
+                           errorDescription.c_str());                         \
+        }                                                                     \
+    } while (false)
+
+#define NTCTLS_RESOURCE_LOG_SECRET_UNAVAILABLE()                              \
+    BSLS_LOG_DEBUG("The resource requires a passphrase but no passphrase "    \
+                   "resolution is available")
+
+#define NTCTLS_RESOURCE_LOG_ALREADY_HAVE_KEY()                                \
+    BSLS_LOG_ERROR("The resource contains more than one private key")
+
+#define NTCTLS_RESOURCE_LOG_ALREADY_HAVE_CERTIFICATE()                        \
+    BSLS_LOG_ERROR("The resource contains more than one certificate")
+
+#define NTCTLS_RESOURCE_LOG_INVALID_DRIVER()                                  \
+    BSLS_LOG_ERROR("The parameters are implemented with a different driver")
+
+namespace {
+
+const int k_DEFAULT_DSA_BITS     = 2048;
+const int k_DEFAULT_RSA_BITS     = 2048;
+const int k_DEFAULT_RSA_EXPONENT = 65537;
+
+void parseDistinguishedName(ntsa::DistinguishedName* identity, X509_NAME* name)
+{
+    identity->reset();
+
+    if (name == 0) {
+        return;
+    }
+
+    const bsl::size_t numEntries = X509_NAME_entry_count(name);
+
+    for (bsl::size_t i = 0; i < numEntries; ++i) {
+        X509_NAME_ENTRY* entry =
+            X509_NAME_get_entry(name, static_cast<int>(i));
+
+        const int n = OBJ_obj2nid(X509_NAME_ENTRY_get_object(entry));
+
+        char scratch[80] = {};
+
+        const char* entryNameData = 0;
+
+        if ((n == NID_undef) || ((entryNameData = OBJ_nid2sn(n)) == 0)) {
+            i2t_ASN1_OBJECT(scratch,
+                            sizeof scratch,
+                            X509_NAME_ENTRY_get_object(entry));
+            entryNameData = scratch;
+        }
+
+        const bsl::size_t entryNameSize = bsl::strlen(entryNameData);
+
+        ASN1_STRING* entry_value = X509_NAME_ENTRY_get_data(entry);
+
+        const unsigned char* entryValueData = entry_value->data;
+        const int            entryValueSize = entry_value->length;
+
+        bsl::string component;
+        if (entryNameData && entryNameSize > 0) {
+            component.assign(entryNameData, entryNameSize);
+        }
+        else {
+            component.assign("?");
+        }
+
+        bsl::string attribute;
+        if (entryValueData && entryValueSize > 0) {
+            attribute.assign((const char*)(entryValueData), entryValueSize);
+        }
+
+        (*identity)[component].addAttribute(attribute);
+    }
+}
+
+int generateX509Name(X509_NAME*                                result,
+                     const ntsa::DistinguishedName::Component& component)
+{
+    for (int i = 0; i < component.numAttributes(); ++i) {
+        int loc = -1;
+        int set = i == 0 ? 0 : 1;
+
+        const bsl::string& value = component[i];
+        if (!X509_NAME_add_entry_by_txt(result,
+                                        component.id().c_str(),
+                                        MBSTRING_ASC,
+                                        (const unsigned char*)value.c_str(),
+                                        static_cast<int>(value.size()),
+                                        loc,
+                                        set))
+        {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+ntsa::Error addExtension(X509*       x509,
+                         X509V3_CTX* x509v3Ctx,
+                         int         nid,
+                         const char* extension)
+{
+    int rc;
+
+    ntctls::Handle<X509_EXTENSION> ex(
+        X509V3_EXT_conf_nid(0, x509v3Ctx, nid, extension));
+    if (!ex) {
+        NTCTLS_CERTIFICATE_LOG_X509_EXTENSION_ERROR(nid, extension);
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    rc = X509_add_ext(x509, ex.get(), -1);
+    if (rc <= 0) {
+        NTCTLS_CERTIFICATE_LOG_X509_EXTENSION_ERROR(nid, extension);
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    return ntsa::Error();
+}
+
+X509_EXTENSION* getExtension(const X509* x509, int nid)
+{
+    int rc = X509_get_ext_by_NID(x509, nid, -1);
+    if (rc < 0) {
+        return 0;
+    }
+
+    return X509_get_ext(x509, rc);
+}
+
+class StreamBufferPositionGuard
+{
+    bsl::streambuf* d_buffer_p;
+    bsl::streampos  d_start;
+
+    StreamBufferPositionGuard(const StreamBufferPositionGuard&)
+        BSLS_KEYWORD_DELETED;
+    StreamBufferPositionGuard& operator=(const StreamBufferPositionGuard&)
+        BSLS_KEYWORD_DELETED;
+
+  public:
+    explicit StreamBufferPositionGuard(bsl::streambuf* buffer);
+    ~StreamBufferPositionGuard();
+
+    void release();
+};
+
+StreamBufferPositionGuard::StreamBufferPositionGuard(bsl::streambuf* buffer)
+: d_buffer_p(buffer)
+, d_start(d_buffer_p->pubseekoff(0, bsl::ios_base::cur, bsl::ios_base::in))
+{
+}
+
+StreamBufferPositionGuard::~StreamBufferPositionGuard()
+{
+    if (d_buffer_p) {
+        if (d_start >= 0) {
+            bsl::streampos current = d_buffer_p->pubseekoff(0,
+                                                            bsl::ios_base::cur,
+                                                            bsl::ios_base::in);
+
+            if (current > d_start) {
+                bsl::streamoff distance =
+                    static_cast<bsl::streamoff>(current - d_start);
+                d_buffer_p->pubseekoff(-distance,
+                                       bsl::ios_base::cur,
+                                       bsl::ios_base::in);
+            }
+        }
+    }
+}
+
+void StreamBufferPositionGuard::release()
+{
+    d_buffer_p = 0;
+    d_start    = -1;
+}
+
+// Provide utilities to encode and decode certificates and keys to and from
+// various storage formats.
+class ResourceUtil
+{
+  private:
+    // Define a type alias for a function to encode a single key.
+    typedef ntsa::Error (*EncodeKey)(
+        ntctls::ErrorStack*                 diagnostics,
+        bsl::streambuf*                     destination,
+        const bsl::shared_ptr<ntctls::Key>& privateKey,
+        ntca::EncryptionResourceOptions*    options);
+
+    // Define a type alias for a function to encode a single certificate.
+    typedef ntsa::Error (*EncodeCertificate)(
+        ntctls::ErrorStack*                         diagnostics,
+        bsl::streambuf*                             destination,
+        const bsl::shared_ptr<ntctls::Certificate>& certificate,
+        ntca::EncryptionResourceOptions*            options);
+
+    // Define a type alias for a function to decode a single key.
+    typedef ntsa::Error (*DecodeKey)(ntctls::ErrorStack*           diagnostics,
+                                     bsl::streambuf*               source,
+                                     bsl::shared_ptr<ntctls::Key>* privateKey,
+                                     ntca::EncryptionResourceOptions* options,
+                                     bslma::Allocator* allocator);
+
+    // Define a type alias for a function to decode a single certificate.
+    typedef ntsa::Error (*DecodeCertificate)(
+        ntctls::ErrorStack*                   diagnostics,
+        bsl::streambuf*                       source,
+        bsl::shared_ptr<ntctls::Certificate>* certificate,
+        ntca::EncryptionResourceOptions*      options,
+        bslma::Allocator*                     allocator);
+
+    // Skip and consecutive leading blank lines and/or leading lines with
+    // comments.
+    static void chomp(bsl::streambuf* source);
+
+    // Detect the storage type of the specified 'source' and load the detected
+    // type, if any, into the specified 'result'. Return the error.
+    static ntsa::Error detectType(
+        bdlb::NullableValue<ntca::EncryptionResourceType::Value>* result,
+        bsl::streambuf*                                           source);
+
+    static ntsa::Error encodeType(
+        ntctls::ErrorStack*                         diagnostics,
+        bsl::streambuf*                             destination,
+        const bsl::shared_ptr<ntctls::Key>&         privateKey,
+        const bsl::shared_ptr<ntctls::Certificate>& certificate,
+        const ntctls::CertificateVector&            caList,
+        ntca::EncryptionResourceOptions*            options);
+
+    static ntsa::Error encodeKeyAsn1(
+        ntctls::ErrorStack*                 diagnostics,
+        bsl::streambuf*                     destination,
+        const bsl::shared_ptr<ntctls::Key>& privateKey,
+        ntca::EncryptionResourceOptions*    options);
+
+    static ntsa::Error encodeKeyAsn1(ntctls::ErrorStack* diagnostics,
+                                     bsl::streambuf*     destination,
+                                     EVP_PKEY*           privateKey,
+                                     ntca::EncryptionResourceOptions* options);
+
+    static ntsa::Error encodeCertificateAsn1(
+        ntctls::ErrorStack*                         diagnostics,
+        bsl::streambuf*                             destination,
+        const bsl::shared_ptr<ntctls::Certificate>& certificate,
+        ntca::EncryptionResourceOptions*            options);
+
+    static ntsa::Error encodeCertificateAsn1(
+        ntctls::ErrorStack*              diagnostics,
+        bsl::streambuf*                  destination,
+        X509*                            certificate,
+        ntca::EncryptionResourceOptions* options);
+
+    static ntsa::Error encodeKeyAsn1Pem(
+        ntctls::ErrorStack*                 diagnostics,
+        bsl::streambuf*                     destination,
+        const bsl::shared_ptr<ntctls::Key>& privateKey,
+        ntca::EncryptionResourceOptions*    options);
+
+    static ntsa::Error encodeCertificateAsn1Pem(
+        ntctls::ErrorStack*                         diagnostics,
+        bsl::streambuf*                             destination,
+        const bsl::shared_ptr<ntctls::Certificate>& certificate,
+        ntca::EncryptionResourceOptions*            options);
+
+    static ntsa::Error encodeKeyPkcs8(
+        ntctls::ErrorStack*                 diagnostics,
+        bsl::streambuf*                     destination,
+        const bsl::shared_ptr<ntctls::Key>& privateKey,
+        ntca::EncryptionResourceOptions*    options);
+
+    static ntsa::Error encodeCertificatePkcs8(
+        ntctls::ErrorStack*                         diagnostics,
+        bsl::streambuf*                             destination,
+        const bsl::shared_ptr<ntctls::Certificate>& certificate,
+        ntca::EncryptionResourceOptions*            options);
+
+    static ntsa::Error encodeKeyPkcs8Pem(
+        ntctls::ErrorStack*                 diagnostics,
+        bsl::streambuf*                     destination,
+        const bsl::shared_ptr<ntctls::Key>& privateKey,
+        ntca::EncryptionResourceOptions*    options);
+
+    static ntsa::Error encodeCertificatePkcs8Pem(
+        ntctls::ErrorStack*                         diagnostics,
+        bsl::streambuf*                             destination,
+        const bsl::shared_ptr<ntctls::Certificate>& certificate,
+        ntca::EncryptionResourceOptions*            options);
+
+    static ntsa::Error encodeResourcePkcs12(
+        ntctls::ErrorStack*                         diagnostics,
+        bsl::streambuf*                             destination,
+        const bsl::shared_ptr<ntctls::Key>&         privateKey,
+        const bsl::shared_ptr<ntctls::Certificate>& certificate,
+        const ntctls::CertificateVector&            caList,
+        ntca::EncryptionResourceOptions*            options);
+
+    static ntsa::Error encodeResourcePkcs7(
+        ntctls::ErrorStack*                         diagnostics,
+        bsl::streambuf*                             destination,
+        const bsl::shared_ptr<ntctls::Key>&         privateKey,
+        const bsl::shared_ptr<ntctls::Certificate>& certificate,
+        const ntctls::CertificateVector&            caList,
+        ntca::EncryptionResourceOptions*            options);
+
+    static ntsa::Error encodeResourcePkcs7Pem(
+        ntctls::ErrorStack*                         diagnostics,
+        bsl::streambuf*                             destination,
+        const bsl::shared_ptr<ntctls::Key>&         privateKey,
+        const bsl::shared_ptr<ntctls::Certificate>& certificate,
+        const ntctls::CertificateVector&            caList,
+        ntca::EncryptionResourceOptions*            options);
+
+    static ntsa::Error decodeType(
+        ntctls::ErrorStack*                   diagnostics,
+        bsl::streambuf*                       source,
+        bsl::shared_ptr<ntctls::Key>*         privateKey,
+        bsl::shared_ptr<ntctls::Certificate>* certificate,
+        ntctls::CertificateVector*            caList,
+        ntca::EncryptionResourceOptions*      options,
+        bslma::Allocator*                     allocator);
+
+    static ntsa::Error decodeKeyAsn1(ntctls::ErrorStack*           diagnostics,
+                                     bsl::streambuf*               source,
+                                     bsl::shared_ptr<ntctls::Key>* privateKey,
+                                     ntca::EncryptionResourceOptions* options,
+                                     bslma::Allocator* allocator);
+
+    static ntsa::Error decodeKeyAsn1(ntctls::ErrorStack*       diagnostics,
+                                     bsl::streambuf*           source,
+                                     ntctls::Handle<EVP_PKEY>* privateKey,
+                                     ntca::EncryptionResourceOptions* options,
+                                     bslma::Allocator* allocator);
+
+    static ntsa::Error decodeCertificateAsn1(
+        ntctls::ErrorStack*                   diagnostics,
+        bsl::streambuf*                       source,
+        bsl::shared_ptr<ntctls::Certificate>* certificate,
+        ntca::EncryptionResourceOptions*      options,
+        bslma::Allocator*                     allocator);
+
+    static ntsa::Error decodeCertificateAsn1(
+        ntctls::ErrorStack*              diagnostics,
+        bsl::streambuf*                  source,
+        ntctls::Handle<X509>*            certificate,
+        ntca::EncryptionResourceOptions* options,
+        bslma::Allocator*                allocator);
+
+    static ntsa::Error decodeKeyAsn1Pem(
+        ntctls::ErrorStack*              diagnostics,
+        bsl::streambuf*                  source,
+        bsl::shared_ptr<ntctls::Key>*    privateKey,
+        ntca::EncryptionResourceOptions* options,
+        bslma::Allocator*                allocator);
+
+    static ntsa::Error decodeKeyAsn1Pem(
+        ntctls::ErrorStack*              diagnostics,
+        bsl::streambuf*                  source,
+        ntctls::Handle<EVP_PKEY>*        privateKey,
+        ntca::EncryptionResourceOptions* options,
+        bslma::Allocator*                allocator);
+
+    static ntsa::Error decodeCertificateAsn1Pem(
+        ntctls::ErrorStack*                   diagnostics,
+        bsl::streambuf*                       source,
+        bsl::shared_ptr<ntctls::Certificate>* certificate,
+        ntca::EncryptionResourceOptions*      options,
+        bslma::Allocator*                     allocator);
+
+    static ntsa::Error decodeCertificateAsn1Pem(
+        ntctls::ErrorStack*              diagnostics,
+        bsl::streambuf*                  source,
+        ntctls::Handle<X509>*            certificate,
+        ntca::EncryptionResourceOptions* options,
+        bslma::Allocator*                allocator);
+
+    static ntsa::Error decodeKeyPkcs8(ntctls::ErrorStack* diagnostics,
+                                      bsl::streambuf*     source,
+                                      bsl::shared_ptr<ntctls::Key>* privateKey,
+                                      ntca::EncryptionResourceOptions* options,
+                                      bslma::Allocator* allocator);
+
+    static ntsa::Error decodeKeyPkcs8(ntctls::ErrorStack*       diagnostics,
+                                      bsl::streambuf*           source,
+                                      ntctls::Handle<EVP_PKEY>* privateKey,
+                                      ntca::EncryptionResourceOptions* options,
+                                      bslma::Allocator* allocator);
+
+    static ntsa::Error decodeKeyPkcs8E(
+        ntctls::ErrorStack*              diagnostics,
+        bsl::streambuf*                  source,
+        ntctls::Handle<EVP_PKEY>*        privateKey,
+        ntca::EncryptionResourceOptions* options,
+        bslma::Allocator*                allocator);
+
+    static ntsa::Error decodeKeyPkcs8U(
+        ntctls::ErrorStack*              diagnostics,
+        bsl::streambuf*                  source,
+        ntctls::Handle<EVP_PKEY>*        privateKey,
+        ntca::EncryptionResourceOptions* options,
+        bslma::Allocator*                allocator);
+
+    static ntsa::Error decodeCertificatePkcs8(
+        ntctls::ErrorStack*                   diagnostics,
+        bsl::streambuf*                       source,
+        bsl::shared_ptr<ntctls::Certificate>* certificate,
+        ntca::EncryptionResourceOptions*      options,
+        bslma::Allocator*                     allocator);
+
+    static ntsa::Error decodeKeyPkcs8Pem(
+        ntctls::ErrorStack*              diagnostics,
+        bsl::streambuf*                  source,
+        bsl::shared_ptr<ntctls::Key>*    privateKey,
+        ntca::EncryptionResourceOptions* options,
+        bslma::Allocator*                allocator);
+
+    static ntsa::Error decodeKeyPkcs8Pem(
+        ntctls::ErrorStack*              diagnostics,
+        bsl::streambuf*                  source,
+        ntctls::Handle<EVP_PKEY>*        privateKey,
+        ntca::EncryptionResourceOptions* options,
+        bslma::Allocator*                allocator);
+
+    static ntsa::Error decodeKeyPkcs8PemE(
+        ntctls::ErrorStack*              diagnostics,
+        bsl::streambuf*                  source,
+        ntctls::Handle<EVP_PKEY>*        privateKey,
+        ntca::EncryptionResourceOptions* options,
+        bslma::Allocator*                allocator);
+
+    static ntsa::Error decodeKeyPkcs8PemU(
+        ntctls::ErrorStack*              diagnostics,
+        bsl::streambuf*                  source,
+        ntctls::Handle<EVP_PKEY>*        privateKey,
+        ntca::EncryptionResourceOptions* options,
+        bslma::Allocator*                allocator);
+
+    static ntsa::Error decodeCertificatePkcs8Pem(
+        ntctls::ErrorStack*                   diagnostics,
+        bsl::streambuf*                       source,
+        bsl::shared_ptr<ntctls::Certificate>* certificate,
+        ntca::EncryptionResourceOptions*      options,
+        bslma::Allocator*                     allocator);
+
+    static ntsa::Error decodeResourcePkcs12(
+        ntctls::ErrorStack*                   diagnostics,
+        bsl::streambuf*                       source,
+        bsl::shared_ptr<ntctls::Key>*         privateKey,
+        bsl::shared_ptr<ntctls::Certificate>* certificate,
+        ntctls::CertificateVector*            caList,
+        ntca::EncryptionResourceOptions*      options,
+        bslma::Allocator*                     allocator);
+
+    static ntsa::Error decodeResourcePkcs7(
+        ntctls::ErrorStack*                   diagnostics,
+        bsl::streambuf*                       source,
+        bsl::shared_ptr<ntctls::Certificate>* certificate,
+        ntctls::CertificateVector*            caList,
+        ntca::EncryptionResourceOptions*      options,
+        bslma::Allocator*                     allocator);
+
+    static ntsa::Error decodeResourcePkcs7Pem(
+        ntctls::ErrorStack*                   diagnostics,
+        bsl::streambuf*                       source,
+        bsl::shared_ptr<ntctls::Certificate>* certificate,
+        ntctls::CertificateVector*            caList,
+        ntca::EncryptionResourceOptions*      options,
+        bslma::Allocator*                     allocator);
+
+  public:
+    // Encode the specified 'privateKey', user 'certificate', and
+    // 'caList' according to the specified 'options' to the
+    // specified 'destination'.
+    static ntsa::Error encode(
+        bsl::streambuf*                             destination,
+        const bsl::shared_ptr<ntctls::Key>&         privateKey,
+        const bsl::shared_ptr<ntctls::Certificate>& certificate,
+        const ntctls::CertificateVector&            caList,
+        const ntca::EncryptionResourceOptions&      options);
+
+    // Decode the specified 'privateKey', user 'certificate', and
+    // 'caList' according to the specified 'options' from the
+    // specified 'source'. Return the error.
+    static ntsa::Error decode(
+        bsl::streambuf*                        source,
+        bsl::shared_ptr<ntctls::Key>*          privateKey,
+        bsl::shared_ptr<ntctls::Certificate>*  certificate,
+        ntctls::CertificateVector*             caList,
+        const ntca::EncryptionResourceOptions& options,
+        bslma::Allocator*                      basicAllocator = 0);
+
+    /// Load into the specified 'result' the driver representation of the
+    /// specified 'certificate'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    static ntsa::Error convertCertificate(
+        bsl::shared_ptr<ntctls::Certificate>* result,
+        const ntca::EncryptionCertificate&    certificate,
+        bslma::Allocator*                     basicAllocator);
+
+    /// Load into the specified 'result' the driver representation of the
+    /// specified 'certificate'. Return the error.
+    static ntsa::Error convertCertificate(
+        ntctls::Handle<X509>*              result,
+        const ntca::EncryptionCertificate& certificate);
+
+    /// Load into the specified 'result' the description of the specified
+    /// 'certificate'. Return the error.
+    static ntsa::Error convertCertificate(
+        ntca::EncryptionCertificate*                result,
+        const bsl::shared_ptr<ntctls::Certificate>& certificate);
+
+    /// Load into the specified 'result' the description of the specified
+    /// 'certificate'. Return the error.
+    static ntsa::Error convertCertificate(
+        ntca::EncryptionCertificate* result,
+        const ntctls::Handle<X509>&  certificate);
+
+    /// Load into the specified 'result' the driver representation of the
+    /// specified 'key'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    static ntsa::Error convertKey(bsl::shared_ptr<ntctls::Key>* result,
+                                  const ntca::EncryptionKey&    key,
+                                  bslma::Allocator* basicAllocator);
+
+    /// Load into the specified 'result' the driver representation of the
+    /// specified 'key'. Return the error.
+    static ntsa::Error convertKey(ntctls::Handle<EVP_PKEY>*  result,
+                                  const ntca::EncryptionKey& key);
+
+    /// Load into the specified 'result' the description of the specified
+    /// 'key'. Return the error.
+    static ntsa::Error convertKey(ntca::EncryptionKey*                result,
+                                  const bsl::shared_ptr<ntctls::Key>& key);
+
+    /// Load into the specified 'result' the description of the specified
+    /// 'key'. Return the error.
+    static ntsa::Error convertKey(ntca::EncryptionKey*            result,
+                                  const ntctls::Handle<EVP_PKEY>& key);
+
+    // Resolve the secret contained in the specified 'options'. Return the
+    // error. Note that when this function returns success then
+    // 'options->secret().has_value()' is guaranteed
+    static ntsa::Error resolveSecret(ntca::EncryptionResourceOptions* options);
+};
+
+extern "C" int ntctls_resource_password_cb(char* buffer,
+                                           int   bufferCapacity,
+                                           int   rw,
+                                           void* userData)
+{
+    // Load into the specified 'buffer' having the specified 'bufferCapacity'
+    // the passphrase indicated by the context represented by the specified
+    // 'userData'. If the specified 'rw' flag is 1, the passphrase is being
+    // used to write (i.e. create) a file, otherwise, the passphrase is being
+    // used to read a file. On success, return the number of bytes written to
+    // 'buffer' (not including the null-terminator), otherwise return -1.
+
+    NTCCFG_WARNING_UNUSED(rw);
+
+    ntsa::Error error;
+
+    if (userData == 0) {
+        NTCTLS_RESOURCE_LOG_SECRET_UNAVAILABLE();
+        return -1;
+    }
+
+    ntca::EncryptionResourceOptions* options =
+        (ntca::EncryptionResourceOptions*)(userData);
+
+    error = ResourceUtil::resolveSecret(options);
+    if (error) {
+        return -1;
+    }
+
+    if (options->secret().isNull()) {
+        NTCTLS_RESOURCE_LOG_SECRET_UNAVAILABLE();
+        return -1;
+    }
+
+    bsl::memset(buffer, 0, (bsl::size_t)(bufferCapacity));
+
+    return (
+        int)(options->secret().value().copy(buffer,
+                                            (bsl::size_t)(bufferCapacity)));
+}
+
+void ResourceUtil::chomp(bsl::streambuf* source)
+{
+    // OpenSSL does not robustly handle newlines or comments in concatenated
+    // PEM-encoded certificates and keys.
+
+    while (true) {
+        StreamBufferPositionGuard guard(source);
+
+        bsl::istream is(source);
+
+        bsl::string line;
+        bsl::getline(is, line);
+
+        if (!is) {
+            break;
+        }
+
+        bdlb::String::trim(&line);
+
+        if (line.empty()) {
+            guard.release();
+            continue;
+        }
+
+        if (line[0] == '#') {
+            guard.release();
+            continue;
+        }
+
+        break;
+    }
+}
+
+ntsa::Error ResourceUtil::detectType(
+    bdlb::NullableValue<ntca::EncryptionResourceType::Value>* result,
+    bsl::streambuf*                                           source)
+{
+    NTCCFG_WARNING_UNUSED(result);
+    NTCCFG_WARNING_UNUSED(source);
+
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error ResourceUtil::encodeType(
+    ntctls::ErrorStack*                         diagnostics,
+    bsl::streambuf*                             destination,
+    const bsl::shared_ptr<ntctls::Key>&         privateKey,
+    const bsl::shared_ptr<ntctls::Certificate>& certificate,
+    const ntctls::CertificateVector&            caList,
+    ntca::EncryptionResourceOptions*            options)
+{
+    ntsa::Error error;
+
+    BSLS_ASSERT(options);
+    BSLS_ASSERT(!options->type().isNull());
+
+    const ntca::EncryptionResourceType::Value type = options->type().value();
+
+    if (type == ntca::EncryptionResourceType::e_PKCS12) {
+        error = ResourceUtil::encodeResourcePkcs12(diagnostics,
+                                                   destination,
+                                                   privateKey,
+                                                   certificate,
+                                                   caList,
+                                                   options);
+        if (error) {
+            return error;
+        }
+    }
+    else if (type == ntca::EncryptionResourceType::e_PKCS7) {
+        error = ResourceUtil::encodeResourcePkcs7(diagnostics,
+                                                  destination,
+                                                  privateKey,
+                                                  certificate,
+                                                  caList,
+                                                  options);
+        if (error) {
+            return error;
+        }
+    }
+    else if (type == ntca::EncryptionResourceType::e_PKCS7_PEM) {
+        error = ResourceUtil::encodeResourcePkcs7Pem(diagnostics,
+                                                     destination,
+                                                     privateKey,
+                                                     certificate,
+                                                     caList,
+                                                     options);
+        if (error) {
+            return error;
+        }
+    }
+    else {
+        EncodeKey         encodeKey         = 0;
+        EncodeCertificate encodeCertificate = 0;
+
+        if (type == ntca::EncryptionResourceType::e_ASN1) {
+            encodeKey         = &ResourceUtil::encodeKeyAsn1;
+            encodeCertificate = &ResourceUtil::encodeCertificateAsn1;
+        }
+        else if (type == ntca::EncryptionResourceType::e_ASN1_PEM) {
+            encodeKey         = &ResourceUtil::encodeKeyAsn1Pem;
+            encodeCertificate = &ResourceUtil::encodeCertificateAsn1Pem;
+        }
+        else if (type == ntca::EncryptionResourceType::e_PKCS8) {
+            encodeKey         = &ResourceUtil::encodeKeyPkcs8;
+            encodeCertificate = &ResourceUtil::encodeCertificatePkcs8;
+        }
+        else if (type == ntca::EncryptionResourceType::e_PKCS8_PEM) {
+            encodeKey         = &ResourceUtil::encodeKeyPkcs8Pem;
+            encodeCertificate = &ResourceUtil::encodeCertificatePkcs8Pem;
+        }
+        else {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        BSLS_ASSERT(encodeKey);
+        BSLS_ASSERT(encodeCertificate);
+
+        if (privateKey) {
+            error = encodeKey(diagnostics, destination, privateKey, options);
+            if (error) {
+                return error;
+            }
+        }
+
+        if (certificate) {
+            error = encodeCertificate(diagnostics,
+                                      destination,
+                                      certificate,
+                                      options);
+            if (error) {
+                return error;
+            }
+        }
+
+        for (ntctls::CertificateVector::const_iterator it = caList.begin();
+             it != caList.end();
+             ++it)
+        {
+            const bsl::shared_ptr<ntctls::Certificate>& certificateAuthority =
+                *it;
+
+            if (certificateAuthority) {
+                error =
+                    encodeCertificate(diagnostics, destination, *it, options);
+                if (error) {
+                    return error;
+                }
+            }
+        }
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::encodeKeyAsn1(
+    ntctls::ErrorStack*                 diagnostics,
+    bsl::streambuf*                     destination,
+    const bsl::shared_ptr<ntctls::Key>& privateKey,
+    ntca::EncryptionResourceOptions*    options)
+{
+    return ResourceUtil::encodeKeyAsn1(diagnostics,
+                                       destination,
+                                       privateKey->native(),
+                                       options);
+}
+
+ntsa::Error ResourceUtil::encodeKeyAsn1(
+    ntctls::ErrorStack*              diagnostics,
+    bsl::streambuf*                  destination,
+    EVP_PKEY*                        privateKey,
+    ntca::EncryptionResourceOptions* options)
+{
+    NTCCFG_WARNING_UNUSED(options);
+
+    int rc;
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(destination);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    rc = i2d_PrivateKey_bio(bio.get(), privateKey);
+    if (rc == 0) {
+        ntctls::Internal::drainErrorQueue(diagnostics);
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::encodeCertificateAsn1(
+    ntctls::ErrorStack*                         diagnostics,
+    bsl::streambuf*                             destination,
+    const bsl::shared_ptr<ntctls::Certificate>& certificate,
+    ntca::EncryptionResourceOptions*            options)
+{
+    return ResourceUtil::encodeCertificateAsn1(diagnostics,
+                                               destination,
+                                               certificate->native(),
+                                               options);
+}
+
+ntsa::Error ResourceUtil::encodeCertificateAsn1(
+    ntctls::ErrorStack*              diagnostics,
+    bsl::streambuf*                  destination,
+    X509*                            certificate,
+    ntca::EncryptionResourceOptions* options)
+{
+    NTCCFG_WARNING_UNUSED(options);
+
+    int rc;
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(destination);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    rc = i2d_X509_bio(bio.get(), certificate);
+    if (rc == 0) {
+        ntctls::Internal::drainErrorQueue(diagnostics);
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::encodeKeyAsn1Pem(
+    ntctls::ErrorStack*                 diagnostics,
+    bsl::streambuf*                     destination,
+    const bsl::shared_ptr<ntctls::Key>& privateKey,
+    ntca::EncryptionResourceOptions*    options)
+{
+    int rc;
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(destination);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    const bool encrypted = options->encrypted().value_or(false);
+
+    if (encrypted) {
+        const EVP_CIPHER* cipher = EVP_des_ede3_cbc();
+
+        unsigned char* passphrase       = 0;
+        int            passphraseLength = 0;
+
+        pem_password_cb* passphraseCallback =
+            (pem_password_cb*)(&ntctls_resource_password_cb);
+
+        void* userData = options;
+
+        rc = PEM_write_bio_PrivateKey(bio.get(),
+                                      privateKey->native(),
+                                      cipher,
+                                      passphrase,
+                                      passphraseLength,
+                                      passphraseCallback,
+                                      userData);
+        if (rc == 0) {
+            ntctls::Internal::drainErrorQueue(diagnostics);
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+    else {
+        rc = PEM_write_bio_PrivateKey(bio.get(),
+                                      privateKey->native(),
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0);
+        if (rc == 0) {
+            ntctls::Internal::drainErrorQueue(diagnostics);
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::encodeCertificateAsn1Pem(
+    ntctls::ErrorStack*                         diagnostics,
+    bsl::streambuf*                             destination,
+    const bsl::shared_ptr<ntctls::Certificate>& certificate,
+    ntca::EncryptionResourceOptions*            options)
+{
+    NTCCFG_WARNING_UNUSED(options);
+
+    int rc;
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(destination);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    rc = PEM_write_bio_X509(bio.get(), certificate->native());
+    if (rc == 0) {
+        ntctls::Internal::drainErrorQueue(diagnostics);
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::encodeKeyPkcs8(
+    ntctls::ErrorStack*                 diagnostics,
+    bsl::streambuf*                     destination,
+    const bsl::shared_ptr<ntctls::Key>& privateKey,
+    ntca::EncryptionResourceOptions*    options)
+{
+    NTCCFG_WARNING_UNUSED(options);
+
+    ntsa::Error error;
+    int         rc;
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(destination);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    const bool encrypted = options->encrypted().value_or(false);
+
+    if (encrypted) {
+        error = ResourceUtil::resolveSecret(options);
+        if (error) {
+            return error;
+        }
+
+        ntctls::Handle<PKCS8_PRIV_KEY_INFO> pkcs8PrivKeyInfo(
+            EVP_PKEY2PKCS8(privateKey->native()));
+        if (!pkcs8PrivKeyInfo) {
+            ntctls::Internal::drainErrorQueue(diagnostics);
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        const EVP_CIPHER* cipher = EVP_aes_256_cbc();
+
+        ntctls::Handle<X509_ALGOR> pbe(
+            PKCS5_pbe2_set_iv(cipher, 1024, NULL, 0, NULL, -1));
+        if (!pbe) {
+            ntctls::Internal::drainErrorQueue(diagnostics);
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        ntctls::Handle<X509_SIG> pkcs8(
+            PKCS8_set0_pbe((const char*)(options->secret().value().data()),
+                           (int)(options->secret().value().size()),
+                           pkcs8PrivKeyInfo.get(),
+                           pbe.get()));
+        if (!pkcs8) {
+            ntctls::Internal::drainErrorQueue(diagnostics);
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        pbe.release();
+
+        rc = i2d_PKCS8_bio(bio.get(), pkcs8.get());
+        if (rc == 0) {
+            ntctls::Internal::drainErrorQueue(diagnostics);
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+    else {
+        ntctls::Handle<PKCS8_PRIV_KEY_INFO> pkcs8PrivKeyInfo(
+            EVP_PKEY2PKCS8(privateKey->native()));
+        if (!pkcs8PrivKeyInfo) {
+            ntctls::Internal::drainErrorQueue(diagnostics);
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        rc = i2d_PKCS8_PRIV_KEY_INFO_bio(bio.get(), pkcs8PrivKeyInfo.get());
+        if (rc == 0) {
+            ntctls::Internal::drainErrorQueue(diagnostics);
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::encodeCertificatePkcs8(
+    ntctls::ErrorStack*                         diagnostics,
+    bsl::streambuf*                             destination,
+    const bsl::shared_ptr<ntctls::Certificate>& certificate,
+    ntca::EncryptionResourceOptions*            options)
+{
+    // Certificates cannot be encoded into PKCS8, it is a key format only.
+
+    NTCCFG_WARNING_UNUSED(diagnostics);
+    NTCCFG_WARNING_UNUSED(destination);
+    NTCCFG_WARNING_UNUSED(certificate);
+    NTCCFG_WARNING_UNUSED(options);
+
+    return ntsa::Error(ntsa::Error::e_INVALID);
+}
+
+ntsa::Error ResourceUtil::encodeKeyPkcs8Pem(
+    ntctls::ErrorStack*                 diagnostics,
+    bsl::streambuf*                     destination,
+    const bsl::shared_ptr<ntctls::Key>& privateKey,
+    ntca::EncryptionResourceOptions*    options)
+{
+    NTCCFG_WARNING_UNUSED(options);
+
+    int rc;
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(destination);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    const bool encrypted = options->encrypted().value_or(false);
+
+    if (encrypted) {
+        char*     passphrase       = 0;
+        const int passphraseLength = 0;
+
+        const EVP_CIPHER* cipher = EVP_des_ede3_cbc();
+
+        pem_password_cb* passphraseCallback =
+            (pem_password_cb*)(&ntctls_resource_password_cb);
+
+        void* userData = options;
+
+        rc = PEM_write_bio_PKCS8PrivateKey(bio.get(),
+                                           privateKey->native(),
+                                           cipher,
+                                           passphrase,
+                                           passphraseLength,
+                                           passphraseCallback,
+                                           userData);
+        if (rc == 0) {
+            ntctls::Internal::drainErrorQueue(diagnostics);
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+    else {
+        ntctls::Handle<PKCS8_PRIV_KEY_INFO> pkcs8PrivKeyInfo(
+            EVP_PKEY2PKCS8(privateKey->native()));
+        if (!pkcs8PrivKeyInfo) {
+            ntctls::Internal::drainErrorQueue(diagnostics);
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        rc = PEM_write_bio_PKCS8_PRIV_KEY_INFO(bio.get(),
+                                               pkcs8PrivKeyInfo.get());
+        if (rc == 0) {
+            ntctls::Internal::drainErrorQueue(diagnostics);
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::encodeCertificatePkcs8Pem(
+    ntctls::ErrorStack*                         diagnostics,
+    bsl::streambuf*                             destination,
+    const bsl::shared_ptr<ntctls::Certificate>& certificate,
+    ntca::EncryptionResourceOptions*            options)
+{
+    // Certificates cannot be encoded into PKCS8, it is a key format only.
+
+    NTCCFG_WARNING_UNUSED(diagnostics);
+    NTCCFG_WARNING_UNUSED(destination);
+    NTCCFG_WARNING_UNUSED(certificate);
+    NTCCFG_WARNING_UNUSED(options);
+
+    return ntsa::Error(ntsa::Error::e_INVALID);
+}
+
+ntsa::Error ResourceUtil::encodeResourcePkcs12(
+    ntctls::ErrorStack*                         diagnostics,
+    bsl::streambuf*                             destination,
+    const bsl::shared_ptr<ntctls::Key>&         privateKey,
+    const bsl::shared_ptr<ntctls::Certificate>& certificate,
+    const ntctls::CertificateVector&            caList,
+    ntca::EncryptionResourceOptions*            options)
+{
+    ntsa::Error error;
+    int         rc;
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(destination);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    const bool encrypted = options->encrypted().value_or(false);
+
+    bsl::string passphraseStorage;
+
+    if (encrypted) {
+        error = ResourceUtil::resolveSecret(options);
+        if (error) {
+            return error;
+        }
+
+        passphraseStorage.resize(options->secret().value().size());
+        options->secret().value().copy(passphraseStorage.data(),
+                                       passphraseStorage.size());
+    }
+
+    const char* passphrase = 0;
+    if (!passphraseStorage.empty()) {
+        passphrase = passphraseStorage.c_str();
+    }
+
+    bsl::string friendlyName;
+    if (!options->label().isNull()) {
+        friendlyName = options->label().value();
+    }
+
+    EVP_PKEY* pkey         = 0;
+    X509*     x509         = 0;
+    STACK_OF(X509)* x509CA = 0;
+
+    if (privateKey) {
+        pkey = privateKey->native();
+    }
+
+    if (certificate) {
+        x509 = certificate->native();
+    }
+
+    if (!caList.empty()) {
+        x509CA = sk_X509_new_null();
+
+        for (ntctls::CertificateVector::const_iterator it = caList.begin();
+             it != caList.end();
+             ++it)
+        {
+            sk_X509_push(x509CA, (*it)->native());
+        }
+    }
+
+    ntctls::Handle<PKCS12> pkcs12(PKCS12_create(passphrase,
+                                                friendlyName.c_str(),
+                                                pkey,
+                                                x509,
+                                                x509CA,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0));
+
+    if (!passphraseStorage.empty()) {
+        OPENSSL_cleanse(passphraseStorage.data(), passphraseStorage.size());
+    }
+
+    if (!pkcs12) {
+        ntctls::Internal::drainErrorQueue(diagnostics);
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    rc = i2d_PKCS12_bio(bio.get(), pkcs12.get());
+    if (rc == 0) {
+        ntctls::Internal::drainErrorQueue(diagnostics);
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::encodeResourcePkcs7(
+    ntctls::ErrorStack*                         diagnostics,
+    bsl::streambuf*                             destination,
+    const bsl::shared_ptr<ntctls::Key>&         privateKey,
+    const bsl::shared_ptr<ntctls::Certificate>& certificate,
+    const ntctls::CertificateVector&            caList,
+    ntca::EncryptionResourceOptions*            options)
+{
+    NTCCFG_WARNING_UNUSED(options);
+
+    int rc;
+
+    if (privateKey) {
+        return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+    }
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(destination);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    STACK_OF(X509)* x509Stack = sk_X509_new_null();
+
+    if (certificate) {
+        sk_X509_push(x509Stack, certificate->native());
+    }
+
+    if (!caList.empty()) {
+        for (ntctls::CertificateVector::const_iterator it = caList.begin();
+             it != caList.end();
+             ++it)
+        {
+            sk_X509_push(x509Stack, (*it)->native());
+        }
+    }
+
+    ntctls::Handle<PKCS7> pkcs7(PKCS7_sign(0, 0, x509Stack, 0, 0));
+    sk_X509_free(x509Stack);
+
+    if (!pkcs7) {
+        ntctls::Internal::drainErrorQueue(diagnostics);
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    rc = i2d_PKCS7_bio(bio.get(), pkcs7.get());
+    if (rc == 0) {
+        ntctls::Internal::drainErrorQueue(diagnostics);
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::encodeResourcePkcs7Pem(
+    ntctls::ErrorStack*                         diagnostics,
+    bsl::streambuf*                             destination,
+    const bsl::shared_ptr<ntctls::Key>&         privateKey,
+    const bsl::shared_ptr<ntctls::Certificate>& certificate,
+    const ntctls::CertificateVector&            caList,
+    ntca::EncryptionResourceOptions*            options)
+{
+    NTCCFG_WARNING_UNUSED(options);
+
+    int rc;
+
+    if (privateKey) {
+        return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+    }
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(destination);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    STACK_OF(X509)* x509Stack = sk_X509_new_null();
+
+    if (certificate) {
+        sk_X509_push(x509Stack, certificate->native());
+    }
+
+    if (!caList.empty()) {
+        for (ntctls::CertificateVector::const_iterator it = caList.begin();
+             it != caList.end();
+             ++it)
+        {
+            sk_X509_push(x509Stack, (*it)->native());
+        }
+    }
+
+    ntctls::Handle<PKCS7> pkcs7(PKCS7_sign(0, 0, x509Stack, 0, 0));
+    sk_X509_free(x509Stack);
+
+    if (!pkcs7) {
+        ntctls::Internal::drainErrorQueue(diagnostics);
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    rc = PEM_write_bio_PKCS7(bio.get(), pkcs7.get());
+    if (rc == 0) {
+        ntctls::Internal::drainErrorQueue(diagnostics);
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeType(
+    ntctls::ErrorStack*                   diagnostics,
+    bsl::streambuf*                       source,
+    bsl::shared_ptr<ntctls::Key>*         privateKey,
+    bsl::shared_ptr<ntctls::Certificate>* certificate,
+    ntctls::CertificateVector*            caList,
+    ntca::EncryptionResourceOptions*      options,
+    bslma::Allocator*                     allocator)
+{
+    ntsa::Error error;
+
+    BSLS_ASSERT(diagnostics);
+    BSLS_ASSERT(source);
+    BSLS_ASSERT(certificate);
+    BSLS_ASSERT(caList);
+    BSLS_ASSERT(options);
+    BSLS_ASSERT(allocator);
+
+    BSLS_ASSERT(!options->type().isNull());
+
+    privateKey->reset();
+    certificate->reset();
+    caList->clear();
+
+    const ntca::EncryptionResourceType::Value type = options->type().value();
+
+    if (type == ntca::EncryptionResourceType::e_PKCS12) {
+        return ResourceUtil::decodeResourcePkcs12(diagnostics,
+                                                  source,
+                                                  privateKey,
+                                                  certificate,
+                                                  caList,
+                                                  options,
+                                                  allocator);
+    }
+    else if (type == ntca::EncryptionResourceType::e_PKCS7) {
+        return ResourceUtil::decodeResourcePkcs7(diagnostics,
+                                                 source,
+                                                 certificate,
+                                                 caList,
+                                                 options,
+                                                 allocator);
+    }
+    else if (type == ntca::EncryptionResourceType::e_PKCS7_PEM) {
+        return ResourceUtil::decodeResourcePkcs7Pem(diagnostics,
+                                                    source,
+                                                    certificate,
+                                                    caList,
+                                                    options,
+                                                    allocator);
+    }
+
+    DecodeKey         decodeKey         = 0;
+    DecodeCertificate decodeCertificate = 0;
+
+    if (type == ntca::EncryptionResourceType::e_ASN1) {
+        decodeKey         = &ResourceUtil::decodeKeyAsn1;
+        decodeCertificate = &ResourceUtil::decodeCertificateAsn1;
+    }
+    else if (type == ntca::EncryptionResourceType::e_ASN1_PEM) {
+        decodeKey         = &ResourceUtil::decodeKeyAsn1Pem;
+        decodeCertificate = &ResourceUtil::decodeCertificateAsn1Pem;
+    }
+    else if (type == ntca::EncryptionResourceType::e_PKCS8) {
+        decodeKey         = &ResourceUtil::decodeKeyPkcs8;
+        decodeCertificate = &ResourceUtil::decodeCertificatePkcs8;
+    }
+    else if (type == ntca::EncryptionResourceType::e_PKCS8_PEM) {
+        decodeKey         = &ResourceUtil::decodeKeyPkcs8Pem;
+        decodeCertificate = &ResourceUtil::decodeCertificatePkcs8Pem;
+    }
+    else {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    BSLS_ASSERT(decodeKey);
+    BSLS_ASSERT(decodeCertificate);
+
+    ntsa::Error decodeKeyError;
+    ntsa::Error decodeCertificateError;
+    ntsa::Error decodeCertificateAuthorityError;
+
+    bsl::streampos start =
+        source->pubseekoff(0, bsl::ios_base::cur, bsl::ios_base::in);
+
+    if (type != ntca::EncryptionResourceType::e_PKCS7 &&
+        type != ntca::EncryptionResourceType::e_PKCS7_PEM)
+    {
+        decodeKeyError =
+            decodeKey(diagnostics, source, privateKey, options, allocator);
+
+        if (decodeKeyError == ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED)) {
+            return decodeKeyError;
+        }
+    }
+
+    if (type == ntca::EncryptionResourceType::e_ASN1_PEM ||
+        type == ntca::EncryptionResourceType::e_PKCS7_PEM ||
+        type == ntca::EncryptionResourceType::e_PKCS8_PEM)
+    {
+        bsl::streampos rewoundPosition =
+            source->pubseekpos(start, bsl::ios_base::in);
+
+        if (rewoundPosition != start) {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    if (type != ntca::EncryptionResourceType::e_PKCS8 &&
+        type != ntca::EncryptionResourceType::e_PKCS8_PEM)
+    {
+        decodeCertificateError = decodeCertificate(diagnostics,
+                                                   source,
+                                                   certificate,
+                                                   options,
+                                                   allocator);
+
+        while (true) {
+            bsl::shared_ptr<ntctls::Certificate> ca;
+            decodeCertificateAuthorityError = decodeCertificate(diagnostics,
+                                                                source,
+                                                                &ca,
+                                                                options,
+                                                                allocator);
+            if (decodeCertificateAuthorityError) {
+                break;
+            }
+
+            caList->push_back(ca);
+        }
+    }
+
+    if (!error && decodeKeyError) {
+        error = decodeKeyError;
+    }
+
+    if (!error && decodeCertificateError) {
+        error = decodeCertificateError;
+    }
+
+    if (!error && decodeCertificateAuthorityError) {
+        error = decodeCertificateAuthorityError;
+    }
+
+    if (error) {
+        if (!*privateKey && !*certificate && caList->empty()) {
+            return error;
+        }
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeKeyAsn1(
+    ntctls::ErrorStack*              diagnostics,
+    bsl::streambuf*                  source,
+    bsl::shared_ptr<ntctls::Key>*    privateKey,
+    ntca::EncryptionResourceOptions* options,
+    bslma::Allocator*                allocator)
+{
+    ntsa::Error error;
+
+    privateKey->reset();
+
+    ntctls::Handle<EVP_PKEY> pkey;
+    error = ResourceUtil::decodeKeyAsn1(diagnostics,
+                                        source,
+                                        &pkey,
+                                        options,
+                                        allocator);
+    if (error) {
+        return error;
+    }
+
+    privateKey->createInplace(allocator, pkey.release(), allocator);
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeKeyAsn1(
+    ntctls::ErrorStack*              diagnostics,
+    bsl::streambuf*                  source,
+    ntctls::Handle<EVP_PKEY>*        privateKey,
+    ntca::EncryptionResourceOptions* options,
+    bslma::Allocator*                allocator)
+{
+    NTCCFG_WARNING_UNUSED(options);
+    NTCCFG_WARNING_UNUSED(allocator);
+
+    StreamBufferPositionGuard guard(source);
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(source);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    ntctls::Handle<EVP_PKEY> pkey(d2i_PrivateKey_bio(bio.get(), 0));
+    if (!pkey) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        if (currentErrorStack.find(ERR_LIB_ASN1, ASN1_R_NOT_ENOUGH_DATA)) {
+            return ntsa::Error(ntsa::Error::e_EOF);
+        }
+        else {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    privateKey->reset(pkey.release());
+    guard.release();
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeCertificateAsn1(
+    ntctls::ErrorStack*                   diagnostics,
+    bsl::streambuf*                       source,
+    bsl::shared_ptr<ntctls::Certificate>* certificate,
+    ntca::EncryptionResourceOptions*      options,
+    bslma::Allocator*                     allocator)
+{
+    ntsa::Error error;
+
+    certificate->reset();
+
+    ntctls::Handle<X509> x509;
+    error = ResourceUtil::decodeCertificateAsn1(diagnostics,
+                                                source,
+                                                &x509,
+                                                options,
+                                                allocator);
+    if (error) {
+        return error;
+    }
+
+    certificate->createInplace(allocator, x509.release(), allocator);
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeCertificateAsn1(
+    ntctls::ErrorStack*              diagnostics,
+    bsl::streambuf*                  source,
+    ntctls::Handle<X509>*            certificate,
+    ntca::EncryptionResourceOptions* options,
+    bslma::Allocator*                allocator)
+{
+    NTCCFG_WARNING_UNUSED(options);
+    NTCCFG_WARNING_UNUSED(allocator);
+
+    certificate->reset();
+
+    StreamBufferPositionGuard guard(source);
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(source);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    ntctls::Handle<X509> x509(d2i_X509_bio(bio.get(), 0));
+    if (!x509) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        if (currentErrorStack.find(ERR_LIB_ASN1, ASN1_R_NOT_ENOUGH_DATA)) {
+            return ntsa::Error(ntsa::Error::e_EOF);
+        }
+        else {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    certificate->reset(x509.release());
+    guard.release();
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeKeyAsn1Pem(
+    ntctls::ErrorStack*              diagnostics,
+    bsl::streambuf*                  source,
+    bsl::shared_ptr<ntctls::Key>*    privateKey,
+    ntca::EncryptionResourceOptions* options,
+    bslma::Allocator*                allocator)
+{
+    ntsa::Error error;
+
+    privateKey->reset();
+
+    ntctls::Handle<EVP_PKEY> pkey;
+    error = ResourceUtil::decodeKeyAsn1Pem(diagnostics,
+                                           source,
+                                           &pkey,
+                                           options,
+                                           allocator);
+    if (error) {
+        return error;
+    }
+
+    privateKey->createInplace(allocator, pkey.release(), allocator);
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeKeyAsn1Pem(
+    ntctls::ErrorStack*              diagnostics,
+    bsl::streambuf*                  source,
+    ntctls::Handle<EVP_PKEY>*        privateKey,
+    ntca::EncryptionResourceOptions* options,
+    bslma::Allocator*                allocator)
+{
+    NTCCFG_WARNING_UNUSED(allocator);
+
+    privateKey->reset();
+
+    ResourceUtil::chomp(source);
+
+    StreamBufferPositionGuard guard(source);
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(source);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    pem_password_cb* passphraseCallback =
+        (pem_password_cb*)(&ntctls_resource_password_cb);
+
+    void* userData = options;
+
+    ntctls::Handle<EVP_PKEY> pkey(
+        PEM_read_bio_PrivateKey(bio.get(), 0, passphraseCallback, userData));
+    if (!pkey) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        if (currentErrorStack.find(ERR_LIB_PEM, PEM_R_NO_START_LINE)) {
+            return ntsa::Error(ntsa::Error::e_EOF);
+        }
+        else if (currentErrorStack.find(ERR_LIB_PEM, PEM_R_BAD_PASSWORD_READ))
+        {
+            return ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED);
+        }
+        else {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    privateKey->reset(pkey.release());
+    guard.release();
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeCertificateAsn1Pem(
+    ntctls::ErrorStack*                   diagnostics,
+    bsl::streambuf*                       source,
+    bsl::shared_ptr<ntctls::Certificate>* certificate,
+    ntca::EncryptionResourceOptions*      options,
+    bslma::Allocator*                     allocator)
+{
+    ntsa::Error error;
+
+    certificate->reset();
+
+    ntctls::Handle<X509> x509;
+    error = ResourceUtil::decodeCertificateAsn1Pem(diagnostics,
+                                                   source,
+                                                   &x509,
+                                                   options,
+                                                   allocator);
+    if (error) {
+        return error;
+    }
+
+    certificate->createInplace(allocator, x509.release(), allocator);
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeCertificateAsn1Pem(
+    ntctls::ErrorStack*              diagnostics,
+    bsl::streambuf*                  source,
+    ntctls::Handle<X509>*            certificate,
+    ntca::EncryptionResourceOptions* options,
+    bslma::Allocator*                allocator)
+{
+    NTCCFG_WARNING_UNUSED(allocator);
+
+    certificate->reset();
+
+    ResourceUtil::chomp(source);
+
+    StreamBufferPositionGuard guard(source);
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(source);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    pem_password_cb* passphraseCallback =
+        (pem_password_cb*)(&ntctls_resource_password_cb);
+
+    void* userData = options;
+
+    ntctls::Handle<X509> x509(
+        PEM_read_bio_X509(bio.get(), 0, passphraseCallback, userData));
+    if (!x509) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        if (currentErrorStack.find(ERR_LIB_PEM, PEM_R_NO_START_LINE)) {
+            return ntsa::Error(ntsa::Error::e_EOF);
+        }
+        else if (currentErrorStack.find(ERR_LIB_PEM, PEM_R_BAD_PASSWORD_READ))
+        {
+            return ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED);
+        }
+        else {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    certificate->reset(x509.release());
+    guard.release();
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeKeyPkcs8(
+    ntctls::ErrorStack*              diagnostics,
+    bsl::streambuf*                  source,
+    bsl::shared_ptr<ntctls::Key>*    privateKey,
+    ntca::EncryptionResourceOptions* options,
+    bslma::Allocator*                allocator)
+{
+    ntsa::Error error;
+
+    privateKey->reset();
+
+    ntctls::Handle<EVP_PKEY> pkey;
+    error = ResourceUtil::decodeKeyPkcs8(diagnostics,
+                                         source,
+                                         &pkey,
+                                         options,
+                                         allocator);
+    if (error) {
+        return error;
+    }
+
+    privateKey->createInplace(allocator, pkey.release(), allocator);
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeKeyPkcs8(
+    ntctls::ErrorStack*              diagnostics,
+    bsl::streambuf*                  source,
+    ntctls::Handle<EVP_PKEY>*        privateKey,
+    ntca::EncryptionResourceOptions* options,
+    bslma::Allocator*                allocator)
+{
+    ntsa::Error error;
+
+    privateKey->reset();
+
+    if (!*privateKey) {
+        error = ResourceUtil::decodeKeyPkcs8U(diagnostics,
+                                              source,
+                                              privateKey,
+                                              options,
+                                              allocator);
+        if (!error) {
+            return ntsa::Error();
+        }
+    }
+
+    if (!*privateKey) {
+        error = ResourceUtil::decodeKeyPkcs8E(diagnostics,
+                                              source,
+                                              privateKey,
+                                              options,
+                                              allocator);
+        if (!error) {
+            return ntsa::Error();
+        }
+    }
+
+    return error;
+}
+
+ntsa::Error ResourceUtil::decodeKeyPkcs8E(
+    ntctls::ErrorStack*              diagnostics,
+    bsl::streambuf*                  source,
+    ntctls::Handle<EVP_PKEY>*        privateKey,
+    ntca::EncryptionResourceOptions* options,
+    bslma::Allocator*                allocator)
+{
+    NTCCFG_WARNING_UNUSED(allocator);
+
+    ntsa::Error error;
+
+    StreamBufferPositionGuard guard(source);
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(source);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    ntctls::Handle<X509_SIG> pkcs8(d2i_PKCS8_bio(bio.get(), 0));
+    if (!pkcs8) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        if (currentErrorStack.find(ERR_LIB_ASN1, ASN1_R_NOT_ENOUGH_DATA)) {
+            return ntsa::Error(ntsa::Error::e_EOF);
+        }
+        else {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    error = ResourceUtil::resolveSecret(options);
+    if (error) {
+        return error;
+    }
+
+    const char* passphrase = (const char*)(options->secret().value().data());
+
+    const int passphraseLength = (int)(options->secret().value().size());
+
+    ntctls::Handle<PKCS8_PRIV_KEY_INFO> pkcs8PrivKeyInfo(
+        PKCS8_decrypt(pkcs8.get(), passphrase, passphraseLength));
+    if (!pkcs8PrivKeyInfo) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        if (currentErrorStack.find(ERR_LIB_PKCS12,
+                                   PKCS12_R_PKCS12_PBE_CRYPT_ERROR))
+        {
+            return ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED);
+        }
+        else {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    ntctls::Handle<EVP_PKEY> pkey(EVP_PKCS82PKEY(pkcs8PrivKeyInfo.get()));
+    if (!pkey) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    privateKey->reset(pkey.release());
+    guard.release();
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeKeyPkcs8U(
+    ntctls::ErrorStack*              diagnostics,
+    bsl::streambuf*                  source,
+    ntctls::Handle<EVP_PKEY>*        privateKey,
+    ntca::EncryptionResourceOptions* options,
+    bslma::Allocator*                allocator)
+{
+    NTCCFG_WARNING_UNUSED(options);
+    NTCCFG_WARNING_UNUSED(allocator);
+
+    StreamBufferPositionGuard guard(source);
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(source);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    ntctls::Handle<PKCS8_PRIV_KEY_INFO> pkcs8PrivKeyInfo(
+        d2i_PKCS8_PRIV_KEY_INFO_bio(bio.get(), 0));
+    if (!pkcs8PrivKeyInfo) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        if (currentErrorStack.find(ERR_LIB_ASN1, ASN1_R_NOT_ENOUGH_DATA)) {
+            return ntsa::Error(ntsa::Error::e_EOF);
+        }
+        else {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    ntctls::Handle<EVP_PKEY> pkey(EVP_PKCS82PKEY(pkcs8PrivKeyInfo.get()));
+    if (!pkey) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    privateKey->reset(pkey.release());
+    guard.release();
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeCertificatePkcs8(
+    ntctls::ErrorStack*                   diagnostics,
+    bsl::streambuf*                       source,
+    bsl::shared_ptr<ntctls::Certificate>* certificate,
+    ntca::EncryptionResourceOptions*      options,
+    bslma::Allocator*                     allocator)
+{
+    // Certificates cannot be encoded from PKCS8, it is a key format only.
+
+    NTCCFG_WARNING_UNUSED(diagnostics);
+    NTCCFG_WARNING_UNUSED(source);
+    NTCCFG_WARNING_UNUSED(certificate);
+    NTCCFG_WARNING_UNUSED(options);
+    NTCCFG_WARNING_UNUSED(allocator);
+
+    return ntsa::Error(ntsa::Error::e_INVALID);
+}
+
+ntsa::Error ResourceUtil::decodeKeyPkcs8Pem(
+    ntctls::ErrorStack*              diagnostics,
+    bsl::streambuf*                  source,
+    bsl::shared_ptr<ntctls::Key>*    privateKey,
+    ntca::EncryptionResourceOptions* options,
+    bslma::Allocator*                allocator)
+{
+    ntsa::Error error;
+
+    privateKey->reset();
+
+    ntctls::Handle<EVP_PKEY> pkey;
+    error = ResourceUtil::decodeKeyPkcs8Pem(diagnostics,
+                                            source,
+                                            &pkey,
+                                            options,
+                                            allocator);
+    if (error) {
+        return error;
+    }
+
+    privateKey->createInplace(allocator, pkey.release(), allocator);
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeKeyPkcs8Pem(
+    ntctls::ErrorStack*              diagnostics,
+    bsl::streambuf*                  source,
+    ntctls::Handle<EVP_PKEY>*        privateKey,
+    ntca::EncryptionResourceOptions* options,
+    bslma::Allocator*                allocator)
+{
+    ntsa::Error error;
+
+    privateKey->reset();
+
+    if (!*privateKey) {
+        error = ResourceUtil::decodeKeyPkcs8PemU(diagnostics,
+                                                 source,
+                                                 privateKey,
+                                                 options,
+                                                 allocator);
+        if (!error) {
+            return ntsa::Error();
+        }
+    }
+
+    if (!*privateKey) {
+        error = ResourceUtil::decodeKeyPkcs8PemE(diagnostics,
+                                                 source,
+                                                 privateKey,
+                                                 options,
+                                                 allocator);
+        if (!error) {
+            return ntsa::Error();
+        }
+    }
+
+    return error;
+}
+
+ntsa::Error ResourceUtil::decodeKeyPkcs8PemE(
+    ntctls::ErrorStack*              diagnostics,
+    bsl::streambuf*                  source,
+    ntctls::Handle<EVP_PKEY>*        privateKey,
+    ntca::EncryptionResourceOptions* options,
+    bslma::Allocator*                allocator)
+{
+    NTCCFG_WARNING_UNUSED(allocator);
+
+    ntsa::Error error;
+
+    privateKey->reset();
+
+    ResourceUtil::chomp(source);
+
+    StreamBufferPositionGuard guard(source);
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(source);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    pem_password_cb* passphraseCallback =
+        (pem_password_cb*)(&ntctls_resource_password_cb);
+
+    void* userData = options;
+
+    ntctls::Handle<X509_SIG> pkcs8(
+        PEM_read_bio_PKCS8(bio.get(), 0, passphraseCallback, userData));
+    if (!pkcs8) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        if (currentErrorStack.find(ERR_LIB_PEM, PEM_R_NO_START_LINE)) {
+            return ntsa::Error(ntsa::Error::e_EOF);
+        }
+        else if (currentErrorStack.find(ERR_LIB_PEM, PEM_R_BAD_PASSWORD_READ))
+        {
+            return ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED);
+        }
+        else {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    error = ResourceUtil::resolveSecret(options);
+    if (error) {
+        return error;
+    }
+
+    const char* passphrase = (const char*)(options->secret().value().data());
+
+    const int passphraseLength = (int)(options->secret().value().size());
+
+    ntctls::Handle<PKCS8_PRIV_KEY_INFO> pkcs8PrivKeyInfo(
+        PKCS8_decrypt(pkcs8.get(), passphrase, passphraseLength));
+    if (!pkcs8PrivKeyInfo) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        if (currentErrorStack.find(ERR_LIB_PKCS12,
+                                   PKCS12_R_PKCS12_PBE_CRYPT_ERROR))
+        {
+            return ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED);
+        }
+        else {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    ntctls::Handle<EVP_PKEY> pkey(EVP_PKCS82PKEY(pkcs8PrivKeyInfo.get()));
+    if (!pkey) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    privateKey->reset(pkey.release());
+    guard.release();
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeKeyPkcs8PemU(
+    ntctls::ErrorStack*              diagnostics,
+    bsl::streambuf*                  source,
+    ntctls::Handle<EVP_PKEY>*        privateKey,
+    ntca::EncryptionResourceOptions* options,
+    bslma::Allocator*                allocator)
+{
+    NTCCFG_WARNING_UNUSED(allocator);
+
+    privateKey->reset();
+
+    ResourceUtil::chomp(source);
+
+    StreamBufferPositionGuard guard(source);
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(source);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    pem_password_cb* passphraseCallback =
+        (pem_password_cb*)(&ntctls_resource_password_cb);
+
+    void* userData = options;
+
+    ntctls::Handle<PKCS8_PRIV_KEY_INFO> pkcs8PrivKeyInfo(
+        PEM_read_bio_PKCS8_PRIV_KEY_INFO(bio.get(),
+                                         0,
+                                         passphraseCallback,
+                                         userData));
+    if (!pkcs8PrivKeyInfo) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        if (currentErrorStack.find(ERR_LIB_PEM, PEM_R_NO_START_LINE)) {
+            return ntsa::Error(ntsa::Error::e_EOF);
+        }
+        else if (currentErrorStack.find(ERR_LIB_PEM, PEM_R_BAD_PASSWORD_READ))
+        {
+            return ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED);
+        }
+        else {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    ntctls::Handle<EVP_PKEY> pkey(EVP_PKCS82PKEY(pkcs8PrivKeyInfo.get()));
+    if (!pkey) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    privateKey->reset(pkey.release());
+    guard.release();
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeCertificatePkcs8Pem(
+    ntctls::ErrorStack*                   diagnostics,
+    bsl::streambuf*                       source,
+    bsl::shared_ptr<ntctls::Certificate>* certificate,
+    ntca::EncryptionResourceOptions*      options,
+    bslma::Allocator*                     allocator)
+{
+    // Certificates cannot be encoded from PKCS8, it is a key format only.
+
+    NTCCFG_WARNING_UNUSED(diagnostics);
+    NTCCFG_WARNING_UNUSED(source);
+    NTCCFG_WARNING_UNUSED(certificate);
+    NTCCFG_WARNING_UNUSED(options);
+    NTCCFG_WARNING_UNUSED(allocator);
+
+    return ntsa::Error(ntsa::Error::e_INVALID);
+}
+
+ntsa::Error ResourceUtil::decodeResourcePkcs12(
+    ntctls::ErrorStack*                   diagnostics,
+    bsl::streambuf*                       source,
+    bsl::shared_ptr<ntctls::Key>*         privateKey,
+    bsl::shared_ptr<ntctls::Certificate>* certificate,
+    ntctls::CertificateVector*            caList,
+    ntca::EncryptionResourceOptions*      options,
+    bslma::Allocator*                     allocator)
+{
+    ntsa::Error error;
+    int         rc;
+
+    privateKey->reset();
+    certificate->reset();
+    caList->clear();
+
+    StreamBufferPositionGuard guard(source);
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(source);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    ntctls::Handle<PKCS12> pkcs12(d2i_PKCS12_bio(bio.get(), 0));
+    if (!pkcs12) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        if (currentErrorStack.find(ERR_LIB_ASN1, ASN1_R_NOT_ENOUGH_DATA)) {
+            return ntsa::Error(ntsa::Error::e_EOF);
+        }
+        else {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    bdlb::NullableValue<ntca::EncryptionSecret> secret;
+
+    if (secret.isNull()) {
+        rc = PKCS12_verify_mac(pkcs12.get(), "", 0);
+        if (rc != 0) {
+            secret.makeValue();
+        }
+    }
+
+    if (secret.isNull()) {
+        rc = PKCS12_verify_mac(pkcs12.get(), 0, 0);
+        if (rc != 0) {
+            secret.makeValue();
+        }
+    }
+
+    if (secret.isNull()) {
+        error = ResourceUtil::resolveSecret(options);
+        if (error) {
+            return error;
+        }
+
+        const char* passphraseLiteral =
+            (const char*)(options->secret().value().data());
+
+        const int passphraseLength = (int)(options->secret().value().size());
+
+        rc = PKCS12_verify_mac(pkcs12.get(),
+                               passphraseLiteral,
+                               passphraseLength);
+        if (rc != 0) {
+            secret.makeValue(options->secret().value());
+        }
+    }
+
+    if (secret.isNull()) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    const char* passphrase = 0;
+    bsl::string passphraseStorage;
+
+    if (!secret.value().empty()) {
+        passphraseStorage.resize(secret.value().size() + 1);
+        secret.value().copy(passphraseStorage.data(),
+                            passphraseStorage.size());
+
+        passphrase = passphraseStorage.c_str();
+    }
+
+    EVP_PKEY* pkey              = 0;
+    X509*     x509              = 0;
+    STACK_OF(X509)* x509CAStack = 0;
+
+    rc = PKCS12_parse(pkcs12.get(), passphrase, &pkey, &x509, &x509CAStack);
+
+    if (!passphraseStorage.empty()) {
+        OPENSSL_cleanse(&passphraseStorage.front(), passphraseStorage.size());
+    }
+
+    if (rc != 1) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        if (currentErrorStack.find(ERR_LIB_PKCS12,
+                                   PKCS12_R_PKCS12_PBE_CRYPT_ERROR))
+        {
+            return ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED);
+        }
+        else {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    if (pkey) {
+        privateKey->createInplace(allocator, pkey, allocator);
+    }
+
+    if (x509) {
+        certificate->createInplace(allocator, x509, allocator);
+    }
+
+    if (x509CAStack) {
+        int x509CAStackSize = sk_X509_num(x509CAStack);
+        for (int i = 0; i < x509CAStackSize; ++i) {
+            X509* x509CA = sk_X509_pop(x509CAStack);
+
+            bsl::shared_ptr<ntctls::Certificate> ca;
+            ca.createInplace(allocator, x509CA, allocator);
+
+            if (ca->isAuthority()) {
+                caList->push_back(ca);
+            }
+            else if (!*certificate) {
+                *certificate = ca;
+            }
+            else {
+                BSLS_LOG_ERROR(
+                    "PKCS12 contains more than one non-CA certificate");
+                sk_X509_free(x509CAStack);
+                return ntsa::Error(ntsa::Error::e_INVALID);
+            }
+        }
+    }
+
+    sk_X509_free(x509CAStack);
+
+    guard.release();
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeResourcePkcs7(
+    ntctls::ErrorStack*                   diagnostics,
+    bsl::streambuf*                       source,
+    bsl::shared_ptr<ntctls::Certificate>* certificate,
+    ntctls::CertificateVector*            caList,
+    ntca::EncryptionResourceOptions*      options,
+    bslma::Allocator*                     allocator)
+{
+    NTCCFG_WARNING_UNUSED(options);
+
+    ntsa::Error error;
+
+    certificate->reset();
+    caList->clear();
+
+    StreamBufferPositionGuard guard(source);
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(source);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    ntctls::Handle<PKCS7> pkcs7(d2i_PKCS7_bio(bio.get(), 0));
+    if (!pkcs7) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        if (currentErrorStack.find(ERR_LIB_ASN1, ASN1_R_NOT_ENOUGH_DATA)) {
+            return ntsa::Error(ntsa::Error::e_EOF);
+        }
+        else {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    STACK_OF(X509)* x509Stack = 0;
+
+    const int type = OBJ_obj2nid(pkcs7.get()->type);
+    if (type == NID_pkcs7_signed) {
+        if (pkcs7.get()->d.sign != 0) {
+            x509Stack = pkcs7.get()->d.sign->cert;
+        }
+        else {
+            BSLS_LOG_ERROR("Missing PKCS7 signed certificate");
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+    else if (type == NID_pkcs7_signedAndEnveloped) {
+        if (pkcs7.get()->d.signed_and_enveloped != 0) {
+            x509Stack = pkcs7.get()->d.signed_and_enveloped->cert;
+        }
+        else {
+            BSLS_LOG_ERROR("Missing PKCS7 signed-and-enveloped certificate");
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+    else {
+        BSLS_LOG_ERROR("Uknown PKCS7 type NID %d", type);
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if (x509Stack != 0) {
+        const int x509StackSize = sk_X509_num(x509Stack);
+        for (int i = 0; i < x509StackSize; ++i) {
+            X509* x509 = sk_X509_pop(x509Stack);
+
+            bsl::shared_ptr<ntctls::Certificate> object;
+            object.createInplace(allocator, x509, allocator);
+
+            if (object->isAuthority()) {
+                caList->push_back(object);
+            }
+            else if (!*certificate) {
+                *certificate = object;
+            }
+            else {
+                BSLS_LOG_ERROR(
+                    "PKCS7 contains more than one non-CA certificate");
+                return ntsa::Error(ntsa::Error::e_INVALID);
+            }
+        }
+    }
+
+    guard.release();
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decodeResourcePkcs7Pem(
+    ntctls::ErrorStack*                   diagnostics,
+    bsl::streambuf*                       source,
+    bsl::shared_ptr<ntctls::Certificate>* certificate,
+    ntctls::CertificateVector*            caList,
+    ntca::EncryptionResourceOptions*      options,
+    bslma::Allocator*                     allocator)
+{
+    NTCCFG_WARNING_UNUSED(options);
+
+    ntsa::Error error;
+
+    certificate->reset();
+    caList->clear();
+
+    StreamBufferPositionGuard guard(source);
+
+    bsl::shared_ptr<BIO> bio = Internal::createStream(source);
+    if (!bio) {
+        return ntsa::Error(ntsa::Error::e_LIMIT);
+    }
+
+    pem_password_cb* passphraseCallback =
+        (pem_password_cb*)(&ntctls_resource_password_cb);
+
+    void* userData = options;
+
+    ntctls::Handle<PKCS7> pkcs7(
+        PEM_read_bio_PKCS7(bio.get(), 0, passphraseCallback, userData));
+    if (!pkcs7) {
+        ntctls::ErrorStack currentErrorStack;
+        ntctls::Internal::drainErrorQueue(&currentErrorStack);
+
+        NTCTLS_RESOURCE_LOG_ERROR_STACK(currentErrorStack);
+        diagnostics->push(currentErrorStack);
+
+        if (currentErrorStack.find(ERR_LIB_ASN1, ASN1_R_NOT_ENOUGH_DATA)) {
+            return ntsa::Error(ntsa::Error::e_EOF);
+        }
+        else {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    STACK_OF(X509)* x509Stack = 0;
+
+    const int type = OBJ_obj2nid(pkcs7.get()->type);
+    if (type == NID_pkcs7_signed) {
+        if (pkcs7.get()->d.sign != 0) {
+            x509Stack = pkcs7.get()->d.sign->cert;
+        }
+        else {
+            BSLS_LOG_ERROR("Missing PKCS7 signed certificate");
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+    else if (type == NID_pkcs7_signedAndEnveloped) {
+        if (pkcs7.get()->d.signed_and_enveloped != 0) {
+            x509Stack = pkcs7.get()->d.signed_and_enveloped->cert;
+        }
+        else {
+            BSLS_LOG_ERROR("Missing PKCS7 signed-and-enveloped certificate");
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+    else {
+        BSLS_LOG_ERROR("Uknown PKCS7 type NID %d", type);
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if (x509Stack != 0) {
+        const int x509StackSize = sk_X509_num(x509Stack);
+        for (int i = 0; i < x509StackSize; ++i) {
+            X509* x509 = sk_X509_pop(x509Stack);
+
+            bsl::shared_ptr<ntctls::Certificate> object;
+            object.createInplace(allocator, x509, allocator);
+
+            if (object->isAuthority()) {
+                caList->push_back(object);
+            }
+            else if (!*certificate) {
+                *certificate = object;
+            }
+            else {
+                BSLS_LOG_ERROR(
+                    "PKCS7 contains more than one non-CA certificate");
+                return ntsa::Error(ntsa::Error::e_INVALID);
+            }
+        }
+    }
+
+    guard.release();
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::encode(
+    bsl::streambuf*                             destination,
+    const bsl::shared_ptr<ntctls::Key>&         privateKey,
+    const bsl::shared_ptr<ntctls::Certificate>& certificate,
+    const ntctls::CertificateVector&            caList,
+    const ntca::EncryptionResourceOptions&      options)
+{
+    ntsa::Error        error;
+    ntctls::ErrorStack diagnostics;
+
+    ntca::EncryptionResourceOptions effectiveOptions = options;
+    if (effectiveOptions.type().isNull()) {
+        effectiveOptions.setType(ntca::EncryptionResourceType::e_ASN1_PEM);
+    }
+
+    error = ResourceUtil::encodeType(&diagnostics,
+                                     destination,
+                                     privateKey,
+                                     certificate,
+                                     caList,
+                                     &effectiveOptions);
+    if (error) {
+        NTCTLS_RESOURCE_LOG_ENCODER_ERROR(diagnostics);
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::decode(
+    bsl::streambuf*                        source,
+    bsl::shared_ptr<ntctls::Key>*          privateKey,
+    bsl::shared_ptr<ntctls::Certificate>*  certificate,
+    ntctls::CertificateVector*             caList,
+    const ntca::EncryptionResourceOptions& options,
+    bslma::Allocator*                      basicAllocator)
+{
+    ntsa::Error        error;
+    ntctls::ErrorStack diagnostics;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    ntca::EncryptionResourceOptions effectiveOptions = options;
+    if (effectiveOptions.type().isNull()) {
+        bdlb::NullableValue<ntca::EncryptionResourceType::Value> type;
+        error = ResourceUtil::detectType(&type, source);
+        if (!error && !type.isNull()) {
+            effectiveOptions.setType(type.value());
+        }
+    }
+
+    bsl::shared_ptr<ntctls::Key>         effectivePrivateKey;
+    bsl::shared_ptr<ntctls::Certificate> effectiveCertificate;
+    ntctls::CertificateVector            effectiveCaList;
+
+    if (!effectiveOptions.type().isNull()) {
+        BSLS_LOG_TRACE("Decoding explicit type %s",
+                       ntca::EncryptionResourceType::toString(
+                           effectiveOptions.type().value()));
+
+        error = ResourceUtil::decodeType(&diagnostics,
+                                         source,
+                                         &effectivePrivateKey,
+                                         &effectiveCertificate,
+                                         &effectiveCaList,
+                                         &effectiveOptions,
+                                         allocator);
+        if (error) {
+            NTCTLS_RESOURCE_LOG_DECODER_ERROR(diagnostics);
+            return error;
+        }
+    }
+    else {
+        bsl::vector<ntca::EncryptionResourceType::Value> types;
+        types.push_back(ntca::EncryptionResourceType::e_ASN1_PEM);
+        types.push_back(ntca::EncryptionResourceType::e_ASN1);
+        types.push_back(ntca::EncryptionResourceType::e_PKCS12);
+        types.push_back(ntca::EncryptionResourceType::e_PKCS8_PEM);
+        types.push_back(ntca::EncryptionResourceType::e_PKCS8);
+
+        for (bsl::size_t i = 0; i < types.size(); ++i) {
+            BSLS_LOG_TRACE("Decoding guessed type %s",
+                           ntca::EncryptionResourceType::toString(types[i]));
+
+            effectiveOptions.setType(types[i]);
+
+            effectivePrivateKey.reset();
+            effectiveCertificate.reset();
+            effectiveCaList.clear();
+
+            error = ResourceUtil::decodeType(&diagnostics,
+                                             source,
+                                             &effectivePrivateKey,
+                                             &effectiveCertificate,
+                                             &effectiveCaList,
+                                             &effectiveOptions,
+                                             allocator);
+            if (!error) {
+                break;
+            }
+        }
+
+        if (error) {
+            NTCTLS_RESOURCE_LOG_DECODER_ERROR(diagnostics);
+            return error;
+        }
+    }
+
+    if (privateKey) {
+        if (effectivePrivateKey) {
+            *privateKey = effectivePrivateKey;
+        }
+    }
+
+    if (certificate) {
+        if (effectiveCertificate) {
+            *certificate = effectiveCertificate;
+        }
+    }
+
+    if (caList) {
+        if (effectiveCaList.size() > 0) {
+            caList->insert(caList->end(),
+                           effectiveCaList.begin(),
+                           effectiveCaList.end());
+        }
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::resolveSecret(
+    ntca::EncryptionResourceOptions* options)
+{
+    ntsa::Error error;
+
+    if (options->secret().isNull()) {
+        if (options->secretCallback().isNull()) {
+            NTCTLS_RESOURCE_LOG_SECRET_UNAVAILABLE();
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        ntca::EncryptionSecretCallback callback =
+            options->secretCallback().value();
+
+        if (!callback) {
+            NTCTLS_RESOURCE_LOG_SECRET_UNAVAILABLE();
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        ntca::EncryptionSecret secret;
+        error = callback(&secret);
+        if (error) {
+            NTCTLS_RESOURCE_LOG_SECRET_UNAVAILABLE();
+            return error;
+        }
+
+        options->setSecret(secret);
+    }
+
+    BSLS_ASSERT(options->secret().has_value());
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::convertCertificate(
+    bsl::shared_ptr<ntctls::Certificate>* result,
+    const ntca::EncryptionCertificate&    certificate,
+    bslma::Allocator*                     basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    ntctls::Handle<X509> x509;
+    error = ResourceUtil::convertCertificate(&x509, certificate);
+    if (error) {
+        return error;
+    }
+
+    result->createInplace(allocator, x509.release(), allocator);
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::convertCertificate(
+    ntctls::Handle<X509>*              result,
+    const ntca::EncryptionCertificate& certificate)
+{
+    ntsa::Error error;
+    int         rc;
+
+    bslma::Allocator* allocator = bslma::Default::allocator();
+
+    bdlsb::MemOutStreamBuf osb;
+    {
+        ntsa::AbstractSyntaxEncoder encoder(&osb);
+        error = certificate.encode(&encoder);
+        if (error) {
+            return error;
+        }
+
+        rc = osb.pubsync();
+        if (rc != 0) {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    ntctls::ErrorStack diagnostics;
+
+    ntca::EncryptionResourceOptions resourceOptions;
+    resourceOptions.setType(ntca::EncryptionResourceType::e_ASN1);
+
+    bdlsb::FixedMemInStreamBuf isb(osb.data(), osb.length());
+
+    error = ResourceUtil::decodeCertificateAsn1(&diagnostics,
+                                                &isb,
+                                                result,
+                                                &resourceOptions,
+                                                allocator);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::convertCertificate(
+    ntca::EncryptionCertificate*                result,
+    const bsl::shared_ptr<ntctls::Certificate>& certificate)
+{
+    ntsa::Error error;
+    int         rc;
+
+    bdlsb::MemOutStreamBuf osb;
+    {
+        ntctls::ErrorStack diagnostics;
+
+        ntca::EncryptionResourceOptions resourceOptions;
+        resourceOptions.setType(ntca::EncryptionResourceType::e_ASN1);
+
+        error = ResourceUtil::encodeCertificateAsn1(&diagnostics,
+                                                    &osb,
+                                                    certificate,
+                                                    &resourceOptions);
+        if (error) {
+            return error;
+        }
+
+        rc = osb.pubsync();
+        if (rc != 0) {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    bdlsb::FixedMemInStreamBuf  isb(osb.data(), osb.length());
+    ntsa::AbstractSyntaxDecoder decoder(&isb);
+
+    error = result->decode(&decoder);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::convertCertificate(
+    ntca::EncryptionCertificate* result,
+    const ntctls::Handle<X509>&  certificate)
+{
+    ntsa::Error error;
+    int         rc;
+
+    bdlsb::MemOutStreamBuf osb;
+    {
+        ntctls::ErrorStack diagnostics;
+
+        ntca::EncryptionResourceOptions resourceOptions;
+        resourceOptions.setType(ntca::EncryptionResourceType::e_ASN1);
+
+        error = ResourceUtil::encodeCertificateAsn1(&diagnostics,
+                                                    &osb,
+                                                    certificate.get(),
+                                                    &resourceOptions);
+        if (error) {
+            return error;
+        }
+
+        rc = osb.pubsync();
+        if (rc != 0) {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    bdlsb::FixedMemInStreamBuf  isb(osb.data(), osb.length());
+    ntsa::AbstractSyntaxDecoder decoder(&isb);
+
+    error = result->decode(&decoder);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::convertKey(bsl::shared_ptr<ntctls::Key>* result,
+                                     const ntca::EncryptionKey&    key,
+                                     bslma::Allocator* basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    ntctls::Handle<EVP_PKEY> pkey;
+    error = ResourceUtil::convertKey(&pkey, key);
+    if (error) {
+        return error;
+    }
+
+    result->createInplace(allocator, pkey.release(), allocator);
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::convertKey(ntctls::Handle<EVP_PKEY>*  result,
+                                     const ntca::EncryptionKey& key)
+{
+    ntsa::Error error;
+    int         rc;
+
+    bslma::Allocator* allocator = bslma::Default::allocator();
+
+    bdlsb::MemOutStreamBuf osb;
+    {
+        ntsa::AbstractSyntaxEncoder encoder(&osb);
+        error = key.encode(&encoder);
+        if (error) {
+            return error;
+        }
+
+        rc = osb.pubsync();
+        if (rc != 0) {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    ntctls::ErrorStack diagnostics;
+
+    ntca::EncryptionResourceOptions resourceOptions;
+    resourceOptions.setType(ntca::EncryptionResourceType::e_ASN1);
+
+    bdlsb::FixedMemInStreamBuf isb(osb.data(), osb.length());
+
+    error = ResourceUtil::decodeKeyAsn1(&diagnostics,
+                                        &isb,
+                                        result,
+                                        &resourceOptions,
+                                        allocator);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::convertKey(ntca::EncryptionKey* result,
+                                     const bsl::shared_ptr<ntctls::Key>& key)
+{
+    ntsa::Error error;
+    int         rc;
+
+    bdlsb::MemOutStreamBuf osb;
+    {
+        ntctls::ErrorStack diagnostics;
+
+        ntca::EncryptionResourceOptions resourceOptions;
+        resourceOptions.setType(ntca::EncryptionResourceType::e_ASN1);
+
+        error = ResourceUtil::encodeKeyAsn1(&diagnostics,
+                                            &osb,
+                                            key,
+                                            &resourceOptions);
+        if (error) {
+            return error;
+        }
+
+        rc = osb.pubsync();
+        if (rc != 0) {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    bdlsb::FixedMemInStreamBuf  isb(osb.data(), osb.length());
+    ntsa::AbstractSyntaxDecoder decoder(&isb);
+
+    error = result->decode(&decoder);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceUtil::convertKey(ntca::EncryptionKey*            result,
+                                     const ntctls::Handle<EVP_PKEY>& key)
+{
+    ntsa::Error error;
+    int         rc;
+
+    bdlsb::MemOutStreamBuf osb;
+    {
+        ntctls::ErrorStack diagnostics;
+
+        ntca::EncryptionResourceOptions resourceOptions;
+        resourceOptions.setType(ntca::EncryptionResourceType::e_ASN1);
+
+        error = ResourceUtil::encodeKeyAsn1(&diagnostics,
+                                            &osb,
+                                            key.get(),
+                                            &resourceOptions);
+        if (error) {
+            return error;
+        }
+
+        rc = osb.pubsync();
+        if (rc != 0) {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    bdlsb::FixedMemInStreamBuf  isb(osb.data(), osb.length());
+    ntsa::AbstractSyntaxDecoder decoder(&isb);
+
+    error = result->decode(&decoder);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+}  // close unnamed namespace
+
+Key::Key(bslma_Allocator* basicAllocator)
+: d_pkey()
+, d_record(basicAllocator)
+, d_allocator_p(bslma::Default::allocator(basicAllocator))
+{
+}
+
+Key::Key(EVP_PKEY* pkey, bslma_Allocator* basicAllocator)
+: d_pkey(pkey)
+, d_record(basicAllocator)
+, d_allocator_p(bslma::Default::allocator(basicAllocator))
+{
+    ntsa::Error error = Resource::convert(&d_record, d_pkey);
+    if (error) {
+        BSLS_LOG_ERROR("Failed to decode private key");
+    }
+}
+
+Key::~Key()
+{
+}
+
+ntsa::Error Key::generateDsa(ntctls::Handle<EVP_PKEY>* result)
+{
+    ntctls::Handle<DSA> dsa(DSA_new());
+    if (!dsa) {
+        NTCTLS_KEY_LOG_DSA_ERROR_ALLOCATE();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    const int bits = k_DEFAULT_DSA_BITS;
+
+    if (!DSA_generate_parameters_ex(dsa.get(), bits, 0, 0, 0, 0, 0)) {
+        NTCTLS_KEY_LOG_DSA_ERROR_GENERATE();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if (!DSA_generate_key(dsa.get())) {
+        NTCTLS_KEY_LOG_DSA_ERROR_GENERATE();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    ntctls::Handle<EVP_PKEY> pkey(EVP_PKEY_new());
+    if (!pkey) {
+        NTCTLS_KEY_LOG_EV_PKEY_ERROR_ALLOCATE();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if (!EVP_PKEY_assign_DSA(pkey.get(), dsa.get())) {
+        NTCTLS_KEY_LOG_EV_PKEY_ERROR_ASSIGN();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    dsa.release();
+
+    result->reset(pkey.release());
+
+    BSLS_LOG_WARN("DSA keys are not recommended: "
+                  "use RSA or NIST P-256 instead");
+
+    return ntsa::Error();
+}
+
+ntsa::Error Key::generateRsa(ntctls::Handle<EVP_PKEY>* result)
+{
+    ntctls::Handle<BIGNUM> bn(BN_new());
+    if (!bn) {
+        NTCTLS_KEY_LOG_BN_ERROR_ALLOCATE();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if (!BN_set_word(bn.get(), k_DEFAULT_RSA_EXPONENT)) {
+        NTCTLS_KEY_LOG_BN_ERROR_SET_EXPONENT();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    ntctls::Handle<RSA> rsa(RSA_new());
+    if (!rsa) {
+        NTCTLS_KEY_LOG_RSA_ERROR_ALLOCATE();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    const int bits = k_DEFAULT_RSA_BITS;
+
+    if (!RSA_generate_key_ex(rsa.get(), bits, bn.get(), 0)) {
+        NTCTLS_KEY_LOG_RSA_ERROR_GENERATE();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    ntctls::Handle<EVP_PKEY> pkey(EVP_PKEY_new());
+    if (!pkey) {
+        NTCTLS_KEY_LOG_EV_PKEY_ERROR_ALLOCATE();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if (!EVP_PKEY_assign_RSA(pkey.get(), rsa.get())) {
+        NTCTLS_KEY_LOG_EV_PKEY_ERROR_ASSIGN();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    rsa.release();
+
+    result->reset(pkey.release());
+
+    return ntsa::Error();
+}
+
+ntsa::Error Key::generateEllipticCurve(ntctls::Handle<EVP_PKEY>* result,
+                                       int                       parameterId)
+{
+    int rc;
+
+    ntctls::Handle<EVP_PKEY_CTX> pkeyCtx(EVP_PKEY_CTX_new_id(EVP_PKEY_EC, 0));
+    if (!pkeyCtx) {
+        NTCTLS_KEY_LOG_EV_PKEY_CTX_ERROR_ALLOCATE();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    rc = EVP_PKEY_keygen_init(pkeyCtx.get());
+    if (rc <= 0) {
+        NTCTLS_KEY_LOG_EV_PKEY_CTX_ERROR_KEYGEN_INIT();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    rc = EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pkeyCtx.get(), parameterId);
+    if (rc <= 0) {
+        NTCTLS_KEY_LOG_EV_PKEY_CTX_ERROR_KEYGEN_SET_CURVE();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    EVP_PKEY* pkey = 0;
+
+    rc = EVP_PKEY_keygen(pkeyCtx.get(), &pkey);
+    if (rc <= 0) {
+        NTCTLS_KEY_LOG_EV_PKEY_CTX_ERROR_KEYGEN_GENERATE();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    result->reset(pkey);
+
+    return ntsa::Error();
+}
+
+ntsa::Error Key::generateEdwardsCurve(ntctls::Handle<EVP_PKEY>* result,
+                                      int                       typeId)
+{
+    int rc;
+
+    ntctls::Handle<EVP_PKEY_CTX> pkeyCtx(EVP_PKEY_CTX_new_id(typeId, 0));
+    if (!pkeyCtx) {
+        NTCTLS_KEY_LOG_EV_PKEY_CTX_ERROR_ALLOCATE();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    rc = EVP_PKEY_keygen_init(pkeyCtx.get());
+    if (rc <= 0) {
+        NTCTLS_KEY_LOG_EV_PKEY_CTX_ERROR_KEYGEN_INIT();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    EVP_PKEY* pkey = 0;
+
+    rc = EVP_PKEY_keygen(pkeyCtx.get(), &pkey);
+    if (rc <= 0) {
+        NTCTLS_KEY_LOG_EV_PKEY_CTX_ERROR_KEYGEN_GENERATE();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    result->reset(pkey);
+
+    return ntsa::Error();
+}
+
+ntsa::Error Key::generate(const ntca::EncryptionKeyOptions& configuration)
+{
+    ntsa::Error error;
+
+    ntca::EncryptionKeyType::Value type =
+        configuration.type().value_or(ntca::EncryptionKeyType::e_NIST_P256);
+
+    if (type == ntca::EncryptionKeyType::e_DSA) {
+        error = ntctls::Key::generateDsa(&d_pkey);
+    }
+    else if (type == ntca::EncryptionKeyType::e_RSA) {
+        error = ntctls::Key::generateRsa(&d_pkey);
+    }
+    else if (type == ntca::EncryptionKeyType::e_NIST_P256) {
+        error =
+            ntctls::Key::generateEllipticCurve(&d_pkey, NID_X9_62_prime256v1);
+    }
+    else if (type == ntca::EncryptionKeyType::e_NIST_P384) {
+        error = ntctls::Key::generateEllipticCurve(&d_pkey, NID_secp384r1);
+    }
+    else if (type == ntca::EncryptionKeyType::e_NIST_P521) {
+        error = ntctls::Key::generateEllipticCurve(&d_pkey, NID_secp521r1);
+    }
+    else if (type == ntca::EncryptionKeyType::e_ED25519) {
+        error = ntctls::Key::generateEdwardsCurve(&d_pkey, EVP_PKEY_ED25519);
+    }
+    else if (type == ntca::EncryptionKeyType::e_ED448) {
+        error = ntctls::Key::generateEdwardsCurve(&d_pkey, EVP_PKEY_ED448);
+    }
+    else {
+        error = ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+    }
+
+    if (error) {
+        return error;
+    }
+
+    error = Resource::convert(&d_record, d_pkey);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Key::decode(bsl::streambuf*                        source,
+                        const ntca::EncryptionResourceOptions& options)
+{
+    ntsa::Error error;
+
+    bsl::shared_ptr<ntctls::Key>         privateKey;
+    bsl::shared_ptr<ntctls::Certificate> certificate;
+    ntctls::CertificateVector            caList;
+
+    error = ResourceUtil::decode(source,
+                                 &privateKey,
+                                 &certificate,
+                                 &caList,
+                                 options,
+                                 d_allocator_p);
+    if (error) {
+        return error;
+    }
+
+    if (!privateKey) {
+        return ntsa::Error(ntsa::Error::e_EOF);
+    }
+
+    d_pkey.reset(privateKey->d_pkey.release());
+
+    error = Resource::convert(&d_record, d_pkey);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Key::encode(bsl::streambuf*                        destination,
+                        const ntca::EncryptionResourceOptions& options) const
+{
+    bsl::shared_ptr<ntctls::Key>         privateKey;
+    bsl::shared_ptr<ntctls::Certificate> certificate;
+    ntctls::CertificateVector            caList;
+
+    privateKey = const_cast<Key*>(this)->getSelf(const_cast<Key*>(this));
+
+    return ResourceUtil::encode(destination,
+                                privateKey,
+                                certificate,
+                                caList,
+                                options);
+}
+
+ntsa::Error Key::unwrap(ntca::EncryptionKey* result) const
+{
+    *result = d_record;
+    return ntsa::Error();
+}
+
+void Key::print(bsl::ostream& stream) const
+{
+    bsl::shared_ptr<BIO> bio = Internal::createStream(stream.rdbuf());
+    if (bio) {
+        EVP_PKEY_print_private(bio.get(), d_pkey.get(), 0, 0);
+    }
+}
+
+void* Key::handle() const
+{
+    return d_pkey.get();
+}
+
+EVP_PKEY* Key::native() const
+{
+    return d_pkey.get();
+}
+
+const ntca::EncryptionKey& Key::record() const
+{
+    return d_record;
+}
+
+bool Key::equals(const ntci::EncryptionKey& other) const
+{
+    const Key* concreteKey = dynamic_cast<const Key*>(&other);
+
+    if (!concreteKey) {
+        return false;
+    }
+
+    enum { k_EVP_PKEY_CMP_EQUAL = 1 };
+
+    int rc = EVP_PKEY_cmp(d_pkey.get(), concreteKey->d_pkey.get());
+    return rc == k_EVP_PKEY_CMP_EQUAL;
+}
+
+ntsa::Error Key::generateKey(bsl::shared_ptr<ntci::EncryptionKey>* result,
+                             const ntca::EncryptionKeyOptions&     options,
+                             bslma::Allocator* basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::Key> effectiveResult;
+    effectiveResult.createInplace(allocator, allocator);
+
+    error = effectiveResult->generate(options);
+    if (error) {
+        return error;
+    }
+
+    *result = effectiveResult;
+    return ntsa::Error();
+}
+
+ntsa::Error Key::generateKey(ntca::EncryptionKey*              result,
+                             const ntca::EncryptionKeyOptions& options,
+                             bslma::Allocator*                 basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::Key> effectiveResult;
+    effectiveResult.createInplace(allocator, allocator);
+
+    error = effectiveResult->generate(options);
+    if (error) {
+        return error;
+    }
+
+    error = ntctls::Resource::convert(result, effectiveResult);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+Certificate::Certificate(bslma_Allocator* basicAllocator)
+: d_x509()
+, d_record(basicAllocator)
+, d_subject(basicAllocator)
+, d_issuer(basicAllocator)
+, d_allocator_p(bslma::Default::allocator(basicAllocator))
+{
+}
+
+Certificate::Certificate(X509* x509, bslma_Allocator* basicAllocator)
+: d_x509(x509)
+, d_record(basicAllocator)
+, d_subject(basicAllocator)
+, d_issuer(basicAllocator)
+, d_allocator_p(bslma::Default::allocator(basicAllocator))
+{
+    ntsa::Error error = Resource::convert(&d_record, d_x509);
+    if (error) {
+        BSLS_LOG_ERROR("Failed to decode certificate");
+    }
+
+    parseDistinguishedName(&d_subject, X509_get_subject_name(x509));
+    parseDistinguishedName(&d_issuer, X509_get_issuer_name(x509));
+}
+
+Certificate::~Certificate()
+{
+}
+
+ntsa::Error Certificate::generate(
+    const ntsa::DistinguishedName&            userIdentity,
+    const bsl::shared_ptr<Key>&               userPrivateKey,
+    const ntca::EncryptionCertificateOptions& configuration)
+{
+    ntsa::Error error;
+    int         rc;
+
+    ntctls::Handle<X509> x509(X509_new());
+    if (!x509) {
+        NTCTLS_CERTIFICATE_LOG_X509_ERROR_ALLOCATE();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    X509_set_version(x509.get(), 2);
+    ASN1_INTEGER_set(X509_get_serialNumber(x509.get()),
+                     configuration.serialNumber());
+
+    bdlt::Datetime startTime = configuration.startTime().gmtDatetime();
+    if (startTime < bdlt::EpochUtil::epoch()) {
+        startTime = bdlt::EpochUtil::epoch();
+    }
+
+    ASN1_TIME_set(X509_getm_notBefore(x509.get()),
+                  bdlt::EpochUtil::convertToTimeT(startTime));
+
+    bdlt::Datetime expirationTime =
+        configuration.expirationTime().gmtDatetime();
+    if (expirationTime >= bdlt::Datetime(2038, 1, 1)) {
+        expirationTime = bdlt::Datetime(2038, 1, 1);
+    }
+
+    ASN1_TIME_set(X509_getm_notAfter(x509.get()),
+                  bdlt::EpochUtil::convertToTimeT(expirationTime));
+
+    {
+        ntctls::Handle<X509_NAME> x509Name(X509_NAME_new());
+        if (!x509Name) {
+            NTCTLS_CERTIFICATE_LOG_X509_NAME_ERROR_ALLOCATE();
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        for (ntsa::DistinguishedName::ComponentList::const_iterator it =
+                 userIdentity.begin();
+             it != userIdentity.end();
+             ++it)
+        {
+            rc = generateX509Name(x509Name.get(), *it);
+            if (0 != rc) {
+                NTCTLS_CERTIFICATE_LOG_X509_NAME_ERROR_GENERATE();
+                return ntsa::Error(ntsa::Error::e_INVALID);
+            }
+        }
+
+        if (!X509_set_subject_name(x509.get(), x509Name.get())) {
+            NTCTLS_CERTIFICATE_LOG_X509_ERROR_SET_SUBJECT_NAME();
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        if (!X509_set_issuer_name(x509.get(), x509Name.get())) {
+            NTCTLS_CERTIFICATE_LOG_X509_ERROR_SET_ISSUER_NAME();
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    if (!X509_set_pubkey(x509.get(), userPrivateKey->native())) {
+        NTCTLS_CERTIFICATE_LOG_X509_ERROR_SET_PUBLIC_KEY();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    X509V3_CTX x509v3Ctx = {};
+
+    X509V3_set_ctx(&x509v3Ctx, x509.get(), x509.get(), 0, 0, 0);
+
+    if (configuration.authority()) {
+        error = addExtension(x509.get(),
+                             &x509v3Ctx,
+                             NID_basic_constraints,
+                             "critical,CA:TRUE");
+        if (error) {
+            return error;
+        }
+
+        error = addExtension(x509.get(),
+                             &x509v3Ctx,
+                             NID_key_usage,
+                             "keyCertSign,cRLSign");
+        if (error) {
+            return error;
+        }
+    }
+    else {
+        error = addExtension(x509.get(),
+                             &x509v3Ctx,
+                             NID_basic_constraints,
+                             "critical,CA:FALSE");
+        if (error) {
+            return error;
+        }
+    }
+
+    error = addExtension(x509.get(),
+                         &x509v3Ctx,
+                         NID_subject_key_identifier,
+                         "hash");
+    if (error) {
+        return error;
+    }
+
+    error = addExtension(x509.get(),
+                         &x509v3Ctx,
+                         NID_authority_key_identifier,
+                         "keyid:always");
+    if (error) {
+        return error;
+    }
+
+    if (!configuration.hosts().empty()) {
+        bsl::string subjectAlternativeName;
+        {
+            bsl::stringstream ss;
+            for (bsl::size_t i = 0; i < configuration.hosts().size(); ++i) {
+                if (i != 0) {
+                    ss << ",";
+                }
+
+                ntsa::IpAddress ipAddress;
+                if (ipAddress.parse(configuration.hosts()[i])) {
+                    ss << "IP:" << ipAddress.text();
+                }
+                else {
+                    ss << "DNS:" << configuration.hosts()[i];
+                }
+            }
+
+            subjectAlternativeName = ss.str();
+        }
+
+        error = addExtension(x509.get(),
+                             &x509v3Ctx,
+                             NID_subject_alt_name,
+                             subjectAlternativeName.c_str());
+        if (error) {
+            return error;
+        }
+    }
+
+    const int keyId = EVP_PKEY_id(userPrivateKey->native());
+
+    if (keyId == NID_ED25519 || keyId == NID_ED448) {
+        if (!X509_sign(x509.get(), userPrivateKey->native(), 0)) {
+            NTCTLS_CERTIFICATE_LOG_X509_ERROR_SIGN();
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+    else {
+        if (!X509_sign(x509.get(), userPrivateKey->native(), EVP_sha256())) {
+            NTCTLS_CERTIFICATE_LOG_X509_ERROR_SIGN();
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    d_x509.reset(x509.release());
+
+    error = Resource::convert(&d_record, d_x509);
+    if (error) {
+        return error;
+    }
+
+    parseDistinguishedName(&d_subject, X509_get_subject_name(d_x509.get()));
+    parseDistinguishedName(&d_issuer, X509_get_issuer_name(d_x509.get()));
+
+    return ntsa::Error();
+}
+
+ntsa::Error Certificate::generate(
+    const ntsa::DistinguishedName&            userIdentity,
+    const bsl::shared_ptr<Key>&               userPrivateKey,
+    const bsl::shared_ptr<Certificate>&       authorityCertificate,
+    const bsl::shared_ptr<Key>&               authorityPrivateKey,
+    const ntca::EncryptionCertificateOptions& configuration)
+{
+    // Review: Consider supporting certificate revocation (CRL).
+
+    ntsa::Error error;
+    int         rc;
+
+    ntctls::Handle<X509> x509(X509_new());
+    if (!x509) {
+        NTCTLS_CERTIFICATE_LOG_X509_ERROR_ALLOCATE();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    X509_set_version(x509.get(), 2);
+    ASN1_INTEGER_set(X509_get_serialNumber(x509.get()),
+                     configuration.serialNumber());
+
+    bdlt::Datetime startTime = configuration.startTime().gmtDatetime();
+
+    bsl::string startTimeString;
+    ntctls::Internal::convertDatetimeToAsn1TimeString(&startTimeString,
+                                                      startTime);
+
+    rc = ASN1_TIME_set_string(X509_getm_notBefore(x509.get()),
+                              startTimeString.c_str());
+    if (rc != 1) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    bdlt::Datetime expirationTime =
+        configuration.expirationTime().gmtDatetime();
+
+    bsl::string expirationTimeString;
+    ntctls::Internal::convertDatetimeToAsn1TimeString(&expirationTimeString,
+                                                      expirationTime);
+
+    rc = ASN1_TIME_set_string(X509_getm_notAfter(x509.get()),
+                              expirationTimeString.c_str());
+    if (rc != 1) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    {
+        ntctls::Handle<X509_NAME> x509Name(X509_NAME_new());
+        if (!x509Name) {
+            NTCTLS_CERTIFICATE_LOG_X509_NAME_ERROR_ALLOCATE();
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        for (ntsa::DistinguishedName::ComponentList::const_iterator it =
+                 userIdentity.begin();
+             it != userIdentity.end();
+             ++it)
+        {
+            rc = generateX509Name(x509Name.get(), *it);
+            if (0 != rc) {
+                NTCTLS_CERTIFICATE_LOG_X509_NAME_ERROR_GENERATE();
+                return ntsa::Error(ntsa::Error::e_INVALID);
+            }
+        }
+
+        if (!X509_set_subject_name(x509.get(), x509Name.get())) {
+            NTCTLS_CERTIFICATE_LOG_X509_ERROR_SET_SUBJECT_NAME();
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    if (!X509_set_issuer_name(
+            x509.get(),
+            X509_get_subject_name(authorityCertificate->native())))
+    {
+        NTCTLS_CERTIFICATE_LOG_X509_ERROR_SET_ISSUER_NAME();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if (!X509_set_pubkey(x509.get(), userPrivateKey->native())) {
+        NTCTLS_CERTIFICATE_LOG_X509_ERROR_SET_PUBLIC_KEY();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    X509V3_CTX x509v3Ctx = {};
+
+    X509V3_set_ctx(&x509v3Ctx,
+                   authorityCertificate->native(),
+                   x509.get(),
+                   0,
+                   0,
+                   0);
+
+    if (configuration.authority()) {
+        error = addExtension(x509.get(),
+                             &x509v3Ctx,
+                             NID_basic_constraints,
+                             "critical,CA:TRUE");
+        if (error) {
+            return error;
+        }
+
+        error = addExtension(x509.get(),
+                             &x509v3Ctx,
+                             NID_key_usage,
+                             "keyCertSign,cRLSign");
+        if (error) {
+            return error;
+        }
+    }
+    else {
+        error = addExtension(x509.get(),
+                             &x509v3Ctx,
+                             NID_basic_constraints,
+                             "critical,CA:FALSE");
+        if (error) {
+            return error;
+        }
+    }
+
+    error = addExtension(x509.get(),
+                         &x509v3Ctx,
+                         NID_subject_key_identifier,
+                         "hash");
+    if (error) {
+        return error;
+    }
+
+    error = addExtension(x509.get(),
+                         &x509v3Ctx,
+                         NID_authority_key_identifier,
+                         "keyid:always");
+    if (error) {
+        return error;
+    }
+
+    if (!configuration.hosts().empty()) {
+        bsl::string subjectAlternativeName;
+        {
+            bsl::stringstream ss;
+            for (bsl::size_t i = 0; i < configuration.hosts().size(); ++i) {
+                if (i != 0) {
+                    ss << ",";
+                }
+
+                ntsa::IpAddress ipAddress;
+                if (ipAddress.parse(configuration.hosts()[i])) {
+                    ss << "IP:" << ipAddress.text();
+                }
+                else {
+                    ss << "DNS:" << configuration.hosts()[i];
+                }
+            }
+
+            subjectAlternativeName = ss.str();
+        }
+
+        error = addExtension(x509.get(),
+                             &x509v3Ctx,
+                             NID_subject_alt_name,
+                             subjectAlternativeName.c_str());
+        if (error) {
+            return error;
+        }
+    }
+
+    const int keyId = EVP_PKEY_id(authorityPrivateKey->native());
+
+    if (keyId == NID_ED25519 || keyId == NID_ED448) {
+        if (!X509_sign(x509.get(), authorityPrivateKey->native(), 0)) {
+            NTCTLS_CERTIFICATE_LOG_X509_ERROR_SIGN();
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+    else {
+        if (!X509_sign(x509.get(),
+                       authorityPrivateKey->native(),
+                       EVP_sha256()))
+        {
+            NTCTLS_CERTIFICATE_LOG_X509_ERROR_SIGN();
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    d_x509.reset(x509.release());
+
+    error = Resource::convert(&d_record, d_x509);
+    if (error) {
+        return error;
+    }
+
+    parseDistinguishedName(&d_subject, X509_get_subject_name(d_x509.get()));
+    parseDistinguishedName(&d_issuer, X509_get_issuer_name(d_x509.get()));
+
+    return ntsa::Error();
+}
+
+ntsa::Error Certificate::decode(bsl::streambuf*                        source,
+                                const ntca::EncryptionResourceOptions& options)
+{
+    ntsa::Error error;
+
+    bsl::shared_ptr<ntctls::Key>         privateKey;
+    bsl::shared_ptr<ntctls::Certificate> certificate;
+    ntctls::CertificateVector            caList;
+
+    error = ResourceUtil::decode(source,
+                                 &privateKey,
+                                 &certificate,
+                                 &caList,
+                                 options,
+                                 d_allocator_p);
+    if (error) {
+        return error;
+    }
+
+    if (!certificate) {
+        if (caList.empty()) {
+            return ntsa::Error(ntsa::Error::e_EOF);
+        }
+
+        certificate = caList.front();
+    }
+
+    d_x509.reset(certificate->d_x509.release());
+
+    error = Resource::convert(&d_record, d_x509);
+    if (error) {
+        return error;
+    }
+
+    d_subject = certificate->d_subject;
+    d_issuer  = certificate->d_issuer;
+
+    return ntsa::Error();
+}
+
+ntsa::Error Certificate::encode(
+    bsl::streambuf*                        destination,
+    const ntca::EncryptionResourceOptions& options) const
+{
+    bsl::shared_ptr<ntctls::Key>         privateKey;
+    bsl::shared_ptr<ntctls::Certificate> certificate;
+    ntctls::CertificateVector            caList;
+
+    certificate = const_cast<Certificate*>(this)->getSelf(
+        const_cast<Certificate*>(this));
+
+    return ResourceUtil::encode(destination,
+                                privateKey,
+                                certificate,
+                                caList,
+                                options);
+}
+
+ntsa::Error Certificate::unwrap(ntca::EncryptionCertificate* result) const
+{
+    *result = d_record;
+    return ntsa::Error();
+}
+
+void Certificate::print(bsl::ostream& stream) const
+{
+    bsl::shared_ptr<BIO> bio = Internal::createStream(stream.rdbuf());
+    if (bio) {
+        if (!X509_print_ex(bio.get(), d_x509.get(), XN_FLAG_SEP_COMMA_PLUS, 0))
+        {
+            NTCTLS_CERTIFICATE_LOG_PRINT_ERROR();
+            return;
+        }
+    }
+}
+
+const ntsa::DistinguishedName& Certificate::subject() const
+{
+    return d_subject;
+}
+
+const ntsa::DistinguishedName& Certificate::issuer() const
+{
+    return d_issuer;
+}
+
+bool Certificate::isAuthority() const
+{
+    bool result = false;
+
+    X509_EXTENSION* extension =
+        getExtension(d_x509.get(), NID_basic_constraints);
+    if (extension == 0) {
+        return false;
+    }
+
+    int critical = 0;
+
+    BASIC_CONSTRAINTS* bs =
+        (BASIC_CONSTRAINTS*)(X509_get_ext_d2i(d_x509.get(),
+                                              NID_basic_constraints,
+                                              &critical,
+                                              0));
+    if (bs != 0) {
+        result = bs->ca;
+    }
+
+    return result;
+}
+
+void* Certificate::handle() const
+{
+    return d_x509.get();
+}
+
+X509* Certificate::native() const
+{
+    return d_x509.get();
+}
+
+const ntca::EncryptionCertificate& Certificate::record() const
+{
+    return d_record;
+}
+
+bool Certificate::equals(const ntci::EncryptionCertificate& other) const
+{
+    const Certificate* concreteCertificate =
+        dynamic_cast<const Certificate*>(&other);
+
+    if (!concreteCertificate) {
+        return false;
+    }
+
+    enum { k_X509_CMP_EQUAL = 0 };
+
+    X509* x509_1 = d_x509.get();
+    X509* x509_2 = concreteCertificate->d_x509.get();
+
+    int rc = X509_cmp(x509_1, x509_2);
+    return rc == k_X509_CMP_EQUAL;
+}
+
+ntsa::Error Certificate::generateCertificate(
+    bsl::shared_ptr<ntci::EncryptionCertificate>* result,
+    const ntsa::DistinguishedName&                userIdentity,
+    const bsl::shared_ptr<ntci::EncryptionKey>&   userPrivateKey,
+    const ntca::EncryptionCertificateOptions&     options,
+    bslma::Allocator*                             basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::Key> effectiveSubjectPrivateKey;
+    error =
+        ntctls::Resource::convert(&effectiveSubjectPrivateKey, userPrivateKey);
+    if (error) {
+        return error;
+    }
+
+    bsl::shared_ptr<ntctls::Certificate> effectiveResult;
+    effectiveResult.createInplace(allocator, allocator);
+
+    error = effectiveResult->generate(userIdentity,
+                                      effectiveSubjectPrivateKey,
+                                      options);
+    if (error) {
+        return error;
+    }
+
+    *result = effectiveResult;
+    return ntsa::Error();
+}
+
+ntsa::Error Certificate::generateCertificate(
+    bsl::shared_ptr<ntci::EncryptionCertificate>*       result,
+    const ntsa::DistinguishedName&                      userIdentity,
+    const bsl::shared_ptr<ntci::EncryptionKey>&         userPrivateKey,
+    const bsl::shared_ptr<ntci::EncryptionCertificate>& authorityCertificate,
+    const bsl::shared_ptr<ntci::EncryptionKey>&         authorityPrivateKey,
+    const ntca::EncryptionCertificateOptions&           options,
+    bslma::Allocator*                                   basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::Key> effectiveSubjectPrivateKey;
+    error =
+        ntctls::Resource::convert(&effectiveSubjectPrivateKey, userPrivateKey);
+    if (error) {
+        return error;
+    }
+
+    bsl::shared_ptr<ntctls::Certificate> effectiveIssuerCertificate;
+    error = ntctls::Resource::convert(&effectiveIssuerCertificate,
+                                      authorityCertificate);
+    if (error) {
+        return error;
+    }
+
+    bsl::shared_ptr<ntctls::Key> effectiveIssuerPrivateKey;
+    error = ntctls::Resource::convert(&effectiveIssuerPrivateKey,
+                                      authorityPrivateKey);
+    if (error) {
+        return error;
+    }
+
+    bsl::shared_ptr<ntctls::Certificate> effectiveResult;
+    effectiveResult.createInplace(allocator, allocator);
+
+    error = effectiveResult->generate(userIdentity,
+                                      effectiveSubjectPrivateKey,
+                                      effectiveIssuerCertificate,
+                                      effectiveIssuerPrivateKey,
+                                      options);
+    if (error) {
+        return error;
+    }
+
+    *result = effectiveResult;
+    return ntsa::Error();
+}
+
+ntsa::Error Certificate::generateCertificate(
+    ntca::EncryptionCertificate*              result,
+    const ntsa::DistinguishedName&            userIdentity,
+    const ntca::EncryptionKey&                userPrivateKey,
+    const ntca::EncryptionCertificateOptions& options,
+    bslma::Allocator*                         basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::Key> concreteSubjectPrivateKey;
+    error = ntctls::Resource::convert(&concreteSubjectPrivateKey,
+                                      userPrivateKey,
+                                      allocator);
+    if (error) {
+        return error;
+    }
+
+    bsl::shared_ptr<ntctls::Certificate> effectiveResult;
+    effectiveResult.createInplace(allocator, allocator);
+
+    error = effectiveResult->generate(userIdentity,
+                                      concreteSubjectPrivateKey,
+                                      options);
+    if (error) {
+        return error;
+    }
+
+    error = ntctls::Resource::convert(result, effectiveResult);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Certificate::generateCertificate(
+    ntca::EncryptionCertificate*              result,
+    const ntsa::DistinguishedName&            userIdentity,
+    const ntca::EncryptionKey&                userPrivateKey,
+    const ntca::EncryptionCertificate&        authorityCertificate,
+    const ntca::EncryptionKey&                authorityPrivateKey,
+    const ntca::EncryptionCertificateOptions& options,
+    bslma::Allocator*                         basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::Key> concreteSubjectPrivateKey;
+    error = ntctls::Resource::convert(&concreteSubjectPrivateKey,
+                                      userPrivateKey,
+                                      allocator);
+    if (error) {
+        return error;
+    }
+
+    bsl::shared_ptr<ntctls::Certificate> concreteIssuerCertificate;
+    error = ntctls::Resource::convert(&concreteIssuerCertificate,
+                                      authorityCertificate,
+                                      allocator);
+    if (error) {
+        return error;
+    }
+
+    bsl::shared_ptr<ntctls::Key> concreteIssuerPrivateKey;
+    error = ntctls::Resource::convert(&concreteIssuerPrivateKey,
+                                      authorityPrivateKey,
+                                      allocator);
+    if (error) {
+        return error;
+    }
+
+    bsl::shared_ptr<ntctls::Certificate> concreteResult;
+    concreteResult.createInplace(allocator, allocator);
+
+    error = concreteResult->generate(userIdentity,
+                                     concreteSubjectPrivateKey,
+                                     concreteIssuerCertificate,
+                                     concreteIssuerPrivateKey,
+                                     options);
+    if (error) {
+        return error;
+    }
+
+    error = ntctls::Resource::convert(result, concreteResult);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+Resource::Resource(bslma::Allocator* basicAllocator)
+: d_privateKey_sp()
+, d_certificate_sp()
+, d_caList(basicAllocator)
+, d_allocator_p(bslma::Default::allocator(basicAllocator))
+{
+}
+
+Resource::~Resource()
+{
+}
+
+ntsa::Error Resource::setPrivateKey(const ntca::EncryptionKey& key)
+{
+    ntsa::Error error;
+
+    if (d_privateKey_sp) {
+        NTCTLS_RESOURCE_LOG_ALREADY_HAVE_KEY();
+        return ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED);
+    }
+
+    bsl::shared_ptr<ntctls::Key> concreteKey;
+    error = ResourceUtil::convertKey(&concreteKey, key, d_allocator_p);
+    if (error) {
+        return error;
+    }
+
+    d_privateKey_sp = concreteKey;
+
+    return ntsa::Error();
+}
+
+ntsa::Error Resource::setPrivateKey(
+    const bsl::shared_ptr<ntci::EncryptionKey>& key)
+{
+    if (d_privateKey_sp) {
+        NTCTLS_RESOURCE_LOG_ALREADY_HAVE_KEY();
+        return ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED);
+    }
+
+    bsl::shared_ptr<ntctls::Key> concreteKey =
+        bsl::dynamic_pointer_cast<ntctls::Key>(key);
+
+    if (!concreteKey) {
+        NTCTLS_RESOURCE_LOG_INVALID_DRIVER();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    d_privateKey_sp = concreteKey;
+
+    return ntsa::Error();
+}
+
+ntsa::Error Resource::setCertificate(
+    const ntca::EncryptionCertificate& certificate)
+{
+    ntsa::Error error;
+
+    if (d_certificate_sp) {
+        NTCTLS_RESOURCE_LOG_ALREADY_HAVE_CERTIFICATE();
+        return ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED);
+    }
+
+    bsl::shared_ptr<ntctls::Certificate> concreteCertificate;
+    error = ResourceUtil::convertCertificate(&concreteCertificate,
+                                             certificate,
+                                             d_allocator_p);
+    if (error) {
+        return error;
+    }
+
+    d_certificate_sp = concreteCertificate;
+
+    return ntsa::Error();
+}
+
+ntsa::Error Resource::setCertificate(
+    const bsl::shared_ptr<ntci::EncryptionCertificate>& certificate)
+{
+    if (d_certificate_sp) {
+        NTCTLS_RESOURCE_LOG_ALREADY_HAVE_CERTIFICATE();
+        return ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED);
+    }
+
+    bsl::shared_ptr<ntctls::Certificate> concreteCertificate =
+        bsl::dynamic_pointer_cast<ntctls::Certificate>(certificate);
+
+    if (!concreteCertificate) {
+        NTCTLS_RESOURCE_LOG_INVALID_DRIVER();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    d_certificate_sp = concreteCertificate;
+
+    return ntsa::Error();
+}
+
+ntsa::Error Resource::addCertificateAuthority(
+    const ntca::EncryptionCertificate& certificate)
+{
+    ntsa::Error error;
+
+    bsl::shared_ptr<ntctls::Certificate> concreteCertificate;
+    error = ResourceUtil::convertCertificate(&concreteCertificate,
+                                             certificate,
+                                             d_allocator_p);
+    if (error) {
+        return error;
+    }
+
+    d_caList.push_back(concreteCertificate);
+
+    return ntsa::Error();
+}
+
+ntsa::Error Resource::addCertificateAuthority(
+    const bsl::shared_ptr<ntci::EncryptionCertificate>& certificate)
+{
+    bsl::shared_ptr<ntctls::Certificate> concreteCertificate =
+        bsl::dynamic_pointer_cast<ntctls::Certificate>(certificate);
+
+    if (!concreteCertificate) {
+        NTCTLS_RESOURCE_LOG_INVALID_DRIVER();
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    d_caList.push_back(concreteCertificate);
+
+    return ntsa::Error();
+}
+
+ntsa::Error Resource::decode(bsl::streambuf*                        source,
+                             const ntca::EncryptionResourceOptions& options)
+{
+    ntsa::Error error;
+
+    bsl::shared_ptr<ntctls::Key>         privateKey;
+    bsl::shared_ptr<ntctls::Certificate> certificate;
+    ntctls::CertificateVector            caList;
+
+    error = ResourceUtil::decode(source,
+                                 &privateKey,
+                                 &certificate,
+                                 &caList,
+                                 options,
+                                 d_allocator_p);
+
+    if (error) {
+        return error;
+    }
+
+    if (privateKey) {
+        if (d_privateKey_sp) {
+            NTCTLS_RESOURCE_LOG_ALREADY_HAVE_KEY();
+            return ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED);
+        }
+
+        d_privateKey_sp = privateKey;
+    }
+
+    if (certificate) {
+        const bool isCa = certificate->isAuthority();
+        if (isCa) {
+            d_caList.push_back(certificate);
+        }
+        else {
+            if (d_certificate_sp) {
+                NTCTLS_RESOURCE_LOG_ALREADY_HAVE_CERTIFICATE();
+                return ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED);
+            }
+
+            d_certificate_sp = certificate;
+        }
+    }
+
+    if (!caList.empty()) {
+        d_caList.insert(d_caList.end(), caList.begin(), caList.end());
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Resource::encode(
+    bsl::streambuf*                        destination,
+    const ntca::EncryptionResourceOptions& options) const
+{
+    if (!d_privateKey_sp && !d_certificate_sp && d_caList.empty()) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    return ResourceUtil::encode(destination,
+                                d_privateKey_sp,
+                                d_certificate_sp,
+                                d_caList,
+                                options);
+}
+
+ntsa::Error Resource::getPrivateKey(
+    bsl::shared_ptr<ntci::EncryptionKey>* result) const
+{
+    if (!d_privateKey_sp) {
+        return ntsa::Error(ntsa::Error::e_EOF);
+    }
+
+    *result = d_privateKey_sp;
+
+    return ntsa::Error();
+}
+
+ntsa::Error Resource::getCertificate(
+    bsl::shared_ptr<ntci::EncryptionCertificate>* result) const
+{
+    if (!d_certificate_sp) {
+        return ntsa::Error(ntsa::Error::e_EOF);
+    }
+
+    *result = d_certificate_sp;
+
+    return ntsa::Error();
+}
+
+ntsa::Error Resource::getCertificateAuthoritySet(
+    bsl::vector<bsl::shared_ptr<ntci::EncryptionCertificate> >* result) const
+{
+    if (d_caList.empty()) {
+        return ntsa::Error(ntsa::Error::e_EOF);
+    }
+
+    result->reserve(result->size() + d_caList.size());
+
+    for (CertificateVector::const_iterator it = d_caList.begin();
+         it != d_caList.end();
+         ++it)
+    {
+        result->push_back(*it);
+    }
+
+    return ntsa::Error();
+}
+
+bool Resource::equals(const Resource& other) const
+{
+    return this->contains(other, true, true);
+}
+
+bool Resource::contains(const Resource& other,
+                        bool            includePrivateKeys,
+                        bool            includeCertificates) const
+{
+    if (includePrivateKeys) {
+        if (d_privateKey_sp) {
+            if (!other.d_privateKey_sp) {
+                return false;
+            }
+        }
+
+        if (other.d_privateKey_sp) {
+            if (!d_privateKey_sp) {
+                return false;
+            }
+        }
+
+        if (d_privateKey_sp && other.d_privateKey_sp) {
+            if (!d_privateKey_sp->equals(*other.d_privateKey_sp)) {
+                return false;
+            }
+        }
+    }
+
+    if (includeCertificates) {
+        if (d_certificate_sp) {
+            if (!other.d_certificate_sp) {
+                return false;
+            }
+        }
+
+        if (other.d_certificate_sp) {
+            if (!d_certificate_sp) {
+                return false;
+            }
+        }
+
+        if (d_certificate_sp && other.d_certificate_sp) {
+            if (!d_certificate_sp->equals(*other.d_certificate_sp)) {
+                return false;
+            }
+        }
+
+        if (d_caList.size() != other.d_caList.size()) {
+            return false;
+        }
+
+        for (bsl::size_t i = 0; i < d_caList.size(); ++i) {
+            if (!d_caList[i]->equals(*other.d_caList[i])) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+ntsa::Error Resource::convert(
+    bsl::shared_ptr<ntctls::Certificate>*               result,
+    const bsl::shared_ptr<ntci::EncryptionCertificate>& certificate)
+{
+    *result = bsl::dynamic_pointer_cast<ntctls::Certificate>(certificate);
+    if (!*result) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Resource::convert(
+    bsl::shared_ptr<ntci::EncryptionCertificate>* result,
+    const ntca::EncryptionCertificate&            certificate,
+    bslma::Allocator*                             basicAllocator)
+{
+    ntsa::Error error;
+
+    bsl::shared_ptr<ntctls::Certificate> concreteResult;
+    error = ResourceUtil::convertCertificate(&concreteResult,
+                                             certificate,
+                                             basicAllocator);
+    if (error) {
+        return error;
+    }
+
+    *result = concreteResult;
+
+    return ntsa::Error();
+}
+
+ntsa::Error Resource::convert(bsl::shared_ptr<ntctls::Certificate>* result,
+                              const ntca::EncryptionCertificate& certificate,
+                              bslma::Allocator* basicAllocator)
+{
+    return ResourceUtil::convertCertificate(result,
+                                            certificate,
+                                            basicAllocator);
+}
+
+ntsa::Error Resource::convert(ntctls::Handle<X509>*              result,
+                              const ntca::EncryptionCertificate& certificate)
+{
+    return ResourceUtil::convertCertificate(result, certificate);
+}
+
+ntsa::Error Resource::convert(
+    ntca::EncryptionCertificate*                result,
+    const bsl::shared_ptr<ntctls::Certificate>& certificate)
+{
+    return ResourceUtil::convertCertificate(result, certificate);
+}
+
+ntsa::Error Resource::convert(ntca::EncryptionCertificate* result,
+                              const ntctls::Handle<X509>&  certificate)
+{
+    return ResourceUtil::convertCertificate(result, certificate);
+}
+
+ntsa::Error Resource::convert(bsl::shared_ptr<ntctls::Key>* result,
+                              const bsl::shared_ptr<ntci::EncryptionKey>& key)
+{
+    *result = bsl::dynamic_pointer_cast<ntctls::Key>(key);
+    if (!*result) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Resource::convert(bsl::shared_ptr<ntci::EncryptionKey>* result,
+                              const ntca::EncryptionKey&            key,
+                              bslma::Allocator* basicAllocator)
+{
+    ntsa::Error error;
+
+    bsl::shared_ptr<ntctls::Key> concreteKey;
+    error = ResourceUtil::convertKey(&concreteKey, key, basicAllocator);
+    if (error) {
+        return error;
+    }
+
+    *result = concreteKey;
+    return ntsa::Error();
+}
+
+ntsa::Error Resource::convert(bsl::shared_ptr<ntctls::Key>* result,
+                              const ntca::EncryptionKey&    key,
+                              bslma::Allocator*             basicAllocator)
+{
+    return ResourceUtil::convertKey(result, key, basicAllocator);
+}
+
+ntsa::Error Resource::convert(ntctls::Handle<EVP_PKEY>*  result,
+                              const ntca::EncryptionKey& key)
+{
+    return ResourceUtil::convertKey(result, key);
+}
+
+ntsa::Error Resource::convert(ntca::EncryptionKey*                result,
+                              const bsl::shared_ptr<ntctls::Key>& key)
+{
+    return ResourceUtil::convertKey(result, key);
+}
+
+ntsa::Error Resource::convert(ntca::EncryptionKey*            result,
+                              const ntctls::Handle<EVP_PKEY>& key)
+{
+    return ResourceUtil::convertKey(result, key);
+}
+
+/// Provide a TLS session state machine to encrypt/decrypt data.
+///
+/// @details
+/// This component provides a mechanism, 'ntctls::Session', that
+/// implements the 'ntci::Encryption' interface to establish a TLS session in
+/// either the client or server role, then encrypt and decrypt a data stream,
+/// then perform a bidirectional shutdown.
+///
+/// @par Shutting Down the TLS session
+/// This component implements a full bidirectional TLS shutdown. Each TLS
+/// peer is responsible for shutting down its side of the TLS session. After
+/// a TLS shutdown has been initiated, it is still possible to push incoming
+/// ciphertext and pop incoming plaintext, but it is no longer possible to push
+/// outgoing plaintext. Similarly, after a TLS shutdown has been received, it
+/// is still possible to push outgoing plaintext and pop outgoing ciphertext,
+/// but it is no longer possible to push incoming ciphertext.
+///
+/// Similar to the Berkeley Sockets API, when a TLS shutdown has been received
+/// from the peer and fully processed by the internal TLS state machine,
+/// 'hasIncomingPlainText' will return true and 'popIncomingPlainText' will
+/// return with no errors but append zero bytes to its output blob parameter.
+///
+/// Users should avoid calling 'isShutdownFinished' because this function will
+/// return true immediately after 'pushIncomingCipherText' is called that
+/// contains the TLS shutdown from the peer, regardless of whether the all the
+/// incoming plaintext has been popped.
+///
+/// @par Thread Safety
+/// This class is thread safe.
+///
+/// @ingroup module_ntctls
+class Session : public ntci::Encryption
+{
+    typedef ntci::Mutex       Mutex;
+    typedef ntci::LockGuard   LockGuard;
+    typedef ntci::UnLockGuard UnLockGuard;
+
+    mutable Mutex                             d_mutex;
+    bsl::shared_ptr<ntctls::SessionContext>   d_context_sp;
+    bsl::shared_ptr<ntctls::SessionManager>   d_sessionManager_sp;
+    bsl::shared_ptr<bdlbb::BlobBufferFactory> d_blobBufferFactory_sp;
+    bsl::shared_ptr<ntctls::Certificate>      d_sourceCertificate_sp;
+    bsl::shared_ptr<ntctls::Certificate>      d_remoteCertificate_sp;
+    bdlb::NullableValue<bsl::string>          d_serverNameIndication;
+    SSL*                                      d_ssl_p;
+    bdlbb::Blob                               d_incomingCipherText;
+    bdlbb::Blob                               d_outgoingCipherText;
+    bdlbb::Blob                               d_incomingPlainText;
+    bdlbb::Blob                               d_outgoingPlainText;
+    ntca::UpgradeOptions                      d_upgradeOptions;
+    ntci::Encryption::HandshakeCallback       d_handshakeCallback;
+    bslma::Allocator*                         d_allocator_p;
+
+  private:
+    Session(const Session&) BSLS_KEYWORD_DELETED;
+    Session& operator=(const Session&) BSLS_KEYWORD_DELETED;
+
+  private:
+    /// Initialize a new session.
+    ntsa::Error init();
+
+    /// Process the available data through the TLS state machine under the
+    /// specified 'lock' guard. Return the error.
+    ntsa::Error process(LockGuard* lock);
+
+  public:
+    /// Create a new session in the specified 'sessionManager'. Allocate blob
+    /// buffers using the specified 'blobBufferFactory'. Optionally specify a
+    /// 'basicAllocator' used to supply memory. If 'basicAllocator' is 0, the
+    /// currently installed default allocator is used.
+    Session(const bsl::shared_ptr<ntctls::SessionManager>&   sessionManager,
+            const bsl::shared_ptr<bdlbb::BlobBufferFactory>& blobBufferFactory,
+            bslma::Allocator* basicAllocator = 0);
+
+    /// Destroy this object.
+    ~Session() BSLS_KEYWORD_OVERRIDE;
+
+    /// Switch to the context associated with the specified 'serverName'
+    /// indication. Load into the speciifed 'found' flag whether the context
+    /// was found. Return the error.
+    ntsa::Error activate(bool* found, const bsl::string& serverName);
+
+    /// Authenticate the specfiied 'x509' certificate that is part of the
+    /// specified 'x509Store' having the specified 'x509StoreCtx'. Return the
+    /// error.
+    ntsa::Error authenticate(X509_STORE_CTX* x509StoreCtx);
+
+    /// Authenticate the specfiied 'x509' certificate that is part of the
+    /// specified 'x509Store' having the specified 'x509StoreCtx'. Return the
+    /// error.
+    ntsa::Error authenticate(X509_STORE_CTX* x509StoreCtx, X509* x509);
+
+    /// Initiate the handshake to begin the session. Invoke the specified
+    /// 'callback' when the handshake completes. Return the error.
+    ntsa::Error initiateHandshake(const HandshakeCallback& callback)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Initiate the handshake to begin the session according to the specified
+    /// 'upgradeOptions'. Invoke the specified 'callback' when the handshake
+    /// completes. Return the error.
+    ntsa::Error initiateHandshake(const ntca::UpgradeOptions& upgradeOptions,
+                                  const HandshakeCallback&    callback)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Add the specified 'input' containing ciphertext read from the peer.
+    /// Return 0 on success and a non-zero value otherwise.
+    ntsa::Error pushIncomingCipherText(const bdlbb::Blob& input)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Add the specified 'input' containing ciphertext read from the peer.
+    /// Return 0 on success and a non-zero value otherwise.
+    ntsa::Error pushIncomingCipherText(const ntsa::Data& input)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Add the specified 'input' containing plaintext to be sent to the peer.
+    /// Return 0 on success and a non-zero value otherwise.
+    ntsa::Error pushOutgoingPlainText(const bdlbb::Blob& input)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Add the specified 'input' containing plaintext to be sent to the peer.
+    /// Return 0 on success and a non-zero value otherwise.
+    ntsa::Error pushOutgoingPlainText(const ntsa::Data& input)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Pop plaintext read from the peer and append it to the specified
+    /// 'output'. Return 0 on success and a non-zero value otherwise.
+    ntsa::Error popIncomingPlainText(bdlbb::Blob* output)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Pop ciphertext to be read from the peer and append to the specified
+    /// 'output'.
+    ntsa::Error popOutgoingCipherText(bdlbb::Blob* output)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Initiate the shutdown of the session.
+    ntsa::Error shutdown() BSLS_KEYWORD_OVERRIDE;
+
+    /// Return true if plaintext data is ready to be read.
+    bool hasIncomingPlainText() const BSLS_KEYWORD_OVERRIDE;
+
+    /// Return true if ciphertext data is ready to be sent.
+    bool hasOutgoingCipherText() const BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' the source certificate used by the
+    /// encryption session. Return true if such a certicate is defined, and
+    /// false otherwise.
+    bool getSourceCertificate(ntca::EncryptionCertificate* result) const
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' the source certificate used by the
+    /// encryption session. Return true if such a certicate is defined, and
+    /// false otherwise.
+    bool getSourceCertificate(bsl::shared_ptr<ntci::EncryptionCertificate>*
+                                  result) const BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' the remote certificate used by the
+    /// encryption session. Return true if such a certicate is defined, and
+    /// false otherwise.
+    bool getRemoteCertificate(ntca::EncryptionCertificate* result) const
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' the remote certificate used by the
+    /// encryption session. Return true if such a certicate is defined, and
+    /// false otherwise.
+    bool getRemoteCertificate(bsl::shared_ptr<ntci::EncryptionCertificate>*
+                                  result) const BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' the cipher used to encrypt data
+    /// passing through the filter. Return true if such a cipher has been
+    /// negotiated, and false otherwise.
+    bool getCipher(bsl::string* result) const BSLS_KEYWORD_OVERRIDE;
+
+    /// Return true if the handshake is finished, otherwise return false.
+    bool isHandshakeFinished() const BSLS_KEYWORD_OVERRIDE;
+
+    /// Return true if the shutdown has been sent, otherwise return false.
+    bool isShutdownSent() const BSLS_KEYWORD_OVERRIDE;
+
+    /// Return true if the shutdown has been received, otherwise return
+    /// false.
+    bool isShutdownReceived() const BSLS_KEYWORD_OVERRIDE;
+
+    /// Return true if the shutdown is finished, otherwise return false.
+    bool isShutdownFinished() const BSLS_KEYWORD_OVERRIDE;
+
+    /// Return the source certificate used by the encryption session, if
+    /// any.
+    bsl::shared_ptr<ntci::EncryptionCertificate> sourceCertificate() const
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Return the remote certificate used by the encryption session, if
+    /// any.
+    bsl::shared_ptr<ntci::EncryptionCertificate> remoteCertificate() const
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Return the private key used by the encryption session, if any.
+    bsl::shared_ptr<ntci::EncryptionKey> privateKey() const
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' the server name indication, if any.
+    /// Return the error, for example, when no server name indication is
+    /// explicitly requested or accepted.
+    ntsa::Error serverNameIndication(bsl::string* result) const
+        BSLS_KEYWORD_OVERRIDE;
+};
+
+/// Provide utilities for sessions.
+///
+/// @par Thread Safety
+/// This class is thread safe.
+///
+/// @ingroup module_ntctls
+class SessionUtil
+{
+    static ntsa::Error configureHost(
+        X509_VERIFY_PARAM*                                      parameters,
+        const ntca::EncryptionValidation::NullableStringVector& hostVector);
+
+    static ntsa::Error configureHost(
+        X509_VERIFY_PARAM*                              parameters,
+        const ntca::EncryptionValidation::StringVector& hostVector);
+
+    static ntsa::Error configureMail(
+        X509_VERIFY_PARAM*                                      parameters,
+        const ntca::EncryptionValidation::NullableStringVector& mailVector);
+
+    static ntsa::Error configureMail(
+        X509_VERIFY_PARAM*                              parameters,
+        const ntca::EncryptionValidation::StringVector& mailVector);
+
+    static ntsa::Error configureUsage(
+        X509_VERIFY_PARAM*                                     parameters,
+        const ntca::EncryptionValidation::NullableUsageVector& usageVector);
+
+    static ntsa::Error configureUsage(
+        X509_VERIFY_PARAM*                             parameters,
+        const ntca::EncryptionValidation::UsageVector& usageVector);
+
+    static ntsa::Error configureUsage(
+        X509_VERIFY_PARAM* parameters,
+        const ntca::EncryptionValidation::NullableUsageExtended&
+            usageExtended);
+
+    static ntsa::Error configureUsage(
+        X509_VERIFY_PARAM* parameters,
+        const ntca::EncryptionCertificateSubjectKeyUsageExtended&
+            usageExtended);
+
+  public:
+    static ntsa::Error configure(
+        X509_VERIFY_PARAM*                                     parameters,
+        const bdlb::NullableValue<ntca::EncryptionValidation>& validation);
+
+    static ntsa::Error configure(X509_VERIFY_PARAM*                parameters,
+                                 const ntca::EncryptionValidation& validation);
+};
+
+/// Provide a context for authenticating SSL connections.
+///
+/// @par Thread Safety
+/// This class is not thread safe.
+///
+/// @ingroup module_ntctls
+class SessionContext
+{
+    ntctls::Handle<SSL_CTX>                         d_context;
+    bsl::shared_ptr<ntctls::Certificate>            d_certificate_sp;
+    ntctls::CertificateVector                       d_authorities;
+    ntca::EncryptionRole::Value                     d_role;
+    ntca::EncryptionMethod::Value                   d_minMethod;
+    ntca::EncryptionMethod::Value                   d_maxMethod;
+    ntca::EncryptionAuthentication::Value           d_authentication;
+    bdlb::NullableValue<ntca::EncryptionValidation> d_validation;
+    bslma::Allocator*                               d_allocator_p;
+
+  private:
+    SessionContext(const SessionContext&) BSLS_KEYWORD_DELETED;
+    SessionContext& operator=(const SessionContext&) BSLS_KEYWORD_DELETED;
+
+  private:
+    /// Add the private keys, and/or certificate, and/or trusted certficate
+    /// authorities contained in the specified 'resource'. Return the error.
+    ntsa::Error addResource(const ntca::EncryptionResource& resource);
+
+    /// Add the private keys, and/or certificate, and/or trusted certficate
+    /// authorities contained in the specified 'resource'. Return the error.
+    ntsa::Error addResourceList(
+        const ntca::EncryptionResourceVector& resourceList);
+
+    /// Add the identity described in the specified 'certificate' as a
+    /// certificate authority. Return the error.
+    ntsa::Error addCertificateAuthority(
+        const bsl::shared_ptr<ntctls::Certificate>& certificate);
+
+    /// Set the specified 'directoryPath' as the directory from which to load
+    /// certificate authorities. Return the error.
+    ntsa::Error setCertificateAuthorityDirectory(
+        const bsl::string& directoryPath);
+
+    /// Set the directory from which to load certificate authorities to the
+    /// default directory for the system. Return the error.
+    ntsa::Error setCertificateAuthorityDirectoryToDefault();
+
+    /// Trust all certificate authorities installed into the default system
+    /// certificate store.
+    ntsa::Error trustSystemDefaults();
+
+    /// Set the certificate to the specified 'certificate'. Return the error.
+    ntsa::Error setCertificate(
+        const bsl::shared_ptr<ntctls::Certificate>& certificate);
+
+    /// Set the private key to the specified 'privateKey'. Return the error.
+    ntsa::Error setPrivateKey(const bsl::shared_ptr<ntctls::Key>& privateKey);
+
+  public:
+    /// Create a new SSL authentication context. Optionally specify a
+    /// 'basicAllocator' used to supply memory. If 'basicAllocator' is 0, the
+    /// currently installed default allocator is used.
+    explicit SessionContext(bslma::Allocator* basicAllocator = 0);
+
+    /// Destroy this object.
+    ~SessionContext();
+
+    /// Configure the SSL authentication context for the specified 'role'
+    /// according to the specified 'options'. Return the error.
+    ntsa::Error configure(ntca::EncryptionRole::Value    role,
+                          const ntca::EncryptionOptions& options);
+
+    /// The role played by this context when establishing TLS sessions.
+    ntca::EncryptionRole::Value role() const;
+
+    /// The minimum method supported by this context when establishing TLS
+    /// sessions, inclusive.
+    ntca::EncryptionMethod::Value minMethod() const;
+
+    /// The maximum method supported by this context when establishing TLS
+    /// sessions, inclusive.
+    ntca::EncryptionMethod::Value maxMethod() const;
+
+    /// The style of authentication used by this context when establishing
+    /// TLS sessions.
+    ntca::EncryptionAuthentication::Value authentication() const;
+
+    /// Return the certificate validation parameters.
+    const bdlb::NullableValue<ntca::EncryptionValidation>& validation() const;
+
+    /// Return the certificate that identifies the user of this context.
+    bsl::shared_ptr<ntctls::Certificate> certificate() const;
+
+#if 0
+    /// Return the private key of the user of this context.
+    bsl::shared_ptr<ntctls::Key> privateKey() const;
+#endif
+
+    /// Return a handle to the private implementation.
+    void* handle() const;
+
+    /// Return a handle to the native implementation.
+    SSL_CTX* native() const;
+
+    /// Load into the specified 'result' a new context configured for the
+    /// specified 'role' according to the specified 'options'. Optionally
+    /// specify a 'basicAllocator' used to supply memory. If 'basicAllocator'
+    /// is 0, the currently installed default allocator is used. Return the
+    /// error.
+    static ntsa::Error createContext(
+        bsl::shared_ptr<ntctls::SessionContext>* result,
+        ntca::EncryptionRole::Value              role,
+        const ntca::EncryptionOptions&           options,
+        bslma::Allocator*                        basicAllocator = 0);
+};
+
+/// Provide a map of contexts for authenticating SSL connections with specific
+/// server names.
+///
+/// @par Thread Safety
+/// This class is thread safe.
+///
+/// @ingroup module_ntctls
+class SessionManager
+{
+    typedef bsl::map<bsl::string, bsl::shared_ptr<ntctls::SessionContext> >
+        Container;
+
+    bslmt::Mutex                            d_mutex;
+    ntca::EncryptionRole::Value             d_role;
+    bsl::shared_ptr<ntctls::SessionContext> d_context_sp;
+    Container                               d_container;
+    bslma::Allocator*                       d_allocator_p;
+
+    SessionManager(const SessionManager&) BSLS_KEYWORD_DELETED;
+    SessionManager& operator=(const SessionManager&) BSLS_KEYWORD_DELETED;
+
+  public:
+    /// Create a new context map for the specified 'role'. Optionally specify a
+    /// 'basicAllocator' used to supply memory. If 'basicAllocator' is 0, the
+    /// currently installed default allocator is used.
+    explicit SessionManager(ntca::EncryptionRole::Value role,
+                            bslma::Allocator*           basicAllocator = 0);
+
+    /// Destroy this object.
+    ~SessionManager();
+
+    /// Configure the default context with the specified 'options'.
+    ntsa::Error configure(const ntca::EncryptionOptions& options);
+
+    /// Configure a context for the specified 'serverName' the specified
+    /// 'options'. Return the error. Note that 'serverName' may be an IP
+    /// address, domain name, or domain name wildcard such as "*.example.com".
+    /// Also that an empty 'serverName' or a 'serverName' of "*" is interpreted
+    /// as identifying the options for the default context.
+    ntsa::Error configure(const bsl::string&             serverName,
+                          const ntca::EncryptionOptions& options);
+
+    /// Load into the specified 'result' the default context.
+    ntsa::Error lookup(bsl::shared_ptr<ntctls::SessionContext>* result);
+
+    /// Load into the specified 'result' the context for the specified
+    /// 'serverName'. If the specified 'fallback' is true, fallback to the
+    /// default context if no context associated with the 'serverName' is
+    /// found. Return the error. Note that 'serverName' may be an IP address,
+    /// domain name, or domain name wildcard such as "*.example.com". Also that
+    /// an empty 'serverName' or a 'serverName' of "*" is interpreted as
+    /// identifying the options for the default context.
+    ntsa::Error lookup(bsl::shared_ptr<ntctls::SessionContext>* result,
+                       const bsl::string&                       serverName,
+                       bool                                     fallback);
+
+    /// The role played by this context when establishing TLS sessions.
+    ntca::EncryptionRole::Value role() const;
+
+    /// Load into the specified 'result' a new client context map configured
+    /// according to the specified 'options'. Optionally specify a
+    /// 'basicAllocator' used to supply memory. If 'basicAllocator' is 0, the
+    /// currently installed default allocator is used. Return the error.
+    static ntsa::Error createClientSessionManager(
+        bsl::shared_ptr<ntctls::SessionManager>* result,
+        const ntca::EncryptionClientOptions&     options,
+        bslma::Allocator*                        basicAllocator = 0);
+
+    /// Load into the specified 'result' a new client context map configured
+    /// according to the specified 'options'. Optionally specify a
+    /// 'basicAllocator' used to supply memory. If 'basicAllocator' is 0, the
+    /// currently installed default allocator is used. Return the error.
+    static ntsa::Error createServerSessionManager(
+        bsl::shared_ptr<ntctls::SessionManager>* result,
+        const ntca::EncryptionServerOptions&     options,
+        bslma::Allocator*                        basicAllocator = 0);
+};
+
+/// Provide a factory to create an encryptor in the client role.
+///
+/// @par Thread Safety
+/// This class is thread safe.
+///
+/// @ingroup module_ntctls
+class SessionClient : public ntci::EncryptionClient
+{
+    bsl::shared_ptr<ntctls::SessionManager>   d_sessionManager_sp;
+    bsl::shared_ptr<bdlbb::BlobBufferFactory> d_blobBufferFactory_sp;
+    bslma::Allocator*                         d_allocator_p;
+
+  private:
+    SessionClient(const SessionClient&) BSLS_KEYWORD_DELETED;
+    SessionClient& operator=(const SessionClient&) BSLS_KEYWORD_DELETED;
+
+  public:
+    /// Create a new client that establishes TLS session using the specified
+    /// 'sessionManager'. Allocate blob buffers using the specified
+    /// 'blobBufferFactory'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used.
+    SessionClient(
+        const bsl::shared_ptr<ntctls::SessionManager>&   sessionManager,
+        const bsl::shared_ptr<bdlbb::BlobBufferFactory>& blobBufferFactory,
+        bslma::Allocator*                                basicAllocator = 0);
+
+    /// Destroy this object.
+    ~SessionClient() BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a new client-side encryption
+    /// session. Optionally specify a 'basicAllocator' used to supply
+    /// memory. If 'basicAllocator' is 0, the currently installed default
+    /// allocator is used. Return the error.
+    ntsa::Error createEncryption(bsl::shared_ptr<ntci::Encryption>* result,
+                                 bslma::Allocator* basicAllocator = 0)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a new client-side encryption session.
+    /// Allocate blob buffers from the specified 'dataPool'. Optionally specify
+    /// a 'basicAllocator' used to supply memory. If 'basicAllocator' is 0, the
+    /// currently installed default allocator is used. Return the error.
+    ntsa::Error createEncryption(
+        bsl::shared_ptr<ntci::Encryption>*     result,
+        const bsl::shared_ptr<ntci::DataPool>& dataPool,
+        bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a new encryption client with the
+    /// specified 'options'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    static ntsa::Error createEncryptionClient(
+        bsl::shared_ptr<ntci::EncryptionClient>* result,
+        const ntca::EncryptionClientOptions&     options,
+        bslma::Allocator*                        basicAllocator = 0);
+
+    /// Load into the specified 'result' a new encryption client with the
+    /// specified 'options'. Allocate blob buffers using the specified
+    /// 'blobBufferFactory'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    static ntsa::Error createEncryptionClient(
+        bsl::shared_ptr<ntci::EncryptionClient>*         result,
+        const ntca::EncryptionClientOptions&             options,
+        const bsl::shared_ptr<bdlbb::BlobBufferFactory>& blobBufferFactory,
+        bslma::Allocator*                                basicAllocator = 0);
+
+    /// Load into the specified 'result' a new encryption client with the
+    /// specified 'options'. Allocate data containers using the specified
+    /// 'dataPool'. Optionally specify a 'basicAllocator' used to supply
+    /// memory. If 'basicAllocator' is 0, the currently installed default
+    /// allocator is used. Return the error.
+    static ntsa::Error createEncryptionClient(
+        bsl::shared_ptr<ntci::EncryptionClient>* result,
+        const ntca::EncryptionClientOptions&     options,
+        const bsl::shared_ptr<ntci::DataPool>&   dataPool,
+        bslma::Allocator*                        basicAllocator = 0);
+};
+
+/// Provide a factory to create an encryptor in the server role.
+///
+/// @par Thread Safety
+/// This class is thread safe.
+///
+/// @ingroup module_ntctls
+class SessionServer : public ntci::EncryptionServer
+{
+    bsl::shared_ptr<ntctls::SessionManager>   d_sessionManager_sp;
+    bsl::shared_ptr<bdlbb::BlobBufferFactory> d_blobBufferFactory_sp;
+    bslma::Allocator*                         d_allocator_p;
+
+  private:
+    SessionServer(const SessionServer&) BSLS_KEYWORD_DELETED;
+    SessionServer& operator=(const SessionServer&) BSLS_KEYWORD_DELETED;
+
+  public:
+    /// Create a new server that establishes TLS session using the specified
+    /// 'sessionManager'. Allocate blob buffers using the specified
+    /// 'blobBufferFactory'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used.
+    SessionServer(
+        const bsl::shared_ptr<ntctls::SessionManager>&   sessionManager,
+        const bsl::shared_ptr<bdlbb::BlobBufferFactory>& blobBufferFactory,
+        bslma::Allocator*                                basicAllocator = 0);
+
+    /// Destroy this object.
+    ~SessionServer() BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a new server-side encryption session.
+    /// Optionally specify a 'basicAllocator' used to supply memory. If
+    /// 'basicAllocator' is 0, the currently installed default allocator is
+    /// used. Return the error.
+    ntsa::Error createEncryption(bsl::shared_ptr<ntci::Encryption>* result,
+                                 bslma::Allocator* basicAllocator = 0)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a new server-side encryption session.
+    /// Allocate blob buffers from the specified 'dataPool'. Optionally specify
+    /// a 'basicAllocator' used to supply memory. If 'basicAllocator' is 0, the
+    /// currently installed default allocator is used. Return the error.
+    ntsa::Error createEncryption(
+        bsl::shared_ptr<ntci::Encryption>*     result,
+        const bsl::shared_ptr<ntci::DataPool>& dataPool,
+        bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a new encryption client with the
+    /// specified 'options'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    static ntsa::Error createEncryptionServer(
+        bsl::shared_ptr<ntci::EncryptionServer>* result,
+        const ntca::EncryptionServerOptions&     options,
+        bslma::Allocator*                        basicAllocator = 0);
+
+    /// Load into the specified 'result' a new encryption client with the
+    /// specified 'options'. Allocate blob buffers using the specified
+    /// 'blobBufferFactory'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    static ntsa::Error createEncryptionServer(
+        bsl::shared_ptr<ntci::EncryptionServer>*         result,
+        const ntca::EncryptionServerOptions&             options,
+        const bsl::shared_ptr<bdlbb::BlobBufferFactory>& blobBufferFactory,
+        bslma::Allocator*                                basicAllocator = 0);
+
+    /// Load into the specified 'result' a new encryption client with the
+    /// specified 'options'. Allocate data containers using the specified
+    /// 'dataPool'. Optionally specify a 'basicAllocator' used to supply
+    /// memory. If 'basicAllocator' is 0, the currently installed default
+    /// allocator is used. Return the error.
+    static ntsa::Error createEncryptionServer(
+        bsl::shared_ptr<ntci::EncryptionServer>* result,
+        const ntca::EncryptionServerOptions&     options,
+        const bsl::shared_ptr<ntci::DataPool>&   dataPool,
+        bslma::Allocator*                        basicAllocator = 0);
+};
+
+// Uncomment to implement reads from the SSL state machine using a new
+// blob buffer allocated for each read (very inefficient).
+// #define NTCTLS_SESSION_ALWAYS_ALLOCATE_NEW_BLOB_BUFFER 1
+
+// Uncomment to log all state transitions from the TLS state machine.
+#define NTCTLS_SESSION_LOG_CALLBACK_VERBOSE 1
+
+// Uncomment to log all errors from the TLS state machine.
+// #define NTCTLS_SESSION_LOG_ERROR_VERBOSE 1
+
+#define NTCTLS_SESSION_LOG_ERROR(phrase)                                      \
+    do {                                                                      \
+        bsl::string description;                                              \
+        ntctls::Internal::drainErrorQueue(&description);                      \
+        if (!description.empty()) {                                           \
+            NTCI_LOG_ERROR("%s: %s", phrase, description.c_str());            \
+        }                                                                     \
+        else {                                                                \
+            NTCI_LOG_ERROR("%s", phrase);                                     \
+        }                                                                     \
+    } while (false)
+
+#define NTCTLS_SESSION_LOG_DEBUG(phrase)                                      \
+    do {                                                                      \
+        bsl::string description;                                              \
+        ntctls::Internal::drainErrorQueue(&description);                      \
+        if (!description.empty()) {                                           \
+            NTCI_LOG_DEBUG("%s: %s", phrase, description.c_str());            \
+        }                                                                     \
+        else {                                                                \
+            NTCI_LOG_DEBUG("%s", phrase);                                     \
+        }                                                                     \
+    } while (false)
+
+namespace {
+
+// clang-format off
+
+// The list of supported ciphers when using TLSv1.0 through TLSv1.2. This list
+// is the default recommendations from OpenSSL 1.1.x.
+const char k_DEFAULT_CIPHER_SPEC[] =
+    "ECDHE-ECDSA-AES128-GCM-SHA256:"
+    "ECDHE-RSA-AES128-GCM-SHA256:"
+    "ECDHE-ECDSA-AES256-GCM-SHA384:"
+    "ECDHE-RSA-AES256-GCM-SHA384:"
+    "ECDHE-ECDSA-CHACHA20-POLY1305:"
+    "ECDHE-RSA-CHACHA20-POLY1305";
+
+// The list of supported cipher suites when using TLSv1.3 and later. This list
+// is the default recommendations from OpenSSL 1.1.x.
+const char k_DEFAULT_CIPHER_SUITES[] =
+    "TLS_AES_256_GCM_SHA384:"
+    "TLS_CHACHA20_POLY1305_SHA256:"
+    "TLS_AES_128_GCM_SHA256";
+
+// clang-format on
+
+bsls::SpinLock s_userDataIndexLock    = BSLS_SPINLOCK_UNLOCKED;
+static int     s_userDataIndex        = 0;
+static bool    s_userDataIndexDefined = false;
+
+extern "C" int ntctls_context_sni_callback(SSL* ssl, int* al, void* userData)
+{
+    // SSL_TLSEXT_ERR_OK
+    //     This is used to indicate that the servername requested by the client
+    //     has been accepted. Typically a server will call SSL_set_SSL_CTX()
+    //     in the callback to set up a different configuration for the selected
+    //     servername in this case.
+    //
+    // SSL_TLSEXT_ERR_ALERT_FATAL
+    //     In this case the servername requested by the client is not accepted
+    //     and the handshake will be aborted. The value of the alert to be used
+    //     should be stored in the location pointed to by the al parameter to
+    //     the callback. By default this value is initialised to
+    //     SSL_AD_UNRECOGNIZED_NAME.
+    //
+    // SSL_TLSEXT_ERR_NOACK
+    //     This return value indicates that the servername is not accepted by
+    //     the server. No alerts are sent and the server will not acknowledge
+    //     the requested servername.
+
+    NTCCFG_WARNING_UNUSED(userData);
+
+    ntsa::Error error;
+
+    *al = SSL_AD_UNRECOGNIZED_NAME;
+
+    if (ssl == 0) {
+        return SSL_TLSEXT_ERR_ALERT_FATAL;
+    }
+
+    const int serverNameType = SSL_get_servername_type(ssl);
+
+    if (serverNameType == -1) {
+        return SSL_TLSEXT_ERR_OK;
+    }
+
+    if (serverNameType != TLSEXT_NAMETYPE_host_name) {
+        return SSL_TLSEXT_ERR_OK;
+    }
+
+    const char* serverNamePtr = SSL_get_servername(ssl, serverNameType);
+    if (serverNamePtr == 0) {
+        return SSL_TLSEXT_ERR_OK;
+    }
+
+    const bsl::size_t serverNameLength = bsl::strlen(serverNamePtr);
+    if (serverNameLength == 0) {
+        return SSL_TLSEXT_ERR_OK;
+    }
+
+    bsl::string serverName(serverNamePtr, serverNamePtr + serverNameLength);
+
+    ntctls::Session* session = reinterpret_cast<ntctls::Session*>(
+        SSL_get_ex_data(ssl, s_userDataIndex));
+
+    if (session == 0) {
+        return SSL_TLSEXT_ERR_ALERT_FATAL;
+    }
+
+    bool found = false;
+
+    error = session->activate(&found, serverName);
+
+    if (error) {
+        return SSL_TLSEXT_ERR_ALERT_FATAL;
+    }
+
+    if (!found) {
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+
+    return SSL_TLSEXT_ERR_OK;
+}
+
+extern "C" int ntctls_context_verify_callback(X509_STORE_CTX* x509StoreCtx,
+                                              void*           userData)
+{
+    // Verify the certificate chain according to the certificate store defined
+    // in the specified 'parameters'.  Return 1 to indicate success (i.e., the
+    // certificate is verified) and 0 to indicate verification failure.
+
+    NTCCFG_WARNING_UNUSED(userData);
+
+    NTCI_LOG_CONTEXT();
+
+    enum { e_SUCCESS = 1, e_FAILURE = 0 };
+
+    ntsa::Error error;
+
+    if (x509StoreCtx == 0) {
+        NTCTLS_SESSION_LOG_ERROR(
+            "Failed to verify certificate: invalid certificate store context");
+        return e_FAILURE;
+    }
+
+    SSL* ssl = reinterpret_cast<SSL*>(
+        X509_STORE_CTX_get_ex_data(x509StoreCtx,
+                                   SSL_get_ex_data_X509_STORE_CTX_idx()));
+    if (ssl == 0) {
+        NTCTLS_SESSION_LOG_ERROR(
+            "Failed to verify certificate: invalid session");
+        return e_FAILURE;
+    }
+
+    ntctls::Session* session = reinterpret_cast<ntctls::Session*>(
+        SSL_get_ex_data(ssl, s_userDataIndex));
+    if (session == 0) {
+        NTCTLS_SESSION_LOG_ERROR(
+            "Failed to verify certificate: invalid session");
+        return e_FAILURE;
+    }
+
+    error = session->authenticate(x509StoreCtx);
+    if (error) {
+        return e_FAILURE;
+    }
+
+    return e_SUCCESS;
+}
+
+// This struct provides utilities for allocating blob buffers. This struct
+// is thread safe.
+struct BlobBufferUtil {
+    // Return the number of bytes to allocate to accomodate a new read into a
+    // read queue having the specified 'size' and 'capacity' to satisfy the
+    // specified 'lowWatermark', ensuring at least the specified
+    // 'minReceiveSize' but no more than the specified 'maxReceiveSize',
+    // inclusive.
+    static size_t calculateNumBytesToAllocate(size_t size,
+                                              size_t capacity,
+                                              size_t lowWatermark,
+                                              size_t minReceiveSize,
+                                              size_t maxReceiveSize);
+
+    // Load more capacity buffers allocated from the specified
+    // 'blobBufferFactory' into the specified 'readQueue' to accomodate a new
+    // read into the unused capacity buffers of the 'readQueue' to satisfy the
+    // specified 'lowWatermark', ensuring at least the specified 'minReadSize'
+    // but no more than the specified 'maxReceiveSize', inclusive.
+    static void reserveCapacity(bdlbb::Blob*              readQueue,
+                                bdlbb::BlobBufferFactory* blobBufferFactory,
+                                void*                     metrics,
+                                size_t                    lowWatermark,
+                                size_t                    minReceiveSize,
+                                size_t                    maxReceiveSize);
+};
+
+size_t BlobBufferUtil::calculateNumBytesToAllocate(size_t size,
+                                                   size_t capacity,
+                                                   size_t lowWatermark,
+                                                   size_t minReceiveSize,
+                                                   size_t maxReceiveSize)
+{
+    BSLS_ASSERT(capacity >= size);
+    BSLS_ASSERT(minReceiveSize > 0);
+    BSLS_ASSERT(maxReceiveSize > 0);
+
+    if (minReceiveSize > maxReceiveSize) {
+        minReceiveSize = maxReceiveSize;
+    }
+
+    bsl::size_t numBytesToAllocate = 0;
+    if (lowWatermark > capacity) {
+        numBytesToAllocate = lowWatermark - capacity;
+    }
+
+    bsl::size_t numBytesToBeAvailable = (capacity - size) + numBytesToAllocate;
+
+    if (numBytesToBeAvailable < minReceiveSize) {
+        bsl::size_t numBytesToAdjust  = minReceiveSize - numBytesToBeAvailable;
+        numBytesToAllocate           += numBytesToAdjust;
+    }
+
+    if (numBytesToBeAvailable > maxReceiveSize) {
+        bsl::size_t numBytesToAdjust = numBytesToBeAvailable - maxReceiveSize;
+        if (numBytesToAdjust > numBytesToAllocate) {
+            numBytesToAllocate = 0;
+        }
+        else {
+            numBytesToAllocate -= numBytesToAdjust;
+        }
+    }
+
+    BSLS_ASSERT((capacity - size) + numBytesToAllocate >= 1);
+    BSLS_ASSERT(numBytesToAllocate <= maxReceiveSize);
+
+    return numBytesToAllocate;
+}
+
+void BlobBufferUtil::reserveCapacity(
+    bdlbb::Blob*              readQueue,
+    bdlbb::BlobBufferFactory* blobBufferFactory,
+    void*                     metrics,
+    size_t                    lowWatermark,
+    size_t                    minReceiveSize,
+    size_t                    maxReceiveSize)
+{
+    BSLS_ASSERT(minReceiveSize > 0);
+    BSLS_ASSERT(maxReceiveSize > 0);
+
+    size_t numBytesToAllocate =
+        BlobBufferUtil::calculateNumBytesToAllocate(readQueue->length(),
+                                                    readQueue->totalSize(),
+                                                    lowWatermark,
+                                                    minReceiveSize,
+                                                    maxReceiveSize);
+
+    bsl::size_t numBytesAllocated = 0;
+    while (numBytesAllocated < numBytesToAllocate) {
+        bdlbb::BlobBuffer buffer;
+        blobBufferFactory->allocate(&buffer);
+
+        bsl::size_t blobBufferCapacity = buffer.size();
+
+        readQueue->appendBuffer(buffer);
+        numBytesAllocated += blobBufferCapacity;
+
+#if 1
+        NTCCFG_WARNING_UNUSED(metrics);
+#else
+        if (metrics) {
+            metrics->logBlobBufferAllocation(blobBufferCapacity);
+        }
+#endif
+    }
+
+    BSLS_ASSERT(static_cast<bsl::size_t>(readQueue->totalSize() -
+                                         readQueue->length()) >=
+                bsl::min(minReceiveSize, maxReceiveSize));
+}
+
+enum {
+    // Enumerates the OpenSSL shutdown state flags.
+
+    TLS_SHUTDOWN_SENT     = 0x01,
+    TLS_SHUTDOWN_RECEIVED = 0x02
+};
+
+#if NTCTLS_SESSION_LOG_CALLBACK_VERBOSE
+#define NTCTLS_SESSION_LOG_CALLBACK(message) NTCI_LOG_DEBUG(message)
+#define NTCTLS_SESSION_LOG_CALLBACK_STATE(message, state)                     \
+    NTCI_LOG_DEBUG(message, state)
+#else
+#define NTCTLS_SESSION_LOG_CALLBACK(message)
+#define NTCTLS_SESSION_LOG_CALLBACK_STATE(message, state)
+#endif
+
+#if NTCTLS_SESSION_LOG_CHECK_ERROR_VERBOSE
+#define NTCTLS_SESSION_LOG_CHECK_ERROR(message) NTCI_LOG_DEBUG(message)
+#else
+#define NTCTLS_SESSION_LOG_CHECK_ERROR(message)
+#endif
+
+void infoCallback(const SSL* ssl, int where, int ret)
+{
+    NTCCFG_WARNING_UNUSED(ssl);
+    NTCCFG_WARNING_UNUSED(ret);
+
+    NTCI_LOG_CONTEXT();
+
+    if ((where & SSL_CB_HANDSHAKE_START) != 0) {
+        NTCTLS_SESSION_LOG_CALLBACK("SSL_CB_HANDSHAKE_START");
+    }
+
+    if ((where & SSL_CB_HANDSHAKE_DONE) != 0) {
+        NTCTLS_SESSION_LOG_CALLBACK("SSL_CB_HANDSHAKE_DONE");
+    }
+
+    if ((where & SSL_CB_LOOP) != 0) {
+        NTCTLS_SESSION_LOG_CALLBACK_STATE("SSL_CB_LOOP: %s",
+                                          SSL_state_string_long(ssl));
+    }
+
+    if ((where & SSL_CB_EXIT) != 0) {
+        NTCTLS_SESSION_LOG_CALLBACK("SSL_CB_EXIT");
+    }
+
+    if ((where & SSL_CB_READ) != 0) {
+        NTCTLS_SESSION_LOG_CALLBACK("SSL_CB_READ");
+    }
+
+    if ((where & SSL_CB_WRITE) != 0) {
+        NTCTLS_SESSION_LOG_CALLBACK("SSL_CB_WRITE");
+    }
+
+    if ((where & SSL_CB_ALERT) != 0) {
+        NTCTLS_SESSION_LOG_CALLBACK("SSL_CB_ALERT");
+    }
+}
+
+bool check(SSL* ssl, int result)
+{
+    int error = SSL_get_error(ssl, result);
+
+    if (error == SSL_ERROR_NONE) {
+        NTCTLS_SESSION_LOG_CHECK_ERROR("SSL_ERROR_NONE");
+        return true;
+    }
+
+    if (error == SSL_ERROR_WANT_READ) {
+        NTCTLS_SESSION_LOG_CHECK_ERROR("SSL_ERROR_WANT_READ");
+        return true;
+    }
+
+    if (error == SSL_ERROR_WANT_WRITE) {
+        NTCTLS_SESSION_LOG_CHECK_ERROR("SSL_ERROR_WANT_WRITE");
+        return true;
+    }
+
+    if (error == SSL_ERROR_SYSCALL) {
+        NTCTLS_SESSION_LOG_CHECK_ERROR("SSL_ERROR_SYSCALL");
+        return false;
+    }
+
+    if (error == SSL_ERROR_SSL) {
+        NTCTLS_SESSION_LOG_CHECK_ERROR("SSL_ERROR_SSL");
+        return false;
+    }
+
+    if (error == SSL_ERROR_WANT_X509_LOOKUP) {
+        NTCTLS_SESSION_LOG_CHECK_ERROR("SSL_ERROR_WANT_X509_LOOKUP");
+        return false;
+    }
+
+    if (error == SSL_ERROR_ZERO_RETURN) {
+        NTCTLS_SESSION_LOG_CHECK_ERROR("SSL_ERROR_ZERO_RETURN");
+        return true;
+    }
+
+    if (error == SSL_ERROR_WANT_CONNECT) {
+        NTCTLS_SESSION_LOG_CHECK_ERROR("SSL_ERROR_WANT_CONNECT");
+        return false;
+    }
+
+    if (error == SSL_ERROR_WANT_ACCEPT) {
+        NTCTLS_SESSION_LOG_CHECK_ERROR("SSL_ERROR_WANT_ACCEPT");
+        return false;
+    }
+
+    NTCTLS_SESSION_LOG_CHECK_ERROR("SSL_ERROR_UNKNOWN");
+    return false;
+}
+
+}  // close unnamed namespace
+
+ntsa::Error Session::init()
+{
+    NTCI_LOG_CONTEXT();
+
+    ntsa::Error error;
+    int         rc;
+
+    if (d_ssl_p) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    {
+        bsls::SpinLockGuard lock(&s_userDataIndexLock);
+        if (!s_userDataIndexDefined) {
+            s_userDataIndex = SSL_get_ex_new_index(0, 0, NULL, NULL, NULL);
+            s_userDataIndexDefined = true;
+        }
+    }
+
+    if (d_sessionManager_sp->role() == ntca::EncryptionRole::e_CLIENT) {
+        bdlb::NullableValue<bsl::string> serverNameIndication =
+            d_upgradeOptions.serverName();
+
+        if (!serverNameIndication.isNull()) {
+            error = d_sessionManager_sp->lookup(&d_context_sp,
+                                                serverNameIndication.value(),
+                                                true);
+            if (error) {
+                return error;
+            }
+        }
+        else {
+            error = d_sessionManager_sp->lookup(&d_context_sp);
+            if (error) {
+                return error;
+            }
+        }
+
+        if (!d_context_sp) {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        d_ssl_p = SSL_new(d_context_sp->native());
+        if (!d_ssl_p) {
+            bsl::string description;
+            Internal::drainErrorQueue(&description);
+
+            NTCI_LOG_DEBUG("Failed to allocate SSL session: %s",
+                           description.c_str());
+
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        rc = SSL_set_ex_data(d_ssl_p, s_userDataIndex, this);
+        if (rc == 0) {
+            bsl::string description;
+            Internal::drainErrorQueue(&description);
+
+            NTCI_LOG_DEBUG("Failed to set SSL session user data: %s",
+                           description.c_str());
+
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        SSL_set_connect_state(d_ssl_p);
+
+        if (!serverNameIndication.isNull()) {
+            rc =
+                SSL_set_tlsext_host_name(d_ssl_p,
+                                         serverNameIndication.value().c_str());
+            if (rc == 0) {
+                bsl::string description;
+                Internal::drainErrorQueue(&description);
+
+                NTCI_LOG_DEBUG(
+                    "Failed to set server name indication to '%s': %s",
+                    serverNameIndication.value().c_str(),
+                    description.c_str());
+
+                return ntsa::Error(ntsa::Error::e_INVALID);
+            }
+
+            d_serverNameIndication = serverNameIndication.value();
+        }
+    }
+    else {
+        error = d_sessionManager_sp->lookup(&d_context_sp);
+        if (error) {
+            return error;
+        }
+
+        if (!d_context_sp) {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        d_ssl_p = SSL_new(d_context_sp->native());
+        if (!d_ssl_p) {
+            bsl::string description;
+            Internal::drainErrorQueue(&description);
+
+            NTCI_LOG_DEBUG("Failed to allocate SSL session: %s",
+                           description.c_str());
+
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        rc = SSL_set_ex_data(d_ssl_p, s_userDataIndex, this);
+        if (rc == 0) {
+            bsl::string description;
+            Internal::drainErrorQueue(&description);
+
+            NTCI_LOG_DEBUG("Failed to set SSL session user data: %s",
+                           description.c_str());
+
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        SSL_set_accept_state(d_ssl_p);
+    }
+
+    SSL_set_quiet_shutdown(d_ssl_p, 0);
+
+    ntctls::Handle<BIO> incomingStream(
+        ntctls::Internal::createStreamRaw(&d_incomingCipherText));
+
+    if (!incomingStream) {
+        bsl::string description;
+        Internal::drainErrorQueue(&description);
+
+        NTCI_LOG_DEBUG("Failed to allocate incoming stream BIO: %s",
+                       description.c_str());
+
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    ntctls::Handle<BIO> outgoingStream(
+        ntctls::Internal::createStreamRaw(&d_outgoingCipherText));
+
+    if (!outgoingStream) {
+        bsl::string description;
+        Internal::drainErrorQueue(&description);
+
+        NTCI_LOG_DEBUG("Failed to allocate outgoing stream BIO: %s",
+                       description.c_str());
+
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    BIO_set_nbio(incomingStream.get(), 1);
+    BIO_set_nbio(outgoingStream.get(), 1);
+
+    SSL_set_bio(d_ssl_p, incomingStream.release(), outgoingStream.release());
+
+    SSL_set_info_callback(d_ssl_p, &infoCallback);
+
+    return ntsa::Error();
+}
+
+ntsa::Error Session::process(LockGuard* lock)
+{
+    NTCI_LOG_CONTEXT();
+
+    if (!d_ssl_p) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if (d_outgoingPlainText.length() > 0) {
+        const int numOutgoingPlainTextBuffers =
+            d_outgoingPlainText.numDataBuffers();
+
+        int numOutgoingPlainTextBytesWritten = 0;
+
+        for (int i = 0; i < numOutgoingPlainTextBuffers; ++i) {
+            const bdlbb::BlobBuffer& outgoingPlainTextBuffer =
+                d_outgoingPlainText.buffer(i);
+
+            const char* outgoingPlainTextBufferData =
+                outgoingPlainTextBuffer.data();
+
+            const int outgoingPlainTextBufferSize =
+                i == numOutgoingPlainTextBuffers - 1
+                    ? d_outgoingPlainText.lastDataBufferLength()
+                    : outgoingPlainTextBuffer.size();
+
+            const int n = SSL_write(d_ssl_p,
+                                    outgoingPlainTextBufferData,
+                                    outgoingPlainTextBufferSize);
+
+            if (!check(d_ssl_p, n)) {
+                bsl::string description;
+                Internal::drainErrorQueue(&description);
+
+                NTCI_LOG_DEBUG("Failed to write SSL data: %s",
+                               description.c_str());
+
+                if (d_handshakeCallback) {
+                    ntci::Encryption::HandshakeCallback handshakeCallback =
+                        d_handshakeCallback;
+
+                    d_handshakeCallback =
+                        ntci::Encryption::HandshakeCallback();
+
+                    lock->release()->unlock();
+
+                    handshakeCallback(
+                        ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED),
+                        bsl::shared_ptr<ntci::EncryptionCertificate>(),
+                        description);
+                }
+
+                return ntsa::Error(ntsa::Error::e_INVALID);
+            }
+
+            if (n > 0) {
+                numOutgoingPlainTextBytesWritten += n;
+            }
+
+            if (n == 0 || n != outgoingPlainTextBufferSize) {
+                break;
+            }
+        }
+
+        if (numOutgoingPlainTextBytesWritten > 0) {
+            bdlbb::BlobUtil::erase(&d_outgoingPlainText,
+                                   0,
+                                   numOutgoingPlainTextBytesWritten);
+        }
+    }
+
+    while (true) {
+#if NTCTLS_SESSION_ALWAYS_ALLOCATE_NEW_BLOB_BUFFER
+        bdlbb::BlobBuffer incomingPlainTextBuffer;
+        d_blobBufferFactory_sp->allocate(&incomingPlainTextBuffer);
+
+        const int incomingPlainTextBufferCapacity =
+            incomingPlainTextBuffer.size();
+
+        const int n = SSL_read(d_ssl_p,
+                               incomingPlainTextBuffer.data(),
+                               incomingPlainTextBufferCapacity);
+#else
+        if (d_incomingPlainText.length() == d_incomingPlainText.totalSize()) {
+            BlobBufferUtil::reserveCapacity(
+                &d_incomingPlainText,
+                d_blobBufferFactory_sp.get(),
+                0,
+                0,
+                NTCCFG_DEFAULT_STREAM_SOCKET_MIN_INCOMING_TRANSFER_SIZE,
+                NTCCFG_DEFAULT_STREAM_SOCKET_MAX_INCOMING_TRANSFER_SIZE);
+        }
+
+        ntsa::MutableBufferSequence<ntsa::MutableBuffer> mutableBufferSequence(
+            &d_incomingPlainText);
+
+        ntsa::MutableBufferSequence<ntsa::MutableBuffer>::Iterator
+            mutableBufferSequenceCurrent = mutableBufferSequence.begin();
+
+        ntsa::MutableBufferSequence<ntsa::MutableBuffer>::Iterator
+            mutableBufferSequenceEnd = mutableBufferSequence.end();
+
+        BSLS_ASSERT(mutableBufferSequenceCurrent != mutableBufferSequenceEnd);
+
+        ntsa::MutableBuffer mutableBuffer = *mutableBufferSequenceCurrent;
+
+        void* incomingPlainTextBufferData = mutableBuffer.data();
+
+        int incomingPlainTextBufferCapacity;
+        if (mutableBuffer.size() <=
+            NTCCFG_WARNING_PROMOTE(bsl::size_t,
+                                   bsl::numeric_limits<int>::max()))
+        {
+            incomingPlainTextBufferCapacity =
+                NTCCFG_WARNING_NARROW(int, mutableBuffer.size());
+        }
+        else {
+            incomingPlainTextBufferCapacity = bsl::numeric_limits<int>::max();
+        }
+
+        const int n = SSL_read(d_ssl_p,
+                               incomingPlainTextBufferData,
+                               incomingPlainTextBufferCapacity);
+#endif
+
+        if (!check(d_ssl_p, n)) {
+            bsl::string description;
+            Internal::drainErrorQueue(&description);
+
+            NTCI_LOG_DEBUG("Failed to read SSL data: %s", description.c_str());
+
+            if (d_handshakeCallback) {
+                ntci::Encryption::HandshakeCallback handshakeCallback =
+                    d_handshakeCallback;
+
+                d_handshakeCallback = ntci::Encryption::HandshakeCallback();
+
+                lock->release()->unlock();
+
+                handshakeCallback(
+                    ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED),
+                    bsl::shared_ptr<ntci::EncryptionCertificate>(),
+                    description);
+            }
+
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        if (n <= 0) {
+            BSLS_ASSERT(SSL_get_error(d_ssl_p, n) == SSL_ERROR_WANT_READ ||
+                        SSL_get_error(d_ssl_p, n) == SSL_ERROR_WANT_WRITE ||
+                        SSL_get_error(d_ssl_p, n) == SSL_ERROR_ZERO_RETURN);
+            break;
+        }
+
+        BSLS_ASSERT(n > 0);
+        BSLS_ASSERT(n <= incomingPlainTextBufferCapacity);
+        BSLS_ASSERT(SSL_get_error(d_ssl_p, n) == SSL_ERROR_NONE);
+
+#if NTCTLS_SESSION_ALWAYS_ALLOCATE_NEW_BLOB_BUFFER
+        incomingPlainTextBuffer.setSize(n);
+        d_incomingPlainText.appendDataBuffer(incomingPlainTextBuffer);
+#else
+        d_incomingPlainText.setLength(d_incomingPlainText.length() + n);
+#endif
+    }
+
+    if (d_handshakeCallback) {
+        OSSL_HANDSHAKE_STATE state = SSL_get_state(d_ssl_p);
+        if (state == TLS_ST_OK) {
+            X509* sourceX509 = SSL_get_certificate(d_ssl_p);
+            if (sourceX509) {
+                X509_up_ref(sourceX509);
+                d_sourceCertificate_sp.createInplace(d_allocator_p,
+                                                     sourceX509,
+                                                     d_allocator_p);
+            }
+
+            X509* remoteX509 = SSL_get_peer_certificate(d_ssl_p);
+            if (remoteX509) {
+                d_remoteCertificate_sp.createInplace(d_allocator_p,
+                                                     remoteX509,
+                                                     d_allocator_p);
+            }
+
+            {
+                ntci::Encryption::HandshakeCallback handshakeCallback =
+                    d_handshakeCallback;
+
+                d_handshakeCallback = ntci::Encryption::HandshakeCallback();
+
+                lock->release()->unlock();
+
+                handshakeCallback(ntsa::Error(), d_remoteCertificate_sp, "");
+            }
+        }
+    }
+
+    return ntsa::Error();
+}
+
+Session::Session(
+    const bsl::shared_ptr<ntctls::SessionManager>&   sessionManager,
+    const bsl::shared_ptr<bdlbb::BlobBufferFactory>& blobBufferFactory,
+    bslma::Allocator*                                basicAllocator)
+: d_mutex()
+, d_context_sp()
+, d_sessionManager_sp(sessionManager)
+, d_blobBufferFactory_sp(blobBufferFactory)
+, d_sourceCertificate_sp()
+, d_remoteCertificate_sp()
+, d_serverNameIndication(basicAllocator)
+, d_ssl_p(0)
+, d_incomingCipherText(blobBufferFactory.get(), basicAllocator)
+, d_outgoingCipherText(blobBufferFactory.get(), basicAllocator)
+, d_incomingPlainText(blobBufferFactory.get(), basicAllocator)
+, d_outgoingPlainText(blobBufferFactory.get(), basicAllocator)
+, d_upgradeOptions(basicAllocator)
+, d_handshakeCallback(NTCCFG_FUNCTION_INIT(basicAllocator))
+, d_allocator_p(bslma::Default::allocator(basicAllocator))
+{
+}
+
+Session::~Session()
+{
+    if (d_ssl_p) {
+        SSL_free(d_ssl_p);
+    }
+}
+
+ntsa::Error Session::activate(bool* found, const bsl::string& serverName)
+{
+    NTCI_LOG_CONTEXT();
+
+    ntsa::Error error;
+
+    *found = false;
+
+    if (d_context_sp->role() == ntca::EncryptionRole::e_CLIENT) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if (d_ssl_p == 0) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    bsl::shared_ptr<ntctls::SessionContext> context;
+    error = d_sessionManager_sp->lookup(&context, serverName, false);
+    if (error) {
+        error = d_sessionManager_sp->lookup(&context);
+        if (error) {
+            NTCI_LOG_DEBUG("Failed to find server name '%s'",
+                           serverName.c_str());
+            return error;
+        }
+    }
+    else {
+        *found = true;
+    }
+
+    if (context != d_context_sp) {
+        SSL_CTX* newSslCtx = SSL_set_SSL_CTX(d_ssl_p, context->native());
+        if (newSslCtx == 0) {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        d_context_sp = context;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Session::authenticate(X509_STORE_CTX* x509StoreCtx)
+{
+    NTCI_LOG_CONTEXT();
+
+    ntsa::Error error;
+    int         rc;
+
+    if (x509StoreCtx == 0) {
+        NTCI_LOG_ERROR("Failed to verify certificate: "
+                       "invalid certificate store context");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    X509_VERIFY_PARAM* param = X509_STORE_CTX_get0_param(x509StoreCtx);
+    if (param == 0) {
+        NTCI_LOG_ERROR("Failed to verify certificate: "
+                       "invalid certificate store context parameters");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    const bdlb::NullableValue<ntca::EncryptionValidation>& validation =
+        d_upgradeOptions.validation().has_value()
+            ? d_upgradeOptions.validation()
+            : d_context_sp->validation();
+
+    error = ntctls::SessionUtil::configure(param, validation);
+    if (error) {
+        NTCI_LOG_ERROR("Failed to verify certificate: "
+                       "failed to set parameters");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    rc = X509_verify_cert(x509StoreCtx);
+
+    int errorCode = X509_STORE_CTX_get_error(x509StoreCtx);
+    int depth     = X509_STORE_CTX_get_error_depth(x509StoreCtx);
+
+    X509* x509 = X509_STORE_CTX_get_current_cert(x509StoreCtx);
+
+    if (x509 != 0 && depth == 0) {
+        if (rc == 1) {
+            error = this->authenticate(x509StoreCtx, x509);
+            if (error) {
+                errorCode = X509_V_ERR_APPLICATION_VERIFICATION;
+                X509_STORE_CTX_set_error(x509StoreCtx, errorCode);
+                error = ntsa::Error();
+            }
+        }
+
+        if (errorCode == X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT) {
+            bool allowSelfSigned = false;
+            if (validation.has_value()) {
+                if (validation.value().allowSelfSigned().has_value()) {
+                    allowSelfSigned =
+                        validation.value().allowSelfSigned().value();
+                }
+            }
+
+            if (allowSelfSigned) {
+                errorCode = X509_V_OK;
+                X509_STORE_CTX_set_error(x509StoreCtx, errorCode);
+                error = ntsa::Error();
+            }
+        }
+    }
+
+    if (errorCode != X509_V_OK) {
+        bsl::string description;
+        ntctls::Internal::drainErrorQueue(&description);
+
+        NTCI_LOG_DEBUG("Failed to verify certificate: %s: %s",
+                       X509_verify_cert_error_string(errorCode),
+                       description.c_str());
+
+        return ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED);
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Session::authenticate(X509_STORE_CTX* x509StoreCtx, X509* x509)
+{
+    NTCI_LOG_CONTEXT();
+
+    if (x509StoreCtx == 0) {
+        NTCI_LOG_ERROR(
+            "Failed to verify certificate: invalid certificate store context");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if (x509 == 0) {
+        NTCTLS_SESSION_LOG_ERROR(
+            "Failed to verify certificate: invalid certificate");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    const bdlb::NullableValue<ntca::EncryptionValidation>& validation =
+        d_upgradeOptions.validation().has_value()
+            ? d_upgradeOptions.validation()
+            : d_context_sp->validation();
+
+    if (validation.has_value()) {
+        if (validation.value().callback().has_value()) {
+            bsl::shared_ptr<ntctls::Certificate> certificate;
+            certificate.createInplace(d_allocator_p,
+                                      X509_dup(x509),
+                                      d_allocator_p);
+
+            const bool isValid =
+                validation.value().callback().value()(certificate->record());
+
+            if (!isValid) {
+                bsl::stringstream ss;
+                ss << "Failed to verify the authenticity of "
+                   << certificate->record();
+
+                NTCI_LOG_DEBUG("%s", ss.str().c_str());
+
+                return ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED);
+            }
+        }
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Session::initiateHandshake(const HandshakeCallback& callback)
+{
+    return this->initiateHandshake(ntca::UpgradeOptions(), callback);
+}
+
+ntsa::Error Session::initiateHandshake(
+    const ntca::UpgradeOptions& upgradeOptions,
+    const HandshakeCallback&    callback)
+{
+    NTCI_LOG_CONTEXT();
+
+    LockGuard lock(&d_mutex);
+
+    ntsa::Error error;
+    int         rc;
+
+    d_upgradeOptions = upgradeOptions;
+
+    if (!d_ssl_p) {
+        error = this->init();
+        if (error) {
+            return error;
+        }
+    }
+    else {
+        rc = SSL_clear(d_ssl_p);
+        if (rc != 1) {
+            bsl::string description;
+            Internal::drainErrorQueue(&description);
+
+            NTCI_LOG_DEBUG("Failed to reset the TLS session for reuse: %s",
+                           description.c_str());
+
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        BSLS_ASSERT(d_incomingCipherText.length() == 0);
+        BSLS_ASSERT(d_incomingPlainText.length() == 0);
+        BSLS_ASSERT(d_outgoingCipherText.length() == 0);
+        BSLS_ASSERT(d_outgoingPlainText.length() == 0);
+    }
+
+    d_handshakeCallback = callback;
+
+    rc = SSL_do_handshake(d_ssl_p);
+
+    if (rc != 1) {
+        if (rc < 0) {
+            int error = SSL_get_error(d_ssl_p, rc);
+
+            if (error == SSL_ERROR_WANT_READ || error == SSL_ERROR_WANT_WRITE)
+            {
+                return this->process(&lock);
+            }
+        }
+
+        bsl::string description;
+        Internal::drainErrorQueue(&description);
+
+        NTCI_LOG_DEBUG("Failed to initiate TLS handshake: %s",
+                       description.c_str());
+
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Session::pushIncomingCipherText(const bdlbb::Blob& input)
+{
+    LockGuard lock(&d_mutex);
+
+    if (!d_ssl_p) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if ((SSL_get_shutdown(d_ssl_p) & TLS_SHUTDOWN_RECEIVED) != 0) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    bdlbb::BlobUtil::append(&d_incomingCipherText, input);
+
+    return this->process(&lock);
+}
+
+ntsa::Error Session::pushIncomingCipherText(const ntsa::Data& input)
+{
+    LockGuard lock(&d_mutex);
+
+    if (!d_ssl_p) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if ((SSL_get_shutdown(d_ssl_p) & TLS_SHUTDOWN_RECEIVED) != 0) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    ntsa::DataUtil::append(&d_incomingCipherText, input);
+
+    return this->process(&lock);
+}
+
+ntsa::Error Session::pushOutgoingPlainText(const bdlbb::Blob& input)
+{
+    LockGuard lock(&d_mutex);
+
+    if (!d_ssl_p) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if ((SSL_get_shutdown(d_ssl_p) & TLS_SHUTDOWN_SENT) != 0) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    bdlbb::BlobUtil::append(&d_outgoingPlainText, input);
+
+    return this->process(&lock);
+}
+
+ntsa::Error Session::pushOutgoingPlainText(const ntsa::Data& input)
+{
+    LockGuard lock(&d_mutex);
+
+    if (!d_ssl_p) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if ((SSL_get_shutdown(d_ssl_p) & TLS_SHUTDOWN_SENT) != 0) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if (input.isFile()) {
+        bsl::size_t inputSize = input.size();
+        bsl::size_t outputSize =
+            ntsa::DataUtil::append(&d_outgoingPlainText, input);
+        if (inputSize != outputSize) {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+    else {
+        ntsa::DataUtil::append(&d_outgoingPlainText, input);
+    }
+
+    return this->process(&lock);
+}
+
+ntsa::Error Session::popIncomingPlainText(bdlbb::Blob* output)
+{
+    LockGuard lock(&d_mutex);
+
+    if (!d_ssl_p) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if (d_incomingPlainText.length() > 0) {
+        bdlbb::BlobUtil::append(output, d_incomingPlainText);
+        bdlbb::BlobUtil::erase(&d_incomingPlainText,
+                               0,
+                               d_incomingPlainText.length());
+    }
+
+    return this->process(&lock);
+}
+
+ntsa::Error Session::popOutgoingCipherText(bdlbb::Blob* output)
+{
+    LockGuard lock(&d_mutex);
+
+    if (!d_ssl_p) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if (d_outgoingCipherText.length() > 0) {
+        bdlbb::BlobUtil::append(output, d_outgoingCipherText);
+        bdlbb::BlobUtil::erase(&d_outgoingCipherText,
+                               0,
+                               d_outgoingCipherText.length());
+    }
+
+    return this->process(&lock);
+}
+
+ntsa::Error Session::shutdown()
+{
+    NTCI_LOG_CONTEXT();
+
+    LockGuard lock(&d_mutex);
+
+    if (!d_ssl_p) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if ((SSL_get_shutdown(d_ssl_p) & TLS_SHUTDOWN_SENT) != 0) {
+        // Redundant shutdown is not an error.
+        return ntsa::Error();
+    }
+
+    enum { k_SHUTDOWN_STARTING = 0, k_SHUTDOWN_COMPLETE = 1 };
+
+    int rc = SSL_shutdown(d_ssl_p);
+
+    if (rc != k_SHUTDOWN_STARTING && rc != k_SHUTDOWN_COMPLETE) {
+        bsl::string description;
+        Internal::drainErrorQueue(&description);
+
+        NTCI_LOG_DEBUG("Failed to initiate TLS shutdown: %s",
+                       description.c_str());
+
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    return this->process(&lock);
+}
+
+bool Session::hasIncomingPlainText() const
+{
+    LockGuard lock(&d_mutex);
+
+    return d_incomingPlainText.length() > 0;
+}
+
+bool Session::hasOutgoingCipherText() const
+{
+    LockGuard lock(&d_mutex);
+
+    return d_outgoingCipherText.length() > 0;
+}
+
+bool Session::getSourceCertificate(ntca::EncryptionCertificate* result) const
+{
+    LockGuard lock(&d_mutex);
+
+    if (d_sourceCertificate_sp) {
+        d_sourceCertificate_sp->unwrap(result);
+        return true;
+    }
+
+    return false;
+}
+
+bool Session::getSourceCertificate(
+    bsl::shared_ptr<ntci::EncryptionCertificate>* result) const
+{
+    LockGuard lock(&d_mutex);
+
+    if (d_sourceCertificate_sp) {
+        *result = d_sourceCertificate_sp;
+        return true;
+    }
+
+    return false;
+}
+
+bool Session::getRemoteCertificate(ntca::EncryptionCertificate* result) const
+{
+    LockGuard lock(&d_mutex);
+
+    if (d_remoteCertificate_sp) {
+        d_remoteCertificate_sp->unwrap(result);
+        return true;
+    }
+
+    return false;
+}
+
+bool Session::getRemoteCertificate(
+    bsl::shared_ptr<ntci::EncryptionCertificate>* result) const
+{
+    LockGuard lock(&d_mutex);
+
+    if (d_remoteCertificate_sp) {
+        *result = d_remoteCertificate_sp;
+        return true;
+    }
+
+    return false;
+}
+
+bool Session::getCipher(bsl::string* result) const
+{
+    LockGuard lock(&d_mutex);
+
+    if (!d_ssl_p) {
+        return false;
+    }
+
+    const SSL_CIPHER* cipher = SSL_get_current_cipher(d_ssl_p);
+    if (!cipher) {
+        return false;
+    }
+
+    char buffer[256];
+    SSL_CIPHER_description(cipher, buffer, sizeof buffer);
+
+    bsl::size_t size = bsl::strlen(buffer);
+
+    const char* current = buffer;
+    const char* end     = buffer + size;
+    bool        space   = false;
+
+    result->clear();
+    result->reserve(size);
+
+    while (current != end) {
+        char ch = *current++;
+        if (bdlb::CharType::isSpace(ch)) {
+            if (ch != '\n' && !space) {
+                result->push_back(ch);
+                space = true;
+            }
+        }
+        else {
+            result->push_back(ch);
+            space = false;
+        }
+    }
+
+    return true;
+}
+
+bool Session::isHandshakeFinished() const
+{
+    LockGuard lock(&d_mutex);
+
+    if (!d_ssl_p) {
+        return false;
+    }
+
+    return static_cast<bool>(SSL_is_init_finished(d_ssl_p));
+}
+
+bool Session::isShutdownSent() const
+{
+    LockGuard lock(&d_mutex);
+
+    if (!d_ssl_p) {
+        return false;
+    }
+
+    int shutdownState = SSL_get_shutdown(d_ssl_p);
+
+    if ((shutdownState & TLS_SHUTDOWN_SENT) != 0) {
+        return true;
+    }
+
+    return false;
+}
+
+bool Session::isShutdownReceived() const
+{
+    LockGuard lock(&d_mutex);
+
+    if (!d_ssl_p) {
+        return false;
+    }
+
+    int shutdownState = SSL_get_shutdown(d_ssl_p);
+
+    if ((shutdownState & TLS_SHUTDOWN_RECEIVED) != 0) {
+        return true;
+    }
+
+    return false;
+}
+
+bool Session::isShutdownFinished() const
+{
+    LockGuard lock(&d_mutex);
+
+    if (!d_ssl_p) {
+        return false;
+    }
+
+    int shutdownState = SSL_get_shutdown(d_ssl_p);
+
+    if ((shutdownState & TLS_SHUTDOWN_SENT) == 0) {
+        return false;
+    }
+
+    if ((shutdownState & TLS_SHUTDOWN_RECEIVED) == 0) {
+        return false;
+    }
+
+    return true;
+}
+
+bsl::shared_ptr<ntci::EncryptionCertificate> Session::sourceCertificate() const
+{
+    LockGuard lock(&d_mutex);
+    return d_sourceCertificate_sp;
+}
+
+bsl::shared_ptr<ntci::EncryptionCertificate> Session::remoteCertificate() const
+{
+    LockGuard lock(&d_mutex);
+    return d_remoteCertificate_sp;
+}
+
+bsl::shared_ptr<ntci::EncryptionKey> Session::privateKey() const
+{
+    return bsl::shared_ptr<ntci::EncryptionKey>();
+}
+
+ntsa::Error Session::serverNameIndication(bsl::string* result) const
+{
+    LockGuard lock(&d_mutex);
+
+    result->clear();
+
+    if (!d_serverNameIndication.isNull()) {
+        *result = d_serverNameIndication.value();
+    }
+
+    return ntsa::Error(ntsa::Error::e_EOF);
+}
+
+ntsa::Error SessionUtil::configureHost(
+    X509_VERIFY_PARAM*                                      parameters,
+    const ntca::EncryptionValidation::NullableStringVector& hostVector)
+{
+    if (hostVector.has_value()) {
+        return ntctls::SessionUtil::configureHost(parameters,
+                                                  hostVector.value());
+    }
+    else {
+        return ntsa::Error();
+    }
+}
+
+ntsa::Error SessionUtil::configureHost(
+    X509_VERIFY_PARAM*                              parameters,
+    const ntca::EncryptionValidation::StringVector& hostVector)
+{
+    NTCI_LOG_CONTEXT();
+
+    ntsa::Error error;
+    int         rc;
+
+    for (bsl::size_t i = 0; i < hostVector.size(); ++i) {
+        const bsl::string& text = hostVector[i];
+
+        ntsa::IpAddress ipAddress;
+        if (ipAddress.parse(text)) {
+            if (ipAddress.isV4()) {
+                unsigned char buffer[4];
+                ipAddress.v4().copyTo(buffer, sizeof buffer);
+                rc = X509_VERIFY_PARAM_set1_ip(parameters,
+                                               buffer,
+                                               sizeof buffer);
+            }
+            else if (ipAddress.isV6()) {
+                unsigned char buffer[16];
+                ipAddress.v6().copyTo(buffer, sizeof buffer);
+                rc = X509_VERIFY_PARAM_set1_ip(parameters,
+                                               buffer,
+                                               sizeof buffer);
+            }
+            else {
+                return ntsa::Error(ntsa::Error::e_INVALID);
+            }
+
+            if (rc == 0) {
+                NTCTLS_SESSION_LOG_ERROR(
+                    "Failed to add IP address verification");
+                return ntsa::Error(ntsa::Error::e_INVALID);
+            }
+        }
+        else {
+            rc = X509_VERIFY_PARAM_add1_host(parameters,
+                                             text.c_str(),
+                                             text.size());
+
+            if (rc == 0) {
+                NTCTLS_SESSION_LOG_ERROR(
+                    "Failed to add domain name verification");
+                return ntsa::Error(ntsa::Error::e_INVALID);
+            }
+
+            rc = X509_VERIFY_PARAM_set_flags(
+                parameters,
+                X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+            if (rc == 0) {
+                NTCTLS_SESSION_LOG_ERROR("Failed to set verification flags");
+                return ntsa::Error(ntsa::Error::e_INVALID);
+            }
+        }
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error SessionUtil::configureMail(
+    X509_VERIFY_PARAM*                                      parameters,
+    const ntca::EncryptionValidation::NullableStringVector& mailVector)
+{
+    if (mailVector.has_value()) {
+        return ntctls::SessionUtil::configureMail(parameters,
+                                                  mailVector.value());
+    }
+    else {
+        return ntsa::Error();
+    }
+}
+
+ntsa::Error SessionUtil::configureMail(
+    X509_VERIFY_PARAM*                              parameters,
+    const ntca::EncryptionValidation::StringVector& mailVector)
+{
+    NTCI_LOG_CONTEXT();
+
+    ntsa::Error error;
+    int         rc;
+
+    for (bsl::size_t i = 0; i < mailVector.size(); ++i) {
+        const bsl::string& text = mailVector[i];
+
+        rc = X509_VERIFY_PARAM_set1_email(parameters,
+                                          text.c_str(),
+                                          text.size());
+        if (rc == 0) {
+            NTCTLS_SESSION_LOG_ERROR("Failed to add email verification");
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error SessionUtil::configureUsage(
+    X509_VERIFY_PARAM*                                     parameters,
+    const ntca::EncryptionValidation::NullableUsageVector& usageVector)
+{
+    if (usageVector.has_value()) {
+        return ntctls::SessionUtil::configureUsage(parameters,
+                                                   usageVector.value());
+    }
+    else {
+        return ntsa::Error();
+    }
+}
+
+ntsa::Error SessionUtil::configureUsage(
+    X509_VERIFY_PARAM*                             parameters,
+    const ntca::EncryptionValidation::UsageVector& usageVector)
+{
+    NTCCFG_WARNING_UNUSED(parameters);
+    NTCCFG_WARNING_UNUSED(usageVector);
+
+    return ntsa::Error();
+}
+
+ntsa::Error SessionUtil::configureUsage(
+    X509_VERIFY_PARAM*                                       parameters,
+    const ntca::EncryptionValidation::NullableUsageExtended& usageExtended)
+{
+    if (usageExtended.has_value()) {
+        return ntctls::SessionUtil::configureUsage(parameters,
+                                                   usageExtended.value());
+    }
+    else {
+        return ntsa::Error();
+    }
+}
+
+ntsa::Error SessionUtil::configureUsage(
+    X509_VERIFY_PARAM*                                        parameters,
+    const ntca::EncryptionCertificateSubjectKeyUsageExtended& usageExtended)
+{
+    NTCCFG_WARNING_UNUSED(parameters);
+    NTCCFG_WARNING_UNUSED(usageExtended);
+
+    return ntsa::Error();
+}
+
+ntsa::Error SessionUtil::configure(
+    X509_VERIFY_PARAM*                                     parameters,
+    const bdlb::NullableValue<ntca::EncryptionValidation>& validation)
+{
+    if (validation.has_value()) {
+        return ntctls::SessionUtil::configure(parameters, validation.value());
+    }
+    else {
+        return ntsa::Error();
+    }
+}
+
+ntsa::Error SessionUtil::configure(
+    X509_VERIFY_PARAM*                parameters,
+    const ntca::EncryptionValidation& validation)
+{
+    ntsa::Error error;
+
+    error = ntctls::SessionUtil::configureHost(parameters, validation.host());
+    if (error) {
+        return error;
+    }
+
+    error = ntctls::SessionUtil::configureMail(parameters, validation.mail());
+    if (error) {
+        return error;
+    }
+
+    error =
+        ntctls::SessionUtil::configureUsage(parameters, validation.usage());
+    if (error) {
+        return error;
+    }
+
+    error = ntctls::SessionUtil::configureUsage(parameters,
+                                                validation.usageExtensions());
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+SessionContext::SessionContext(bslma::Allocator* basicAllocator)
+: d_context()
+, d_certificate_sp()
+, d_authorities(basicAllocator)
+, d_role(ntca::EncryptionRole::e_CLIENT)
+, d_minMethod(ntca::EncryptionMethod::e_DEFAULT)
+, d_maxMethod(ntca::EncryptionMethod::e_DEFAULT)
+, d_authentication(ntca::EncryptionAuthentication::e_DEFAULT)
+, d_validation(basicAllocator)
+, d_allocator_p(bslma::Default::allocator(basicAllocator))
+{
+}
+
+SessionContext::~SessionContext()
+{
+}
+
+ntsa::Error SessionContext::configure(ntca::EncryptionRole::Value    role,
+                                      const ntca::EncryptionOptions& options)
+{
+    NTCI_LOG_CONTEXT();
+
+    ntsa::Error error;
+    int         rc;
+
+    if (d_context) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    d_role           = role;
+    d_minMethod      = options.minMethod();
+    d_minMethod      = options.maxMethod();
+    d_authentication = options.authentication();
+    d_validation     = options.validation();
+
+    if (d_minMethod == ntca::EncryptionMethod::e_DEFAULT) {
+        d_minMethod = ntca::EncryptionMethod::e_TLS_V1_2;
+    }
+
+    if (d_maxMethod == ntca::EncryptionMethod::e_DEFAULT) {
+        d_maxMethod = ntca::EncryptionMethod::e_TLS_V1_X;
+    }
+
+    if (d_authentication == ntca::EncryptionAuthentication::e_DEFAULT) {
+        if (d_role == ntca::EncryptionRole::e_CLIENT) {
+            d_authentication = ntca::EncryptionAuthentication::e_VERIFY;
+        }
+        else if (d_role == ntca::EncryptionRole::e_SERVER) {
+            d_authentication = ntca::EncryptionAuthentication::e_NONE;
+        }
+        else {
+            NTCTLS_SESSION_LOG_ERROR("Unsupported role");
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    // Create the SSL context in the desired role.
+
+    const SSL_METHOD* method = 0;
+    if (role == ntca::EncryptionRole::e_CLIENT) {
+        method = TLS_client_method();
+    }
+    else if (role == ntca::EncryptionRole::e_SERVER) {
+        method = TLS_server_method();
+    }
+    else {
+        NTCTLS_SESSION_LOG_ERROR("Unsupported role");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    d_context.reset(SSL_CTX_new(method));
+    if (!d_context) {
+        NTCTLS_SESSION_LOG_ERROR("Failed to allocate SSL context");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    // Explicitly disable SSLv2 and SSLv3. These methods are never supported.
+
+    SSL_CTX_set_options(d_context.get(), SSL_OP_NO_SSLv2);
+    SSL_CTX_set_options(d_context.get(), SSL_OP_NO_SSLv3);
+
+    // Set the minimum supported version.
+
+    if (d_minMethod == ntca::EncryptionMethod::e_TLS_V1_0) {
+        NTCTLS_SESSION_LOG_ERROR("TLSv1.0 is not supported");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+    else if (d_minMethod == ntca::EncryptionMethod::e_TLS_V1_1) {
+        NTCTLS_SESSION_LOG_ERROR("TLSv1.1 is not supported");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+    else if (d_minMethod == ntca::EncryptionMethod::e_TLS_V1_2) {
+        SSL_CTX_set_min_proto_version(d_context.get(), TLS1_2_VERSION);
+    }
+    else if (d_minMethod == ntca::EncryptionMethod::e_TLS_V1_3) {
+        SSL_CTX_set_min_proto_version(d_context.get(), TLS1_3_VERSION);
+    }
+    else {
+        SSL_CTX_set_min_proto_version(d_context.get(), TLS1_2_VERSION);
+    }
+
+    // Set the maximum supported version.
+
+    if (d_maxMethod == ntca::EncryptionMethod::e_TLS_V1_0) {
+        NTCTLS_SESSION_LOG_ERROR("TLSv1.0 is not supported");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+    else if (d_maxMethod == ntca::EncryptionMethod::e_TLS_V1_1) {
+        NTCTLS_SESSION_LOG_ERROR("TLSv1.1 is not supported");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+    else if (d_maxMethod == ntca::EncryptionMethod::e_TLS_V1_2) {
+        SSL_CTX_set_max_proto_version(d_context.get(), TLS1_2_VERSION);
+    }
+    else if (d_maxMethod == ntca::EncryptionMethod::e_TLS_V1_3) {
+        SSL_CTX_set_max_proto_version(d_context.get(), TLS1_3_VERSION);
+    }
+    else {
+        SSL_CTX_set_max_proto_version(d_context.get(), TLS1_3_VERSION);
+    }
+
+    // Disable usage of compression.
+
+    SSL_CTX_set_options(d_context.get(), SSL_OP_NO_COMPRESSION);
+
+    // Always create a new key when using tmp_dh parameters.
+
+    SSL_CTX_set_options(d_context.get(), SSL_OP_SINGLE_DH_USE);
+
+    // Always create a new key when using tmp_ecdh parameters.
+
+    SSL_CTX_set_options(d_context.get(), SSL_OP_SINGLE_ECDH_USE);
+
+    // Make it possible to retry SSL_write() with changed buffer location (the
+    // buffer contents must stay the same).  This is required because on
+    // non-blocking writes, a copy of the write buffer is made to a chararray.
+
+    SSL_CTX_set_mode(d_context.get(), SSL_MODE_ENABLE_PARTIAL_WRITE);
+
+    // Allow SSL_write(..., n) to return r with 0 < r < n (i.e. report success
+    // when just a single record has been written). When not set (the default),
+    // SSL_write() will only report success once the complete chunk was
+    // written.  Once SSL_write() returns with r, r bytes have been
+    // successfully written and the next call to SSL_write() must only send the
+    // n-r bytes left, imitating the behavior of write().
+
+    SSL_CTX_set_mode(d_context.get(), SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+
+    // Perform full duplex shutdown.
+
+    SSL_CTX_set_quiet_shutdown(d_context.get(), 0);
+
+    // Configure elliptic curve selection.
+
+    SSL_CTX_set1_curves_list(d_context.get(), "P-384:P-256");
+
+    // Disable temporary Diffie-Hellman parameters.
+
+    SSL_CTX_set_dh_auto(d_context.get(), 0);
+
+    // Disable session caching.
+
+    SSL_CTX_set_session_cache_mode(d_context.get(), SSL_SESS_CACHE_OFF);
+
+    // Set the ciphers supported for TLSv1.0 through TLSv1.2.
+
+    rc = SSL_CTX_set_cipher_list(d_context.get(), k_DEFAULT_CIPHER_SPEC);
+    if (rc == 0) {
+        NTCTLS_SESSION_LOG_ERROR(
+            "Failed to configure SSL context cipher spec");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    // Set the cipher suites supported for TLSv1.3 and later.
+
+    rc = SSL_CTX_set_ciphersuites(d_context.get(), k_DEFAULT_CIPHER_SUITES);
+    if (rc == 0) {
+        NTCTLS_SESSION_LOG_ERROR(
+            "Failed to configure SSL context cipher suites");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    // Set the certificate verification behavior.
+
+    if (d_authentication == ntca::EncryptionAuthentication::e_NONE) {
+        SSL_CTX_set_verify(d_context.get(), SSL_VERIFY_NONE, 0);
+    }
+    else if (d_authentication == ntca::EncryptionAuthentication::e_VERIFY) {
+        SSL_CTX_set_verify(d_context.get(),
+                           SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+                           0);
+        SSL_CTX_set_cert_verify_callback(d_context.get(),
+                                         &ntctls_context_verify_callback,
+                                         this);
+    }
+    else {
+        NTCTLS_SESSION_LOG_ERROR("Unsupported authentication mode");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if (d_role == ntca::EncryptionRole::e_SERVER) {
+        SSL_CTX_set_tlsext_servername_callback(d_context.get(),
+                                               &ntctls_context_sni_callback);
+    }
+
+    // Add the certificates and keys used by this context.
+
+    error = this->addResourceList(options.resources());
+    if (error) {
+        return error;
+    }
+
+    if (!options.authorityDirectory().isNull()) {
+        error = this->setCertificateAuthorityDirectory(
+            options.authorityDirectory().value());
+        if (error) {
+            return error;
+        }
+    }
+    else {
+        error = this->setCertificateAuthorityDirectoryToDefault();
+        if (error) {
+            return error;
+        }
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error SessionContext::addResource(
+    const ntca::EncryptionResource& resource)
+{
+    NTCI_LOG_CONTEXT();
+
+    ntsa::Error error;
+
+    if (!d_context) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    ntctls::Resource resourceLoader(d_allocator_p);
+
+    ntca::EncryptionResourceOptions options;
+    if (!resource.options().isNull()) {
+        options = resource.options().value();
+    }
+
+    if (resource.descriptor().isCertificate()) {
+        const ntca::EncryptionCertificate& certificate =
+            resource.descriptor().certificate();
+
+        if (certificate.isAuthority()) {
+            error = resourceLoader.addCertificateAuthority(certificate);
+            if (error) {
+                return error;
+            }
+        }
+        else {
+            error = resourceLoader.setCertificate(certificate);
+            if (error) {
+                return error;
+            }
+        }
+    }
+    else if (resource.descriptor().isKey()) {
+        const ntca::EncryptionKey& privateKey = resource.descriptor().key();
+        error = resourceLoader.setPrivateKey(privateKey);
+        if (error) {
+            return error;
+        }
+    }
+    else if (resource.descriptor().isPath()) {
+        bsl::fstream fs(resource.descriptor().path().c_str(),
+                        bsl::ios_base::in);
+        if (!fs) {
+            error = ntsa::Error::last();
+            NTCI_LOG_ERROR("Failed to open resource file '%s': %s",
+                           resource.descriptor().path().c_str(),
+                           error.text().c_str());
+            return error;
+        }
+
+        error = resourceLoader.decode(fs.rdbuf(), options);
+        if (error) {
+            NTCI_LOG_ERROR("Failed to decode resource file '%s': %s",
+                           resource.descriptor().path().c_str(),
+                           error.text().c_str());
+            return error;
+        }
+    }
+    else if (resource.descriptor().isData()) {
+        if (resource.descriptor().data().empty()) {
+            NTCI_LOG_ERROR("Failed to decode resource: no data");
+            return error;
+        }
+
+        bdlsb::FixedMemInStreamBuf isb(&resource.descriptor().data().front(),
+                                       resource.descriptor().data().size());
+
+        error = resourceLoader.decode(&isb, options);
+        if (error) {
+            NTCI_LOG_ERROR("Failed to decode resource: %s",
+                           error.text().c_str());
+            return error;
+        }
+    }
+    else {
+        NTCI_LOG_ERROR("Failed to decode resource: unsupported descriptor");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    bsl::vector<bsl::shared_ptr<ntci::EncryptionCertificate> > caList;
+    error = resourceLoader.getCertificateAuthoritySet(&caList);
+    if (!error) {
+        for (bsl::size_t i = 0; i < caList.size(); ++i) {
+            bsl::shared_ptr<ntctls::Certificate> concreteCertificate;
+            error = ntctls::Resource::convert(&concreteCertificate, caList[i]);
+            if (error) {
+                NTCI_LOG_ERROR("Failed to decode resource: invalid driver");
+                return error;
+            }
+
+            error = this->addCertificateAuthority(concreteCertificate);
+            if (error) {
+                return error;
+            }
+        }
+    }
+
+    bsl::shared_ptr<ntci::EncryptionKey> privateKey;
+    error = resourceLoader.getPrivateKey(&privateKey);
+    if (!error) {
+        bsl::shared_ptr<ntctls::Key> concretePrivateKey;
+        error = ntctls::Resource::convert(&concretePrivateKey, privateKey);
+        if (error) {
+            NTCI_LOG_ERROR("Failed to decode resource: invalid driver");
+            return error;
+        }
+
+        error = this->setPrivateKey(concretePrivateKey);
+        if (error) {
+            return error;
+        }
+    }
+
+    bsl::shared_ptr<ntci::EncryptionCertificate> certificate;
+    error = resourceLoader.getCertificate(&certificate);
+    if (!error) {
+        bsl::shared_ptr<ntctls::Certificate> concreteCertificate;
+        error = ntctls::Resource::convert(&concreteCertificate, certificate);
+        if (error) {
+            NTCI_LOG_ERROR("Failed to decode resource: invalid driver");
+            return error;
+        }
+
+        error = this->setCertificate(concreteCertificate);
+        if (error) {
+            return error;
+        }
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error SessionContext::addResourceList(
+    const ntca::EncryptionResourceVector& resourceList)
+{
+    ntsa::Error error;
+
+    if (!d_context) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    for (ntca::EncryptionResourceVector::const_iterator it =
+             resourceList.begin();
+         it != resourceList.end();
+         ++it)
+    {
+        const ntca::EncryptionResource& resource = *it;
+
+        error = this->addResource(resource);
+        if (error) {
+            return error;
+        }
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error SessionContext::addCertificateAuthority(
+    const bsl::shared_ptr<ntctls::Certificate>& certificate)
+{
+    NTCI_LOG_CONTEXT();
+
+    int rc;
+
+    if (!d_context) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    X509_STORE* store = SSL_CTX_get_cert_store(d_context.get());
+    if (store == 0) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    rc = X509_STORE_add_cert(store, certificate->native());
+    if (rc == 0) {
+        NTCTLS_SESSION_LOG_ERROR("Failed add certificate authority");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    d_authorities.push_back(certificate);
+
+    return ntsa::Error();
+}
+
+ntsa::Error SessionContext::setCertificateAuthorityDirectory(
+    const bsl::string& directoryPath)
+{
+    NTCI_LOG_CONTEXT();
+
+    int rc;
+
+    if (!d_context) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    rc = SSL_CTX_load_verify_locations(d_context.get(),
+                                       0,
+                                       directoryPath.c_str());
+    if (rc == 0) {
+        NTCTLS_SESSION_LOG_ERROR("Failed add certificate authority directory");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error SessionContext::trustSystemDefaults()
+{
+#if defined(BSLS_PLATFORM_OS_WINDOWS)
+
+    NTCI_LOG_CONTEXT();
+
+    int rc;
+
+    if (!d_context) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    X509_STORE* store = SSL_CTX_get_cert_store(d_context.get());
+    BSLS_ASSERT(store);
+
+    HCERTSTORE systemStore = CertOpenSystemStore(0, "ROOT");
+    if (systemStore == 0) {
+        return ntsa::Error::last();
+    }
+
+    PCCERT_CONTEXT certificateContext = 0;
+
+    while (true) {
+        certificateContext =
+            CertEnumCertificatesInStore(systemStore, certificateContext);
+        if (certificateContext == 0) {
+            break;
+        }
+
+        X509* x509 = d2i_X509(
+            0,
+            (const unsigned char**)(&certificateContext->pbCertEncoded),
+            static_cast<long>(certificateContext->cbCertEncoded));
+
+        if (x509) {
+            rc = X509_STORE_add_cert(store, x509);
+            if (rc == 0) {
+                X509_free(x509);
+                return ntsa::Error(ntsa::Error::e_INVALID);
+            }
+
+            X509_free(x509);
+        }
+    }
+
+    CertFreeCertificateContext(certificateContext);
+    CertCloseStore(systemStore, 0);
+
+    return ntsa::Error();
+
+#else
+
+    // Note: On non-Windows platforms, the default CAs are assumed to solely
+    // reside in the default OpenSSL CA directory, and not augmented by CAs in
+    // any other locations.
+
+    return ntsa::Error();
+
+#endif
+}
+
+ntsa::Error SessionContext::setCertificateAuthorityDirectoryToDefault()
+{
+    NTCI_LOG_CONTEXT();
+
+    ntsa::Error error;
+    int         rc;
+
+    if (!d_context) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    rc = SSL_CTX_set_default_verify_paths(d_context.get());
+    if (rc == 0) {
+        NTCTLS_SESSION_LOG_ERROR("Failed add certificate authority directory");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    error = this->trustSystemDefaults();
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error SessionContext::setCertificate(
+    const bsl::shared_ptr<ntctls::Certificate>& certificate)
+{
+    NTCI_LOG_CONTEXT();
+
+    int rc;
+
+    if (!d_context) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    rc = SSL_CTX_use_certificate(d_context.get(), certificate->native());
+    if (rc == 0) {
+        NTCTLS_SESSION_LOG_ERROR("Failed to set certificate");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    d_certificate_sp = certificate;
+
+    return ntsa::Error();
+}
+
+ntsa::Error SessionContext::setPrivateKey(
+    const bsl::shared_ptr<ntctls::Key>& privateKey)
+{
+    NTCI_LOG_CONTEXT();
+
+    int rc;
+
+    if (!d_context) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    rc = SSL_CTX_use_PrivateKey(d_context.get(), privateKey->native());
+    if (rc == 0) {
+        NTCTLS_SESSION_LOG_ERROR("Failed to set private key");
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    return ntsa::Error();
+}
+
+ntca::EncryptionRole::Value SessionContext::role() const
+{
+    return d_role;
+}
+
+ntca::EncryptionMethod::Value SessionContext::minMethod() const
+{
+    return d_minMethod;
+}
+
+ntca::EncryptionMethod::Value SessionContext::maxMethod() const
+{
+    return d_maxMethod;
+}
+
+ntca::EncryptionAuthentication::Value SessionContext::authentication() const
+{
+    return d_authentication;
+}
+
+const bdlb::NullableValue<ntca::EncryptionValidation>& SessionContext::
+    validation() const
+{
+    return d_validation;
+}
+
+bsl::shared_ptr<ntctls::Certificate> SessionContext::certificate() const
+{
+    return d_certificate_sp;
+}
+
+void* SessionContext::handle() const
+{
+    return d_context.get();
+}
+
+SSL_CTX* SessionContext::native() const
+{
+    return d_context.get();
+}
+
+ntsa::Error SessionContext::createContext(
+    bsl::shared_ptr<ntctls::SessionContext>* result,
+    ntca::EncryptionRole::Value              role,
+    const ntca::EncryptionOptions&           options,
+    bslma::Allocator*                        basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::SessionContext> context;
+    context.createInplace(allocator, allocator);
+
+    error = context->configure(role, options);
+    if (error) {
+        return error;
+    }
+
+    *result = context;
+    return ntsa::Error();
+}
+
+SessionManager::SessionManager(ntca::EncryptionRole::Value role,
+                               bslma::Allocator*           basicAllocator)
+: d_mutex()
+, d_role(role)
+, d_context_sp()
+, d_container(basicAllocator)
+, d_allocator_p(bslma::Default::allocator(basicAllocator))
+{
+}
+
+SessionManager::~SessionManager()
+{
+}
+
+ntsa::Error SessionManager::configure(const ntca::EncryptionOptions& options)
+{
+    ntsa::Error error;
+
+    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+
+    d_context_sp.reset();
+
+    error = ntctls::SessionContext::createContext(&d_context_sp,
+                                                  d_role,
+                                                  options,
+                                                  d_allocator_p);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error SessionManager::configure(const bsl::string& serverName,
+                                      const ntca::EncryptionOptions& options)
+{
+    ntsa::Error error;
+
+    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+
+    if (serverName.empty() || serverName == "*") {
+        d_context_sp.reset();
+
+        error = ntctls::SessionContext::createContext(&d_context_sp,
+                                                      d_role,
+                                                      options,
+                                                      d_allocator_p);
+        if (error) {
+            return error;
+        }
+    }
+    else {
+        bsl::shared_ptr<ntctls::SessionContext>& context =
+            d_container[serverName];
+
+        if (context) {
+            context.reset();
+        }
+
+        error = ntctls::SessionContext::createContext(&context,
+                                                      d_role,
+                                                      options,
+                                                      d_allocator_p);
+        if (error) {
+            return error;
+        }
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error SessionManager::lookup(
+    bsl::shared_ptr<ntctls::SessionContext>* result)
+{
+    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+    *result = d_context_sp;
+    return ntsa::Error();
+}
+
+ntsa::Error SessionManager::lookup(
+    bsl::shared_ptr<ntctls::SessionContext>* result,
+    const bsl::string&                       serverName,
+    bool                                     fallback)
+{
+    ntsa::Error error;
+
+    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+
+    if (serverName.empty() || serverName == "*") {
+        *result = d_context_sp;
+    }
+    else {
+        Container::const_iterator it = d_container.find(serverName);
+        if (it == d_container.end()) {
+            if (fallback) {
+                *result = d_context_sp;
+            }
+            else {
+                return ntsa::Error(ntsa::Error::e_EOF);
+            }
+        }
+        else {
+            *result = it->second;
+        }
+    }
+
+    return ntsa::Error();
+}
+
+ntca::EncryptionRole::Value SessionManager::role() const
+{
+    return d_role;
+}
+
+ntsa::Error SessionManager::createClientSessionManager(
+    bsl::shared_ptr<ntctls::SessionManager>* result,
+    const ntca::EncryptionClientOptions&     options,
+    bslma::Allocator*                        basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::SessionManager> sessionManager;
+    sessionManager.createInplace(allocator,
+                                 ntca::EncryptionRole::e_CLIENT,
+                                 allocator);
+
+    bsl::vector<bsl::string> serverNameVector;
+    options.loadServerNameList(&serverNameVector);
+
+    for (bsl::size_t i = 0; i < serverNameVector.size(); ++i) {
+        const bsl::string& serverName = serverNameVector[i];
+
+        ntca::EncryptionOptions nameSpecificOptions;
+        if (!options.loadServerNameOptions(&nameSpecificOptions, serverName)) {
+            return ntsa::Error(ntsa::Error::e_EOF);
+        }
+
+        error = sessionManager->configure(serverName, nameSpecificOptions);
+        if (error) {
+            return error;
+        }
+    }
+
+    *result = sessionManager;
+    return ntsa::Error();
+}
+
+ntsa::Error SessionManager::createServerSessionManager(
+    bsl::shared_ptr<ntctls::SessionManager>* result,
+    const ntca::EncryptionServerOptions&     options,
+    bslma::Allocator*                        basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::SessionManager> sessionManager;
+    sessionManager.createInplace(allocator,
+                                 ntca::EncryptionRole::e_SERVER,
+                                 allocator);
+
+    bsl::vector<bsl::string> serverNameVector;
+    options.loadServerNameList(&serverNameVector);
+
+    for (bsl::size_t i = 0; i < serverNameVector.size(); ++i) {
+        const bsl::string& serverName = serverNameVector[i];
+
+        ntca::EncryptionOptions nameSpecificOptions;
+        if (!options.loadServerNameOptions(&nameSpecificOptions, serverName)) {
+            return ntsa::Error(ntsa::Error::e_EOF);
+        }
+
+        error = sessionManager->configure(serverName, nameSpecificOptions);
+        if (error) {
+            return error;
+        }
+    }
+
+    *result = sessionManager;
+    return ntsa::Error();
+}
+
+SessionClient::SessionClient(
+    const bsl::shared_ptr<ntctls::SessionManager>&   sessionManager,
+    const bsl::shared_ptr<bdlbb::BlobBufferFactory>& blobBufferFactory,
+    bslma::Allocator*                                basicAllocator)
+: d_sessionManager_sp(sessionManager)
+, d_blobBufferFactory_sp(blobBufferFactory)
+, d_allocator_p(bslma::Default::allocator(basicAllocator))
+{
+    BSLS_ASSERT(d_sessionManager_sp);
+    BSLS_ASSERT(d_blobBufferFactory_sp);
+}
+
+SessionClient::~SessionClient()
+{
+}
+
+ntsa::Error SessionClient::createEncryption(
+    bsl::shared_ptr<ntci::Encryption>* result,
+    bslma::Allocator*                  basicAllocator)
+{
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::Session> session;
+    session.createInplace(allocator,
+                          d_sessionManager_sp,
+                          d_blobBufferFactory_sp,
+                          allocator);
+
+    *result = session;
+    return ntsa::Error();
+}
+
+ntsa::Error SessionClient::createEncryption(
+    bsl::shared_ptr<ntci::Encryption>*     result,
+    const bsl::shared_ptr<ntci::DataPool>& dataPool,
+    bslma::Allocator*                      basicAllocator)
+{
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::Session> session;
+    session.createInplace(allocator,
+                          d_sessionManager_sp,
+                          dataPool->incomingBlobBufferFactory(),
+                          allocator);
+
+    *result = session;
+    return ntsa::Error();
+}
+
+ntsa::Error SessionClient::createEncryptionClient(
+    bsl::shared_ptr<ntci::EncryptionClient>* result,
+    const ntca::EncryptionClientOptions&     options,
+    bslma::Allocator*                        basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::SessionManager> sessionManager;
+    error = ntctls::SessionManager::createClientSessionManager(&sessionManager,
+                                                               options,
+                                                               allocator);
+    if (error) {
+        return error;
+    }
+
+    bsl::shared_ptr<bdlbb::PooledBlobBufferFactory> blobBufferFactory;
+    blobBufferFactory.createInplace(allocator,
+                                    NTCCFG_DEFAULT_INCOMING_BLOB_BUFFER_SIZE,
+                                    allocator);
+
+    bsl::shared_ptr<ntctls::SessionClient> client;
+    client.createInplace(allocator,
+                         sessionManager,
+                         blobBufferFactory,
+                         allocator);
+
+    *result = client;
+    return ntsa::Error();
+}
+
+ntsa::Error SessionClient::createEncryptionClient(
+    bsl::shared_ptr<ntci::EncryptionClient>*         result,
+    const ntca::EncryptionClientOptions&             options,
+    const bsl::shared_ptr<bdlbb::BlobBufferFactory>& blobBufferFactory,
+    bslma::Allocator*                                basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::SessionManager> sessionManager;
+    error = ntctls::SessionManager::createClientSessionManager(&sessionManager,
+                                                               options,
+                                                               allocator);
+    if (error) {
+        return error;
+    }
+
+    bsl::shared_ptr<ntctls::SessionClient> client;
+    client.createInplace(allocator,
+                         sessionManager,
+                         blobBufferFactory,
+                         allocator);
+
+    *result = client;
+    return ntsa::Error();
+}
+
+ntsa::Error SessionClient::createEncryptionClient(
+    bsl::shared_ptr<ntci::EncryptionClient>* result,
+    const ntca::EncryptionClientOptions&     options,
+    const bsl::shared_ptr<ntci::DataPool>&   dataPool,
+    bslma::Allocator*                        basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::SessionManager> sessionManager;
+    error = ntctls::SessionManager::createClientSessionManager(&sessionManager,
+                                                               options,
+                                                               allocator);
+    if (error) {
+        return error;
+    }
+
+    bsl::shared_ptr<ntctls::SessionClient> client;
+    client.createInplace(allocator,
+                         sessionManager,
+                         dataPool->incomingBlobBufferFactory(),
+                         allocator);
+
+    *result = client;
+    return ntsa::Error();
+}
+
+SessionServer::SessionServer(
+    const bsl::shared_ptr<ntctls::SessionManager>&   sessionManager,
+    const bsl::shared_ptr<bdlbb::BlobBufferFactory>& blobBufferFactory,
+    bslma::Allocator*                                basicAllocator)
+: d_sessionManager_sp(sessionManager)
+, d_blobBufferFactory_sp(blobBufferFactory)
+, d_allocator_p(bslma::Default::allocator(basicAllocator))
+{
+    BSLS_ASSERT(d_sessionManager_sp);
+    BSLS_ASSERT(d_blobBufferFactory_sp);
+}
+
+SessionServer::~SessionServer()
+{
+}
+
+ntsa::Error SessionServer::createEncryption(
+    bsl::shared_ptr<ntci::Encryption>* result,
+    bslma::Allocator*                  basicAllocator)
+{
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::Session> session;
+    session.createInplace(allocator,
+                          d_sessionManager_sp,
+                          d_blobBufferFactory_sp,
+                          allocator);
+
+    *result = session;
+    return ntsa::Error();
+}
+
+ntsa::Error SessionServer::createEncryption(
+    bsl::shared_ptr<ntci::Encryption>*     result,
+    const bsl::shared_ptr<ntci::DataPool>& dataPool,
+    bslma::Allocator*                      basicAllocator)
+{
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::Session> session;
+    session.createInplace(allocator,
+                          d_sessionManager_sp,
+                          dataPool->incomingBlobBufferFactory(),
+                          allocator);
+
+    *result = session;
+    return ntsa::Error();
+}
+
+ntsa::Error SessionServer::createEncryptionServer(
+    bsl::shared_ptr<ntci::EncryptionServer>* result,
+    const ntca::EncryptionServerOptions&     options,
+    bslma::Allocator*                        basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::SessionManager> sessionManager;
+    error = ntctls::SessionManager::createServerSessionManager(&sessionManager,
+                                                               options,
+                                                               allocator);
+    if (error) {
+        return error;
+    }
+
+    bsl::shared_ptr<bdlbb::PooledBlobBufferFactory> blobBufferFactory;
+    blobBufferFactory.createInplace(allocator,
+                                    NTCCFG_DEFAULT_INCOMING_BLOB_BUFFER_SIZE,
+                                    allocator);
+
+    bsl::shared_ptr<ntctls::SessionServer> server;
+    server.createInplace(allocator,
+                         sessionManager,
+                         blobBufferFactory,
+                         allocator);
+
+    *result = server;
+    return ntsa::Error();
+}
+
+ntsa::Error SessionServer::createEncryptionServer(
+    bsl::shared_ptr<ntci::EncryptionServer>*         result,
+    const ntca::EncryptionServerOptions&             options,
+    const bsl::shared_ptr<bdlbb::BlobBufferFactory>& blobBufferFactory,
+    bslma::Allocator*                                basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::SessionManager> sessionManager;
+    error = ntctls::SessionManager::createServerSessionManager(&sessionManager,
+                                                               options,
+                                                               allocator);
+    if (error) {
+        return error;
+    }
+
+    bsl::shared_ptr<ntctls::SessionServer> server;
+    server.createInplace(allocator,
+                         sessionManager,
+                         blobBufferFactory,
+                         allocator);
+
+    *result = server;
+    return ntsa::Error();
+}
+
+ntsa::Error SessionServer::createEncryptionServer(
+    bsl::shared_ptr<ntci::EncryptionServer>* result,
+    const ntca::EncryptionServerOptions&     options,
+    const bsl::shared_ptr<ntci::DataPool>&   dataPool,
+    bslma::Allocator*                        basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::SessionManager> sessionManager;
+    error = ntctls::SessionManager::createServerSessionManager(&sessionManager,
+                                                               options,
+                                                               allocator);
+    if (error) {
+        return error;
+    }
+
+    bsl::shared_ptr<ntctls::SessionServer> server;
+    server.createInplace(allocator,
+                         sessionManager,
+                         dataPool->incomingBlobBufferFactory(),
+                         allocator);
+
+    *result = server;
+    return ntsa::Error();
+}
+
+/// Provide an OpenSSL encryption driver.
+///
+/// @details
+/// This class implements the 'ntci::EncryptionDriver' interface to
+/// implement TLS in NTC using the 'openssl' third-party library.
+///
+/// @par Thread Safety
+/// This class is thread safe.
+///
+/// @ingroup module_ntctls
+class Driver : public ntci::EncryptionDriver
+{
+    bslma::Allocator* d_allocator_p;
+
+  private:
+    Driver(const Driver&) BSLS_KEYWORD_DELETED;
+    Driver& operator=(const Driver&) BSLS_KEYWORD_DELETED;
+
+  public:
+    /// Create a new driver. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used.
+    explicit Driver(bslma::Allocator* basicAllocator = 0);
+
+    /// Destroy this object.
+    ~Driver() BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' an RSA key generated according to
+    /// the specified 'options'. Optionally specify a 'basicAllocator' used
+    /// to supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    ntsa::Error generateKey(ntca::EncryptionKey*              result,
+                            const ntca::EncryptionKeyOptions& options,
+                            bslma::Allocator* basicAllocator = 0)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' an RSA key generated according to the
+    /// specified 'options'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    ntsa::Error generateKey(bsl::shared_ptr<ntci::EncryptionKey>* result,
+                            const ntca::EncryptionKeyOptions&     options,
+                            bslma::Allocator* basicAllocator = 0)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Encode the specified 'privateKey' to the specified 'destination'
+    /// according to the specified 'options'. Return the error.
+    ntsa::Error encodeKey(
+        bsl::streambuf*                             destination,
+        const bsl::shared_ptr<ntci::EncryptionKey>& privateKey,
+        const ntca::EncryptionResourceOptions& options) BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a private key decoded from the
+    /// specified 'source' according to the specified 'options'. Return
+    /// the error. Optionally specify a 'basicAllocator' used to supply
+    /// memory.  If 'basicAllocator' is 0, the currently installed default
+    /// allocator is used.
+    ntsa::Error decodeKey(bsl::shared_ptr<ntci::EncryptionKey>*  result,
+                          bsl::streambuf*                        source,
+                          const ntca::EncryptionResourceOptions& options,
+                          bslma::Allocator* basicAllocator = 0)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a certificate generated according
+    /// to the specified 'options' for the specified 'subjectIdentity' and
+    /// 'subjectPrivateKey' signed by itself. Optionally specify a
+    /// 'basicAllocator' used to supply memory. If 'basicAllocator' is 0,
+    /// the currently installed default allocator is used. Return the error.
+    ntsa::Error generateCertificate(
+        ntca::EncryptionCertificate*              result,
+        const ntsa::DistinguishedName&            subjectIdentity,
+        const ntca::EncryptionKey&                subjectPrivateKey,
+        const ntca::EncryptionCertificateOptions& options,
+        bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a certificate generated according
+    /// to the specified 'options' for the specified 'subjectIdentity' and
+    /// 'subjectPrivateKey' signed by the certificate authority identified
+    /// by the specified 'issuerCertificate' that uses the specified
+    /// 'issuerPrivateKey'. Optionally specify a 'basicAllocator' used
+    /// to supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    ntsa::Error generateCertificate(
+        ntca::EncryptionCertificate*              result,
+        const ntsa::DistinguishedName&            subjectIdentity,
+        const ntca::EncryptionKey&                subjectPrivateKey,
+        const ntca::EncryptionCertificate&        issuerCertificate,
+        const ntca::EncryptionKey&                issuerPrivateKey,
+        const ntca::EncryptionCertificateOptions& options,
+        bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a certificate generated according
+    /// to the specified 'options' for the specified 'subjectIdentity' and
+    /// 'subjectPrivateKey' signed by itself. Optionally specify a
+    /// 'basicAllocator' used to supply memory. If 'basicAllocator' is 0,
+    /// the currently installed default allocator is used. Return the error.
+    ntsa::Error generateCertificate(
+        bsl::shared_ptr<ntci::EncryptionCertificate>* result,
+        const ntsa::DistinguishedName&                subjectIdentity,
+        const bsl::shared_ptr<ntci::EncryptionKey>&   subjectPrivateKey,
+        const ntca::EncryptionCertificateOptions&     options,
+        bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a certificate generated according to
+    /// the specified 'options' for the specified 'subjectIdentity' and
+    /// 'subjectPrivateKey' signed by the certificate authority identified by
+    /// the specified 'issuerCertificate' that uses the specified
+    /// 'issuerPrivateKey'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    ntsa::Error generateCertificate(
+        bsl::shared_ptr<ntci::EncryptionCertificate>*       result,
+        const ntsa::DistinguishedName&                      subjectIdentity,
+        const bsl::shared_ptr<ntci::EncryptionKey>&         subjectPrivateKey,
+        const bsl::shared_ptr<ntci::EncryptionCertificate>& issuerCertificate,
+        const bsl::shared_ptr<ntci::EncryptionKey>&         issuerPrivateKey,
+        const ntca::EncryptionCertificateOptions&           options,
+        bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
+
+    /// Encode the specified 'certificate' to the specified 'destination'
+    /// according to the specified 'options'. Return the error.
+    ntsa::Error encodeCertificate(
+        bsl::streambuf*                                     destination,
+        const bsl::shared_ptr<ntci::EncryptionCertificate>& certificate,
+        const ntca::EncryptionResourceOptions& options) BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a certificate decoded from the
+    /// specified 'source' according to the specified 'options'. Return
+    /// the error. Optionally specify a 'basicAllocator' used to supply
+    /// memory.  If 'basicAllocator' is 0, the currently installed default
+    /// allocator is used.
+    ntsa::Error decodeCertificate(
+        bsl::shared_ptr<ntci::EncryptionCertificate>* result,
+        bsl::streambuf*                               source,
+        const ntca::EncryptionResourceOptions&        options,
+        bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a new encryption client with the
+    /// specified 'options'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    ntsa::Error createEncryptionClient(
+        bsl::shared_ptr<ntci::EncryptionClient>* result,
+        const ntca::EncryptionClientOptions&     options,
+        bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a new encryption client with the
+    /// specified 'options'. Allocate blob buffers using the specified
+    /// 'blobBufferFactory'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    ntsa::Error createEncryptionClient(
+        bsl::shared_ptr<ntci::EncryptionClient>*         result,
+        const ntca::EncryptionClientOptions&             options,
+        const bsl::shared_ptr<bdlbb::BlobBufferFactory>& blobBufferFactory,
+        bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a new encryption client with the
+    /// specified 'options'. Allocate data containers using the specified
+    /// 'dataPool'. Optionally specify a 'basicAllocator' used to supply
+    /// memory. If 'basicAllocator' is 0, the currently installed default
+    /// allocator is used. Return the error.
+    ntsa::Error createEncryptionClient(
+        bsl::shared_ptr<ntci::EncryptionClient>* result,
+        const ntca::EncryptionClientOptions&     options,
+        const bsl::shared_ptr<ntci::DataPool>&   dataPool,
+        bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a new encryption client with the
+    /// specified 'options'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    ntsa::Error createEncryptionServer(
+        bsl::shared_ptr<ntci::EncryptionServer>* result,
+        const ntca::EncryptionServerOptions&     options,
+        bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a new encryption client with the
+    /// specified 'options'. Allocate blob buffers using the specified
+    /// 'blobBufferFactory'. Optionally specify a 'basicAllocator' used to
+    /// supply memory. If 'basicAllocator' is 0, the currently installed
+    /// default allocator is used. Return the error.
+    ntsa::Error createEncryptionServer(
+        bsl::shared_ptr<ntci::EncryptionServer>*         result,
+        const ntca::EncryptionServerOptions&             options,
+        const bsl::shared_ptr<bdlbb::BlobBufferFactory>& blobBufferFactory,
+        bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a new encryption client with the
+    /// specified 'options'. Allocate data containers using the specified
+    /// 'dataPool'. Optionally specify a 'basicAllocator' used to supply
+    /// memory. If 'basicAllocator' is 0, the currently installed default
+    /// allocator is used. Return the error.
+    ntsa::Error createEncryptionServer(
+        bsl::shared_ptr<ntci::EncryptionServer>* result,
+        const ntca::EncryptionServerOptions&     options,
+        const bsl::shared_ptr<ntci::DataPool>&   dataPool,
+        bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
+
+    /// Load into the specified 'result' a new encryption resource. Optionally
+    /// specify a 'basicAllocator' used to supply memory. If 'basicAllocator'
+    /// is 0, the currently installed default allocator is used. Return the
+    /// error.
+    ntsa::Error createEncryptionResource(
+        bsl::shared_ptr<ntci::EncryptionResource>* result,
+        bslma::Allocator* basicAllocator = 0) BSLS_KEYWORD_OVERRIDE;
+};
+
+Driver::Driver(bslma::Allocator* basicAllocator)
+: d_allocator_p(bslma::Default::allocator(basicAllocator))
+{
+}
+
+Driver::~Driver()
+{
+}
+
+ntsa::Error Driver::generateKey(ntca::EncryptionKey*              result,
+                                const ntca::EncryptionKeyOptions& options,
+                                bslma::Allocator* basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    error = ntctls::Key::generateKey(result, options, allocator);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Driver::generateKey(bsl::shared_ptr<ntci::EncryptionKey>* result,
+                                const ntca::EncryptionKeyOptions&     options,
+                                bslma::Allocator* basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    error = ntctls::Key::generateKey(result, options, allocator);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Driver::encodeKey(
+    bsl::streambuf*                             destination,
+    const bsl::shared_ptr<ntci::EncryptionKey>& privateKey,
+    const ntca::EncryptionResourceOptions&      options)
+{
+    ntsa::Error error;
+
+    bsl::shared_ptr<ntctls::Key> effectivePrivateKey;
+    error = ntctls::Resource::convert(&effectivePrivateKey, privateKey);
+    if (error) {
+        return error;
+    }
+
+    return effectivePrivateKey->encode(destination, options);
+}
+
+ntsa::Error Driver::decodeKey(bsl::shared_ptr<ntci::EncryptionKey>*  result,
+                              bsl::streambuf*                        source,
+                              const ntca::EncryptionResourceOptions& options,
+                              bslma::Allocator* basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::Key> effectiveResult;
+    effectiveResult.createInplace(allocator, allocator);
+
+    error = effectiveResult->decode(source, options);
+    if (error) {
+        return error;
+    }
+
+    *result = effectiveResult;
+    return ntsa::Error();
+}
+
+ntsa::Error Driver::generateCertificate(
+    ntca::EncryptionCertificate*              result,
+    const ntsa::DistinguishedName&            subjectIdentity,
+    const ntca::EncryptionKey&                subjectPrivateKey,
+    const ntca::EncryptionCertificateOptions& options,
+    bslma::Allocator*                         basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    error = ntctls::Certificate::generateCertificate(result,
+                                                     subjectIdentity,
+                                                     subjectPrivateKey,
+                                                     options,
+                                                     allocator);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Driver::generateCertificate(
+    ntca::EncryptionCertificate*              result,
+    const ntsa::DistinguishedName&            subjectIdentity,
+    const ntca::EncryptionKey&                subjectPrivateKey,
+    const ntca::EncryptionCertificate&        issuerCertificate,
+    const ntca::EncryptionKey&                issuerPrivateKey,
+    const ntca::EncryptionCertificateOptions& options,
+    bslma::Allocator*                         basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    error = ntctls::Certificate::generateCertificate(result,
+                                                     subjectIdentity,
+                                                     subjectPrivateKey,
+                                                     issuerCertificate,
+                                                     issuerPrivateKey,
+                                                     options,
+                                                     allocator);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Driver::generateCertificate(
+    bsl::shared_ptr<ntci::EncryptionCertificate>* result,
+    const ntsa::DistinguishedName&                subjectIdentity,
+    const bsl::shared_ptr<ntci::EncryptionKey>&   subjectPrivateKey,
+    const ntca::EncryptionCertificateOptions&     options,
+    bslma::Allocator*                             basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    error = ntctls::Certificate::generateCertificate(result,
+                                                     subjectIdentity,
+                                                     subjectPrivateKey,
+                                                     options,
+                                                     allocator);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Driver::generateCertificate(
+    bsl::shared_ptr<ntci::EncryptionCertificate>*       result,
+    const ntsa::DistinguishedName&                      subjectIdentity,
+    const bsl::shared_ptr<ntci::EncryptionKey>&         subjectPrivateKey,
+    const bsl::shared_ptr<ntci::EncryptionCertificate>& issuerCertificate,
+    const bsl::shared_ptr<ntci::EncryptionKey>&         issuerPrivateKey,
+    const ntca::EncryptionCertificateOptions&           options,
+    bslma::Allocator*                                   basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    error = ntctls::Certificate::generateCertificate(result,
+                                                     subjectIdentity,
+                                                     subjectPrivateKey,
+                                                     issuerCertificate,
+                                                     issuerPrivateKey,
+                                                     options,
+                                                     allocator);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Driver::encodeCertificate(
+    bsl::streambuf*                                     destination,
+    const bsl::shared_ptr<ntci::EncryptionCertificate>& certificate,
+    const ntca::EncryptionResourceOptions&              options)
+{
+    ntsa::Error error;
+
+    bsl::shared_ptr<ntctls::Certificate> effectiveCertificate;
+    error = ntctls::Resource::convert(&effectiveCertificate, certificate);
+    if (error) {
+        return error;
+    }
+
+    return effectiveCertificate->encode(destination, options);
+}
+
+ntsa::Error Driver::decodeCertificate(
+    bsl::shared_ptr<ntci::EncryptionCertificate>* result,
+    bsl::streambuf*                               source,
+    const ntca::EncryptionResourceOptions&        options,
+    bslma::Allocator*                             basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::Certificate> effectiveResult;
+    effectiveResult.createInplace(allocator, allocator);
+
+    error = effectiveResult->decode(source, options);
+    if (error) {
+        return error;
+    }
+
+    *result = effectiveResult;
+    return ntsa::Error();
+}
+
+ntsa::Error Driver::createEncryptionClient(
+    bsl::shared_ptr<ntci::EncryptionClient>* result,
+    const ntca::EncryptionClientOptions&     options,
+    bslma::Allocator*                        basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    error = ntctls::SessionClient::createEncryptionClient(result,
+                                                          options,
+                                                          allocator);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Driver::createEncryptionClient(
+    bsl::shared_ptr<ntci::EncryptionClient>*         result,
+    const ntca::EncryptionClientOptions&             options,
+    const bsl::shared_ptr<bdlbb::BlobBufferFactory>& blobBufferFactory,
+    bslma::Allocator*                                basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    error = ntctls::SessionClient::createEncryptionClient(result,
+                                                          options,
+                                                          blobBufferFactory,
+                                                          allocator);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Driver::createEncryptionClient(
+    bsl::shared_ptr<ntci::EncryptionClient>* result,
+    const ntca::EncryptionClientOptions&     options,
+    const bsl::shared_ptr<ntci::DataPool>&   dataPool,
+    bslma::Allocator*                        basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    error = ntctls::SessionClient::createEncryptionClient(result,
+                                                          options,
+                                                          dataPool,
+                                                          allocator);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Driver::createEncryptionServer(
+    bsl::shared_ptr<ntci::EncryptionServer>* result,
+    const ntca::EncryptionServerOptions&     options,
+    bslma::Allocator*                        basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    error = ntctls::SessionServer::createEncryptionServer(result,
+                                                          options,
+                                                          allocator);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Driver::createEncryptionServer(
+    bsl::shared_ptr<ntci::EncryptionServer>*         result,
+    const ntca::EncryptionServerOptions&             options,
+    const bsl::shared_ptr<bdlbb::BlobBufferFactory>& blobBufferFactory,
+    bslma::Allocator*                                basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    error = ntctls::SessionServer::createEncryptionServer(result,
+                                                          options,
+                                                          blobBufferFactory,
+                                                          allocator);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Driver::createEncryptionServer(
+    bsl::shared_ptr<ntci::EncryptionServer>* result,
+    const ntca::EncryptionServerOptions&     options,
+    const bsl::shared_ptr<ntci::DataPool>&   dataPool,
+    bslma::Allocator*                        basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    error = ntctls::SessionServer::createEncryptionServer(result,
+                                                          options,
+                                                          dataPool,
+                                                          allocator);
+    if (error) {
+        return error;
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error Driver::createEncryptionResource(
+    bsl::shared_ptr<ntci::EncryptionResource>* result,
+    bslma::Allocator*                          basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntctls::Resource> resource;
+    resource.createInplace(allocator, allocator);
+
+    *result = resource;
+    return ntsa::Error();
+}
+
+Initializer::Initializer()
+{
+    ntcs::Plugin::initialize();
+
+    const int blobTypeIndex = BIO_get_new_index() | BIO_TYPE_SOURCE_SINK;
+
+    s_streamState.d_blobMethods = BIO_meth_new(blobTypeIndex, "blob");
+
+    BIO_meth_set_write(s_streamState.d_blobMethods, &bio_blob_write);
+    BIO_meth_set_read(s_streamState.d_blobMethods, &bio_blob_read);
+    BIO_meth_set_puts(s_streamState.d_blobMethods, &bio_blob_puts);
+    BIO_meth_set_gets(s_streamState.d_blobMethods, &bio_blob_gets);
+    BIO_meth_set_ctrl(s_streamState.d_blobMethods, &bio_blob_ctrl);
+    BIO_meth_set_create(s_streamState.d_blobMethods, &bio_blob_new);
+    BIO_meth_set_destroy(s_streamState.d_blobMethods, &bio_blob_free);
+
+    const int streamTypeIndex = BIO_get_new_index() | BIO_TYPE_SOURCE_SINK;
+
+    s_streamState.d_streambufMethods =
+        BIO_meth_new(streamTypeIndex, "streambuf");
+
+    BIO_meth_set_write(s_streamState.d_streambufMethods, &bio_streambuf_write);
+    BIO_meth_set_read(s_streamState.d_streambufMethods, &bio_streambuf_read);
+    BIO_meth_set_puts(s_streamState.d_streambufMethods, &bio_streambuf_puts);
+    BIO_meth_set_gets(s_streamState.d_streambufMethods, &bio_streambuf_gets);
+    BIO_meth_set_ctrl(s_streamState.d_streambufMethods, &bio_streambuf_ctrl);
+    BIO_meth_set_create(s_streamState.d_streambufMethods, &bio_streambuf_new);
+    BIO_meth_set_destroy(s_streamState.d_streambufMethods,
+                         &bio_streambuf_free);
+
+    bslma::Allocator* allocator = &bslma::NewDeleteAllocator::singleton();
+
+    bsl::shared_ptr<ntci::EncryptionDriver> encryptionDriver(
+        new (*allocator) ntctls::Driver(allocator),
+        allocator);
+
+    ntcs::Plugin::registerEncryptionDriver(encryptionDriver);
+}
+
+Initializer::~Initializer()
+{
+    BIO_meth_free(s_streamState.d_blobMethods);
+    s_streamState.d_blobMethods = 0;
+
+    BIO_meth_free(s_streamState.d_streambufMethods);
+    s_streamState.d_streambufMethods = 0;
+}
+
+void Plugin::initialize(bslma::Allocator* basicAllocator)
+{
+    NTCCFG_WARNING_UNUSED(basicAllocator);
+    ntctls::Internal::initialize();
+}
+
+void Plugin::load(bsl::shared_ptr<ntci::EncryptionDriver>* result)
+{
+    ntsa::Error error;
+
+    ntctls::Internal::initialize();
+
+    error = ntcs::Plugin::lookupEncryptionDriver(result);
+    if (error) {
+        bslma::Allocator* allocator = &bslma::NewDeleteAllocator::singleton();
+
+        bsl::shared_ptr<ntctls::Driver> driver;
+        driver.createInplace(allocator, allocator);
+
+        *result = driver;
+    }
+}
+
+void Plugin::exit()
+{
+    ntctls::Internal::exit();
+}
+
+PluginGuard::PluginGuard(bslma::Allocator* basicAllocator)
+{
+    ntctls::Plugin::initialize(basicAllocator);
+}
+
+PluginGuard::~PluginGuard()
+{
+    ntctls::Plugin::exit();
+}
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/groups/ntc/ntctls/ntctls_plugin.h
+++ b/groups/ntc/ntctls/ntctls_plugin.h
@@ -1,0 +1,445 @@
+// Copyright 2020-2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_NTCTLS_PLUGIN
+#define INCLUDED_NTCTLS_PLUGIN
+
+#include <bsls_ident.h>
+BSLS_IDENT("$Id: $")
+
+#include <ntccfg_config.h>
+#include <ntccfg_platform.h>
+#include <ntci_encryptiondriver.h>
+#include <ntcscm_version.h>
+#include <bsl_memory.h>
+
+#if NTC_BUILD_WITH_OPENSSL
+
+namespace BloombergLP {
+namespace ntctls {
+
+/// Provide a facility to inject OpenSSL into NTC.
+///
+/// @par Thread Safety
+/// This class is thread safe.
+///
+/// @par Usage Example
+/// This example illustrates how to listen for connections, connect a socket,
+/// accept a socket, upgrade those sockets into TLS, exchange data between
+/// those two sockets, gracefully shut down each socket and detect the shutdown
+/// of each peer, then close each socket. Note that all operations execute
+/// asynchronously, but for the purposes of this example, the thread that
+/// initiates each asynchronous operation blocks on a semaphore (posted by each
+/// asynchronous operation's callback), to illustrate the functionality in a
+/// linear fashion despite the operations executing asynchronously. This
+/// example shows how to create and use TCP/IPv4 sockets, but the usage for
+/// TCP/IPv6 sockets and Unix domain sockets is identical, with the only
+/// difference being the type of transport specified in the options used to
+/// construct the socket and/or the type of endpoint to which a socket is bound
+/// or connected.
+///
+/// First, initialize the library and install the OpenSSL plugin as a provider
+/// of encryption to NTF.
+///
+///     ntcf::System::initialize();
+///     ntcf::System::ignore(ntscfg::Signal::e_PIPE);
+///
+///     NTF_REGISTER_PLUGIN_OPENSSL();
+///
+///     ntsa::Error      error;
+///     bslmt::Semaphore semaphore;
+///
+/// Create and start a pool of I/O threads.
+///
+///     ntca::InterfaceConfig interfaceConfig;
+///     interfaceConfig.setThreadName("example");
+///     interfaceConfig.setMinThreads(1);
+///     interfaceConfig.setMaxThreads(1);
+///
+///     bsl::shared_ptr<ntci::Interface> interface =
+///         ntcf::System::createInterface(interfaceConfig, allocator);
+///
+///     error = interface->start();
+///     BSLS_ASSERT(!error);
+///
+/// Generate a certificate and private key for a certificate authority.
+///
+///     ntca::EncryptionKeyOptions authorityPrivateKeyOptions;
+///     authorityPrivateKeyOptions.setType(
+///         ntca::EncryptionKeyType::e_NIST_P256);
+///
+///     ntca::EncryptionKey authorityPrivateKey;
+///     error = interface->generateKey(&authorityPrivateKey,
+///                                    authorityPrivateKeyOptions,
+///                                    allocator);
+///     BSLS_ASSERT(!error);
+///
+///     ntsa::DistinguishedName authorityIdentity;
+///     authorityIdentity["CN"] = "Authority";
+///
+///     ntca::EncryptionCertificateOptions authorityCertificateOptions;
+///     authorityCertificateOptions.setAuthority(true);
+///
+///     ntca::EncryptionCertificate authorityCertificate;
+///     error = interface->generateCertificate(&authorityCertificate,
+///                                            authorityIdentity,
+///                                            authorityPrivateKey,
+///                                            authorityCertificateOptions,
+///                                            allocator);
+///     BSLS_ASSERT(!error);
+///
+/// Generate a certificate and private key for the server, signed by the
+/// certificate authority.
+///
+///     ntca::EncryptionKeyOptions serverPrivateKeyOptions;
+///     serverPrivateKeyOptions.setType(ntca::EncryptionKeyType::e_NIST_P256);
+///
+///     ntca::EncryptionKey serverPrivateKey;
+///     error = interface->generateKey(&serverPrivateKey,
+///                                    serverPrivateKeyOptions,
+///                                    allocator);
+///     BSLS_ASSERT(!error);
+///
+///     ntsa::DistinguishedName serverIdentity;
+///     serverIdentity["CN"] = "Server";
+///
+///     ntca::EncryptionCertificateOptions serverCertificateOptions;
+///     serverCertificateOptions.addHost("test.example.com");
+///
+///     ntca::EncryptionCertificate serverCertificate;
+///     error = interface->generateCertificate(&serverCertificate,
+///                                            serverIdentity,
+///                                            serverPrivateKey,
+///                                            authorityCertificate,
+///                                            authorityPrivateKey,
+///                                            serverCertificateOptions,
+///                                            allocator);
+///     BSLS_ASSERT(!error);
+///
+/// Create an encryption client, configured to require the server to
+/// provide its certificate, which will be verified by trusting the
+/// certificate authority that signed the server's certificate.
+///
+///     ntca::EncryptionClientOptions encryptionClientOptions;
+///
+///     encryptionClientOptions.setAuthentication(
+///         ntca::EncryptionAuthentication::e_VERIFY);
+///
+///     encryptionClientOptions.setMinMethod(
+///         ntca::EncryptionMethod::e_TLS_V1_2);
+///
+///     encryptionClientOptions.setMaxMethod(
+///         ntca::EncryptionMethod::e_TLS_V1_X);
+///
+///     encryptionClientOptions.addAuthority(authorityCertificate);
+///
+///     bsl::shared_ptr<ntci::EncryptionClient> encryptionClient;
+///     error = ntcf::System::createEncryptionClient(&encryptionClient,
+///                                                  encryptionClientOptions,
+///                                                  allocator);
+///     BSLS_ASSERT(!error);
+///
+/// Create an encryption server, configured to not require any client to
+/// provide a certificate.
+///
+///     ntca::EncryptionServerOptions encryptionServerOptions;
+///
+///     encryptionServerOptions.setAuthentication(
+///         ntca::EncryptionAuthentication::e_NONE);
+///
+///     encryptionServerOptions.setMinMethod(
+///         ntca::EncryptionMethod::e_TLS_V1_2);
+///
+///     encryptionServerOptions.setMaxMethod(
+///         ntca::EncryptionMethod::e_TLS_V1_X);
+///
+///     encryptionServerOptions.setIdentity(serverCertificate);
+///     encryptionServerOptions.setPrivateKey(serverPrivateKey);
+///
+///     bsl::shared_ptr<ntci::EncryptionServer> encryptionServer;
+///     error = ntcf::System::createEncryptionServer(&encryptionServer,
+///                                                  encryptionServerOptions,
+///                                                  allocator);
+///     BSLS_ASSERT(!error);
+///
+/// Create a listener socket.
+///
+///     bsl::shared_ptr<ntci::ListenerSocket> listenerSocket =
+///         interface->createListenerSocket(ntca::ListenerSocketOptions());
+///
+/// Bind the listener socket to any endpoint on the local host and wait for
+/// the operation to complete.
+///
+///     error = listenerSocket->bind(
+///         ntsa::Endpoint(ntsa::IpEndpoint(ntsa::Ipv4Address::any(), 0)),
+///         ntca::BindOptions(),
+///         [&](auto bindable, auto event) {
+///             BSLS_ASSERT(bindable == listenerSocket);
+///             BSLS_ASSERT(event.isComplete());
+///             semaphore.post();
+///         });
+///
+///     BSLS_ASSERT(!error);
+///     semaphore.wait();
+///
+/// Begin listening.
+///
+///     error = listenerSocket->listen();
+///     BSLS_ASSERT(!error);
+///
+/// Create a stream socket to act as a client.
+///
+///     bsl::shared_ptr<ntci::StreamSocket> clientStreamSocket =
+///         interface->createStreamSocket(ntca::StreamSocketOptions());
+///
+/// Connect the client stream socket to the endpoint of the listener socket
+/// and wait for the operation to complete.
+///
+///     error = clientStreamSocket->connect(
+///         listenerSocket->sourceEndpoint(),
+///         ntca::ConnectOptions(),
+///         [&](auto connector, auto event) {
+///             BSLS_ASSERT(connector == clientStreamSocket);
+///             BSLS_ASSERT(event.isComplete());
+///             semaphore.post();
+///         });
+///
+///     BSLS_ASSERT(!error);
+///     semaphore.wait();
+///
+/// Accept a stream socket to act as the server and wait for the operation to
+/// complete.
+///
+///     bsl::shared_ptr<ntci::StreamSocket> serverStreamSocket;
+///     error = listenerSocket->accept(
+///         ntca::AcceptOptions(),
+///         [&](auto acceptor, auto streamSocket, auto event) {
+///             BSLS_ASSERT(acceptor == listenerSocket);
+///             BSLS_ASSERT(event.isComplete());
+///             serverStreamSocket = streamSocket;
+///             semaphore.post();
+///         });
+///
+///     BSLS_ASSERT(!error);
+///     semaphore.wait();
+///
+/// Upgrade the server socket to TLS.
+///
+///     ntca::UpgradeOptions serverUpgradeOptions;
+///
+///     error = serverSocket->upgrade(
+///         encryptionServer,
+///         serverUpgradeOptions,
+///         [&](auto upgradable, auto event) {
+///             BSLS_ASSERT(event.isComplete());
+///             BSLS_ASSERT(upgradable == serverSocket);
+///             semaphore.post();
+///         });
+///     BSLS_ASSERT(!error);
+///
+/// Upgrade the client socket to TLS.
+///
+///    ntca::UpgradeOptions clientUpgradeOptions;
+///
+///    error = clientSocket->upgrade(
+///        encryptionClient,
+///        clientUpgradeOptions,
+///        [&](auto upgradable, auto event) {
+///             BSLS_ASSERT(event.isComplete());
+///             BSLS_ASSERT(upgradable == clientSocket);
+///             clientSocket->remoteCertificate()->equals(serverCertificate);
+///             semaphore.post();
+///         });
+///     BSLS_ASSERT(!error);
+///
+/// Wait for the client socket and server socket to complete
+/// upgrading to TLS.
+///
+///     semaphore.wait();
+///     semaphore.wait();
+///
+/// Send data from the client stream socket to the server stream socket and
+/// wait for the operation to complete.
+///
+///     const char CLIENT_SEND_DATA[] = "Hello, server!";
+///
+///     bdlbb::Blob clientSendData(
+///         clientStreamSocket->outgoingBlobBufferFactory().get());
+///
+///     bdlbb::BlobUtil::append(
+///         &clientSendData, CLIENT_SEND_DATA, sizeof CLIENT_SEND_DATA - 1);
+///
+///     error = clientStreamSocket->send(
+///         clientSendData,
+///         ntca::SendOptions(),
+///         [&](auto sender, auto event) {
+///             BSLS_ASSERT(sender == clientStreamSocket);
+///             BSLS_ASSERT(event.isComplete());
+///             semaphore.post();
+///         });
+///
+///     BSLS_ASSERT(!error);
+///     semaphore.wait();
+///
+/// Receive data at the server stream socket and wait for the operation to
+/// complete. Require that exactly the amount of data sent by the client has
+/// been received for the operation to complete.
+///
+///     ntca::ReceiveOptions serverReceiveOptions;
+///     serverReceiveOptions.setMinSize(clientSendData.length());
+///     serverReceiveOptions.setMaxSize(clientSendData.length());
+///
+///     error = serverStreamSocket->receive(
+///         serverReceiveOptions,
+///         [&](auto receiver, auto data, auto event) {
+///             BSLS_ASSERT(receiver == serverStreamSocket);
+///             BSLS_ASSERT(event.isComplete());
+///             BSLS_ASSERT(data);
+///             BSLS_ASSERT(bdlbb::BlobUtil::compare(*data, clientSendData)
+///                         == 0);
+///             semaphore.post();
+///         });
+///
+///     BSLS_ASSERT(!error);
+///     semaphore.wait();
+///
+/// Send data from the server stream socket to the client stream socket and
+/// wait for the operation to complete.
+///
+///     const char SERVER_SEND_DATA[] = "Hello, client!";
+///
+///     bdlbb::Blob serverSendData(
+///         serverStreamSocket->outgoingBlobBufferFactory().get());
+///
+///     bdlbb::BlobUtil::append(
+///         &serverSendData, SERVER_SEND_DATA, sizeof SERVER_SEND_DATA - 1);
+///
+///     error = serverStreamSocket->send(
+///         serverSendData,
+///         ntca::SendOptions(),
+///         [&](auto sender, auto event) {
+///             BSLS_ASSERT(sender == serverStreamSocket);
+///             BSLS_ASSERT(event.isComplete());
+///             semaphore.post();
+///         });
+///
+///     BSLS_ASSERT(!error);
+///     semaphore.wait();
+///
+/// Receive data at the client stream socket and wait for the operation to
+/// complete. Require that exactly the amount of data sent by the server has
+/// been received for the receive operation to complete.
+///
+///     ntca::ReceiveOptions clientReceiveOptions;
+///     clientReceiveOptions.setMinSize(serverSendData.length());
+///     clientReceiveOptions.setMaxSize(serverSendData.length());
+///
+///     error = clientStreamSocket->receive(
+///         clientReceiveOptions,
+///         [&](auto receiver, auto data, auto event) {
+///             BSLS_ASSERT(receiver == clientStreamSocket);
+///             BSLS_ASSERT(event.isComplete());
+///             BSLS_ASSERT(data);
+///             BSLS_ASSERT(bdlbb::BlobUtil::compare(*data, serverSendData)
+///                         == 0);
+///             semaphore.post();
+///         });
+///
+///     BSLS_ASSERT(!error);
+///     semaphore.wait();
+///
+/// Downgrade the client.
+///
+///     error = clientSocket->downgrade();
+///     BSLS_ASSERT(!error);
+///
+/// Close the client socket.
+///
+///     clientSocket->close(clientSocket->createCloseCallback(
+///         NTCCFG_BIND(&test::processClose, &semaphore)));
+///
+///     semaphore.wait();
+///
+/// Close the server socket.
+///
+///     serverSocket->close(serverSocket->createCloseCallback(
+///         NTCCFG_BIND(&test::processClose, &semaphore)));
+///
+///     semaphore.wait();
+///
+/// Close the listener socket.
+///
+///     listenerSocket->close(listenerSocket->createCloseCallback(
+///         NTCCFG_BIND(&test::processClose, &semaphore)));
+///
+///     semaphore.wait();
+///
+/// Join the interface.
+///
+///     interface->shutdown();
+///     interface->linger();
+///
+/// @ingroup module_a_ntcopenssl
+struct Plugin {
+    /// Initialize this plugin and register support for TLS in NTF using the
+    /// 'openssl' third-party library. Optionally specify a 'basicAllocator'
+    /// used to supply memory. If 'basicAllocator' is 0, the global allocator
+    /// is used.
+    static void initialize(bslma::Allocator* basicAllocator = 0);
+
+    /// Load into the specified 'result' the encryption driver implemented
+    /// using 'openssl' third-party library.
+    static void load(bsl::shared_ptr<ntci::EncryptionDriver>* result);
+
+    /// Deregister support for TLS in NTF using the 'openssl' third-party
+    /// library and clean up all resources required by this plugin.
+    static void exit();
+};
+
+/// Provide a a scoped guard to automatically initialize and clean up the NTF
+/// plugin provided by this library.
+///
+/// @par Thread Safety
+/// This class is thread safe.
+///
+/// @ingroup module_a_ntcopenssl
+class PluginGuard
+{
+  private:
+    PluginGuard(const PluginGuard&) BSLS_KEYWORD_DELETED;
+    PluginGuard& operator=(const PluginGuard&) BSLS_KEYWORD_DELETED;
+
+  public:
+    /// Initialize this plugin and register support for TLS in NTF using the
+    /// 'openssl' third-party library. Optionally specify a 'basicAllocator'
+    /// used to supply memory. If 'basicAllocator' is 0, the global allocator
+    /// is used.
+    explicit PluginGuard(bslma::Allocator* allocator = 0);
+
+    /// Deregister support for TLS in NTF using the 'openssl' third-party
+    /// library and clean up all resources required by this plugin.
+    ~PluginGuard();
+};
+
+/// Initialize this plugin and register support for TLS in NTF using the
+/// 'openssl' third-party library.
+#define NTF_REGISTER_PLUGIN_OPENSSL()                                         \
+    BloombergLP::ntctls::PluginGuard ntfPluginOpenSSL
+
+}  // end namespace ntctls
+}  // end namespace BloombergLP
+#endif
+
+#endif

--- a/groups/ntc/ntctls/ntctls_plugin.t.cpp
+++ b/groups/ntc/ntctls/ntctls_plugin.t.cpp
@@ -1,0 +1,4242 @@
+// Copyright 2020-2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ntscfg_test.h>
+
+#include <bsls_ident.h>
+BSLS_IDENT_RCSID(ntctls_plugin_t_cpp, "$Id$ $CSID$")
+
+#include <ntctls_plugin.h>
+
+#include <ntca_encryptionauthentication.h>
+#include <ntca_encryptioncertificate.h>
+#include <ntca_encryptioncertificateoptions.h>
+#include <ntca_encryptionclientoptions.h>
+#include <ntca_encryptionkey.h>
+#include <ntca_encryptionkeyoptions.h>
+#include <ntca_encryptionkeytype.h>
+#include <ntca_encryptionmethod.h>
+#include <ntca_encryptionoptions.h>
+#include <ntca_encryptionresource.h>
+#include <ntca_encryptionresourcedescriptor.h>
+#include <ntca_encryptionresourceoptions.h>
+#include <ntca_encryptionresourcetype.h>
+#include <ntca_encryptionrole.h>
+#include <ntca_encryptionsecret.h>
+#include <ntca_encryptionserveroptions.h>
+#include <ntca_encryptionvalidation.h>
+#include <ntci_encryption.h>
+#include <ntci_encryptioncertificate.h>
+#include <ntci_encryptioncertificategenerator.h>
+#include <ntci_encryptioncertificatestorage.h>
+#include <ntci_encryptionclient.h>
+#include <ntci_encryptionclientfactory.h>
+#include <ntci_encryptiondriver.h>
+#include <ntci_encryptionkey.h>
+#include <ntci_encryptionkeygenerator.h>
+#include <ntci_encryptionkeystorage.h>
+#include <ntci_encryptionserver.h>
+#include <ntci_encryptionserverfactory.h>
+#include <ntci_log.h>
+#include <ntci_mutex.h>
+#include <ntcs_datapool.h>
+#include <ntsf_system.h>
+#include <bslim_printer.h>
+
+using namespace BloombergLP;
+
+#if NTC_BUILD_WITH_OPENSSL
+
+#define NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_MAIN()                           \
+    NTCI_LOG_CONTEXT_GUARD_OWNER("main")
+
+#define NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_CLIENT()                         \
+    NTCI_LOG_CONTEXT_GUARD_OWNER("client")
+
+#define NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_SERVER()                         \
+    NTCI_LOG_CONTEXT_GUARD_OWNER("server")
+
+namespace BloombergLP {
+namespace ntctls {
+
+// Provide utilties for key tests.
+class KeyTestUtil
+{
+  public:
+    // Load into the specified 'result' each supported key type.
+    static void loadKeyTypes(
+        bsl::vector<ntca::EncryptionKeyType::Value>* result);
+
+    // Load into the specified 'result' each supported variation of key
+    // storage options.
+    static void loadKeyStorageOptions(
+        bsl::vector<ntca::EncryptionResourceOptions>* result);
+
+    // Log the hex dump of the specified 'osb' stream buffer.
+    static void logHexDump(const bdlsb::MemOutStreamBuf& osb);
+
+    // Log the hex dump of the specified 'ob' blob.
+    static void logHexDump(const bdlbb::Blob& ob);
+
+    // Generate a key.
+    static void verifyKeyGeneration(
+        bsl::shared_ptr<ntci::EncryptionKey>* result,
+        const ntca::EncryptionKeyOptions&     keyConfig,
+        bslma::Allocator*                     allocator);
+
+    // Encode then decode the specified 'key' to verify it is encoded and
+    // decoded losslessly.
+    static void verifyKeyEncoding(
+        const bsl::shared_ptr<ntci::EncryptionKey>& key,
+        const ntca::EncryptionKeyOptions&           keyConfig,
+        const ntca::EncryptionResourceOptions&      keyStorageOptions,
+        bslma::Allocator*                           allocator);
+
+    // Generate a key and test that the key can be encoded and decoded
+    // losslessly.
+    static void verifyKeyConfig(
+        const ntca::EncryptionKeyOptions&      keyConfig,
+        const ntca::EncryptionResourceOptions& keyStorageOptions,
+        bslma::Allocator*                      allocator);
+};
+
+// Provide keys tests.
+class KeyTest
+{
+  public:
+    // Generate a key and verify it can be encoded and decoded losslessly.
+    static void verifyUsage();
+};
+
+void KeyTestUtil::loadKeyTypes(
+    bsl::vector<ntca::EncryptionKeyType::Value>* result)
+{
+    // result->push_back(ntca::EncryptionKeyType::e_DSA);
+    result->push_back(ntca::EncryptionKeyType::e_RSA);
+    result->push_back(ntca::EncryptionKeyType::e_NIST_P256);
+    result->push_back(ntca::EncryptionKeyType::e_NIST_P384);
+    result->push_back(ntca::EncryptionKeyType::e_NIST_P521);
+    result->push_back(ntca::EncryptionKeyType::e_ED25519);
+    result->push_back(ntca::EncryptionKeyType::e_ED448);
+}
+
+void KeyTestUtil::loadKeyStorageOptions(
+    bsl::vector<ntca::EncryptionResourceOptions>* result)
+{
+    {
+        ntca::EncryptionResourceOptions options;
+        options.setType(ntca::EncryptionResourceType::e_ASN1);
+        result->push_back(options);
+    }
+
+    {
+        ntca::EncryptionResourceOptions options;
+        options.setType(ntca::EncryptionResourceType::e_ASN1_PEM);
+        result->push_back(options);
+    }
+
+    {
+        ntca::EncryptionResourceOptions options;
+        options.setType(ntca::EncryptionResourceType::e_PKCS8);
+        result->push_back(options);
+    }
+
+    {
+        ntca::EncryptionResourceOptions options;
+        options.setType(ntca::EncryptionResourceType::e_PKCS8_PEM);
+        result->push_back(options);
+    }
+
+    {
+        ntca::EncryptionResourceOptions options;
+        options.setType(ntca::EncryptionResourceType::e_PKCS12);
+        result->push_back(options);
+    }
+}
+
+void KeyTestUtil::logHexDump(const bdlsb::MemOutStreamBuf& osb)
+{
+    bsl::stringstream ss;
+    ss << bdlb::PrintStringHexDumper(osb.data(),
+                                     static_cast<int>(osb.length()));
+
+    BSLS_LOG_DEBUG("Key:\n%s", ss.str().c_str());
+}
+
+void KeyTestUtil::logHexDump(const bdlbb::Blob& ob)
+{
+    bsl::stringstream ss;
+    ss << bdlbb::BlobUtilHexDumper(&ob);
+
+    BSLS_LOG_DEBUG("Key:\n%s", ss.str().c_str());
+}
+
+void KeyTestUtil::verifyKeyGeneration(
+    bsl::shared_ptr<ntci::EncryptionKey>* result,
+    const ntca::EncryptionKeyOptions&     keyConfig,
+    bslma::Allocator*                     allocator)
+{
+    ntsa::Error error;
+
+    bsl::shared_ptr<ntci::EncryptionDriver> driver;
+    ntctls::Plugin::load(&driver);
+
+    error = driver->generateKey(result, keyConfig, allocator);
+    NTSCFG_TEST_OK(error);
+}
+
+void KeyTestUtil::verifyKeyEncoding(
+    const bsl::shared_ptr<ntci::EncryptionKey>& key,
+    const ntca::EncryptionKeyOptions&           keyConfig,
+    const ntca::EncryptionResourceOptions&      keyStorageOptions,
+    bslma::Allocator*                           allocator)
+{
+    ntsa::Error error;
+    int         rc;
+
+    bsl::shared_ptr<ntci::EncryptionDriver> driver;
+    ntctls::Plugin::load(&driver);
+
+    // Write the key to an output stream buffer.
+
+    bdlsb::MemOutStreamBuf osb(allocator);
+
+    error = key->encode(&osb, keyStorageOptions);
+    NTSCFG_TEST_OK(error);
+
+    rc = osb.pubsync();
+    NTSCFG_TEST_EQ(rc, 0);
+
+    ntctls::KeyTestUtil::logHexDump(osb);
+
+    NTSCFG_TEST_NE(osb.data(), 0);
+    NTSCFG_TEST_GT(osb.length(), 0);
+
+    // Read the key from an input stream buffer.
+
+    bdlsb::FixedMemInStreamBuf isb(osb.data(), osb.length());
+
+    bsl::shared_ptr<ntci::EncryptionKey> key1;
+    error = driver->decodeKey(&key1, &isb, keyStorageOptions, allocator);
+    NTSCFG_TEST_OK(error);
+
+    // Compare the two keys.
+
+    bool equal = key->equals(*key1);
+    NTSCFG_TEST_TRUE(equal);
+
+    // Write the key just read back to another output stream buffer.
+
+    bdlsb::MemOutStreamBuf osb1(allocator);
+
+    error = key1->encode(&osb1, keyStorageOptions);
+    NTSCFG_TEST_OK(error);
+
+    rc = osb1.pubsync();
+    NTSCFG_TEST_EQ(rc, 0);
+
+    ntctls::KeyTestUtil::logHexDump(osb1);
+
+    // Compare the contents of the two streams. Note that recreating
+    // a PKCS12 container can result in a different encoding, even if
+    // the keys are the same.
+
+    if (keyStorageOptions.type().isNull() ||
+        keyStorageOptions.type().value() !=
+            ntca::EncryptionResourceType::e_PKCS12)
+    {
+        NTSCFG_TEST_EQ(osb.length(), osb1.length());
+
+        rc = bsl::memcmp(osb.data(), osb1.data(), osb1.length());
+        NTSCFG_TEST_EQ(rc, 0);
+    }
+}
+
+void KeyTestUtil::verifyKeyConfig(
+    const ntca::EncryptionKeyOptions&      keyConfig,
+    const ntca::EncryptionResourceOptions& keyStorageOptions,
+    bslma::Allocator*                      allocator)
+{
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_STREAM_INFO << "Testing " << keyConfig << " storage "
+                         << keyStorageOptions << NTCI_LOG_STREAM_END;
+
+    // Generate a key.
+
+    bsl::shared_ptr<ntci::EncryptionKey> key;
+    ntctls::KeyTestUtil::verifyKeyGeneration(&key, keyConfig, allocator);
+
+    // Test that the key can be encoded and decoded losslessly.
+
+    ntctls::KeyTestUtil::verifyKeyEncoding(key,
+                                           keyConfig,
+                                           keyStorageOptions,
+                                           allocator);
+}
+
+NTSCFG_TEST_FUNCTION(ntctls::KeyTest::verifyUsage)
+{
+    NTCI_LOG_CONTEXT();
+
+    NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_MAIN();
+
+    bslma::Allocator* allocator = NTSCFG_TEST_ALLOCATOR;
+
+    bsl::vector<ntca::EncryptionKeyType::Value> keyTypeVector(allocator);
+    ntctls::KeyTestUtil::loadKeyTypes(&keyTypeVector);
+
+    bsl::vector<ntca::EncryptionResourceOptions> keyStorageOptionsVector;
+    ntctls::KeyTestUtil::loadKeyStorageOptions(&keyStorageOptionsVector);
+
+    for (bsl::size_t i = 0; i < keyTypeVector.size(); ++i) {
+        for (bsl::size_t j = 0; j < keyStorageOptionsVector.size(); ++j) {
+            ntca::EncryptionKeyOptions keyConfig;
+            keyConfig.setType(keyTypeVector[i]);
+
+            ntctls::KeyTestUtil::verifyKeyConfig(keyConfig,
+                                                 keyStorageOptionsVector[j],
+                                                 allocator);
+        }
+    }
+}
+
+// Provide utilties for certificate tests.
+class CertificateTestUtil
+{
+  public:
+    // Load into the specified 'result' each supported key type.
+    static void loadKeyTypes(
+        bsl::vector<ntca::EncryptionKeyType::Value>* result);
+
+    // Load into the specified 'result' each supported variation of key
+    // storage options.
+    static void loadKeyStorageOptions(
+        bsl::vector<ntca::EncryptionResourceOptions>* result);
+
+    // Load into the specified 'result' each supported variation of certificate
+    // storage options.
+    static void loadCertificateStorageOptions(
+        bsl::vector<ntca::EncryptionResourceOptions>* result);
+
+    // Log the hex dump of the specified 'osb' stream buffer.
+    static void logHexDump(const char*                   type,
+                           const bdlsb::MemOutStreamBuf& osb);
+
+    // Log the hex dump of the specified 'ob' blob.
+    static void logHexDump(const char* type, const bdlbb::Blob& ob);
+
+    // Log the specified 'certificate'.
+    static void logCertificate(
+        const char*                                         label,
+        const bsl::shared_ptr<ntci::EncryptionCertificate>& certificate);
+
+    // Generate a key.
+    static void verifyKeyGeneration(
+        bsl::shared_ptr<ntci::EncryptionKey>* result,
+        const ntca::EncryptionKeyOptions&     keyConfig,
+        bslma::Allocator*                     allocator);
+
+    // Generate a self-signed certificate.
+    static void verifyCertificateGeneration(
+        bsl::shared_ptr<ntci::EncryptionCertificate>* result,
+        const ntsa::DistinguishedName&                userIdentity,
+        const bsl::shared_ptr<ntci::EncryptionKey>&   userPrivateKey,
+        const ntca::EncryptionCertificateOptions&     certificateConfig,
+        bslma::Allocator*                             allocator);
+
+    // Generate a certificate signed by another certificate.
+    static void verifyCertificateGeneration(
+        bsl::shared_ptr<ntci::EncryptionCertificate>* result,
+        const ntsa::DistinguishedName&                userIdentity,
+        const bsl::shared_ptr<ntci::EncryptionKey>&   userPrivateKey,
+        const bsl::shared_ptr<ntci::EncryptionCertificate>&
+                                                    authorityCertificate,
+        const bsl::shared_ptr<ntci::EncryptionKey>& authorityPrivateKey,
+        const ntca::EncryptionCertificateOptions&   certificateConfig,
+        bslma::Allocator*                           allocator);
+
+    // Encode then decode the specified 'key' to verify it is encoded and
+    // decoded losslessly.
+    static void verifyKeyEncoding(
+        const bsl::shared_ptr<ntci::EncryptionKey>& key,
+        const ntca::EncryptionKeyOptions&           keyConfig,
+        const ntca::EncryptionResourceOptions&      keyStorageOptions,
+        bslma::Allocator*                           allocator);
+
+    // Encode then decode the specified 'certificate' to verify it is encoded
+    // and decoded losslessly.
+    static void verifyCertificateEncoding(
+        const bsl::shared_ptr<ntci::EncryptionCertificate>& certificate,
+        const ntca::EncryptionCertificateOptions&           certificateConfig,
+        const ntca::EncryptionResourceOptions& certificateStorageOptions,
+        bslma::Allocator*                      allocator);
+};
+
+void CertificateTestUtil::loadKeyTypes(
+    bsl::vector<ntca::EncryptionKeyType::Value>* result)
+{
+    // result->push_back(ntca::EncryptionKeyType::e_DSA);
+    // result->push_back(ntca::EncryptionKeyType::e_RSA);
+    result->push_back(ntca::EncryptionKeyType::e_NIST_P256);
+    // result->push_back(ntca::EncryptionKeyType::e_NIST_P384);
+    // result->push_back(ntca::EncryptionKeyType::e_NIST_P521);
+    result->push_back(ntca::EncryptionKeyType::e_ED25519);
+    // result->push_back(ntca::EncryptionKeyType::e_ED448);
+}
+
+void CertificateTestUtil::loadKeyStorageOptions(
+    bsl::vector<ntca::EncryptionResourceOptions>* result)
+{
+    {
+        ntca::EncryptionResourceOptions options;
+        options.setType(ntca::EncryptionResourceType::e_ASN1);
+        result->push_back(options);
+    }
+
+    {
+        ntca::EncryptionResourceOptions options;
+        options.setType(ntca::EncryptionResourceType::e_ASN1_PEM);
+        result->push_back(options);
+    }
+
+    {
+        ntca::EncryptionResourceOptions options;
+        options.setType(ntca::EncryptionResourceType::e_PKCS8);
+        result->push_back(options);
+    }
+
+    {
+        ntca::EncryptionResourceOptions options;
+        options.setType(ntca::EncryptionResourceType::e_PKCS8_PEM);
+        result->push_back(options);
+    }
+
+    {
+        ntca::EncryptionResourceOptions options;
+        options.setType(ntca::EncryptionResourceType::e_PKCS12);
+        result->push_back(options);
+    }
+}
+
+void CertificateTestUtil::loadCertificateStorageOptions(
+    bsl::vector<ntca::EncryptionResourceOptions>* result)
+{
+    {
+        ntca::EncryptionResourceOptions options;
+        options.setType(ntca::EncryptionResourceType::e_ASN1);
+        result->push_back(options);
+    }
+
+    {
+        ntca::EncryptionResourceOptions options;
+        options.setType(ntca::EncryptionResourceType::e_ASN1_PEM);
+        result->push_back(options);
+    }
+
+    {
+        ntca::EncryptionResourceOptions options;
+        options.setType(ntca::EncryptionResourceType::e_PKCS12);
+        result->push_back(options);
+    }
+}
+
+void CertificateTestUtil::logHexDump(const char*                   type,
+                                     const bdlsb::MemOutStreamBuf& osb)
+{
+    bsl::stringstream ss;
+    ss << bdlb::PrintStringHexDumper(osb.data(),
+                                     static_cast<int>(osb.length()));
+
+    BSLS_LOG_TRACE("%s:\n%s", type, ss.str().c_str());
+}
+
+void CertificateTestUtil::logHexDump(const char* type, const bdlbb::Blob& ob)
+{
+    bsl::stringstream ss;
+    ss << bdlbb::BlobUtilHexDumper(&ob);
+
+    BSLS_LOG_TRACE("%s:\n%s", type, ss.str().c_str());
+}
+
+void CertificateTestUtil::logCertificate(
+    const char*                                         label,
+    const bsl::shared_ptr<ntci::EncryptionCertificate>& certificate)
+{
+    bsl::stringstream ss;
+    certificate->print(ss);
+
+    BSLS_LOG_DEBUG("%s = \n%s", label, ss.str().c_str());
+}
+
+void CertificateTestUtil::verifyKeyGeneration(
+    bsl::shared_ptr<ntci::EncryptionKey>* result,
+    const ntca::EncryptionKeyOptions&     keyConfig,
+    bslma::Allocator*                     allocator)
+{
+    ntsa::Error error;
+
+    bsl::shared_ptr<ntci::EncryptionDriver> driver;
+    ntctls::Plugin::load(&driver);
+
+    error = driver->generateKey(result, keyConfig, allocator);
+    NTSCFG_TEST_OK(error);
+}
+
+void CertificateTestUtil::verifyCertificateGeneration(
+    bsl::shared_ptr<ntci::EncryptionCertificate>* result,
+    const ntsa::DistinguishedName&                userIdentity,
+    const bsl::shared_ptr<ntci::EncryptionKey>&   userPrivateKey,
+    const ntca::EncryptionCertificateOptions&     certificateConfig,
+    bslma::Allocator*                             allocator)
+{
+    ntsa::Error error;
+
+    bsl::shared_ptr<ntci::EncryptionDriver> driver;
+    ntctls::Plugin::load(&driver);
+
+    error = driver->generateCertificate(result,
+                                        userIdentity,
+                                        userPrivateKey,
+                                        certificateConfig,
+                                        allocator);
+    NTSCFG_TEST_OK(error);
+}
+
+void CertificateTestUtil::verifyCertificateGeneration(
+    bsl::shared_ptr<ntci::EncryptionCertificate>*       result,
+    const ntsa::DistinguishedName&                      userIdentity,
+    const bsl::shared_ptr<ntci::EncryptionKey>&         userPrivateKey,
+    const bsl::shared_ptr<ntci::EncryptionCertificate>& authorityCertificate,
+    const bsl::shared_ptr<ntci::EncryptionKey>&         authorityPrivateKey,
+    const ntca::EncryptionCertificateOptions&           certificateConfig,
+    bslma::Allocator*                                   allocator)
+{
+    ntsa::Error error;
+
+    bsl::shared_ptr<ntci::EncryptionDriver> driver;
+    ntctls::Plugin::load(&driver);
+
+    error = driver->generateCertificate(result,
+                                        userIdentity,
+                                        userPrivateKey,
+                                        authorityCertificate,
+                                        authorityPrivateKey,
+                                        certificateConfig,
+                                        allocator);
+    NTSCFG_TEST_OK(error);
+}
+
+void CertificateTestUtil::verifyKeyEncoding(
+    const bsl::shared_ptr<ntci::EncryptionKey>& key,
+    const ntca::EncryptionKeyOptions&           keyConfig,
+    const ntca::EncryptionResourceOptions&      keyStorageOptions,
+    bslma::Allocator*                           allocator)
+{
+    ntsa::Error error;
+    int         rc;
+
+    bsl::shared_ptr<ntci::EncryptionDriver> driver;
+    ntctls::Plugin::load(&driver);
+
+    // Write the key to an output stream buffer.
+
+    bdlsb::MemOutStreamBuf osb(allocator);
+
+    error = key->encode(&osb, keyStorageOptions);
+    NTSCFG_TEST_OK(error);
+
+    rc = osb.pubsync();
+    NTSCFG_TEST_EQ(rc, 0);
+
+    CertificateTestUtil::logHexDump("Key", osb);
+
+    NTSCFG_TEST_NE(osb.data(), 0);
+    NTSCFG_TEST_GT(osb.length(), 0);
+
+    // Read the key from an input stream buffer.
+
+    bdlsb::FixedMemInStreamBuf isb(osb.data(), osb.length());
+
+    bsl::shared_ptr<ntci::EncryptionKey> key1;
+    error = driver->decodeKey(&key1, &isb, keyStorageOptions, allocator);
+    NTSCFG_TEST_OK(error);
+
+    // Compare the two keys.
+
+    bool equal = key->equals(*key1);
+    NTSCFG_TEST_TRUE(equal);
+
+    // Write the key just read back to another output stream buffer.
+
+    bdlsb::MemOutStreamBuf osb1(allocator);
+
+    error = key1->encode(&osb1, keyStorageOptions);
+    NTSCFG_TEST_OK(error);
+
+    rc = osb1.pubsync();
+    NTSCFG_TEST_EQ(rc, 0);
+
+    CertificateTestUtil::logHexDump("Key", osb1);
+
+    // Compare the contents of the two streams. Note that recreating
+    // a PKCS12 container can result in a different encoding, even if
+    // the keys are the same.
+
+    if (keyStorageOptions.type().isNull() ||
+        keyStorageOptions.type().value() !=
+            ntca::EncryptionResourceType::e_PKCS12)
+    {
+        NTSCFG_TEST_EQ(osb.length(), osb1.length());
+
+        rc = bsl::memcmp(osb.data(), osb1.data(), osb1.length());
+        NTSCFG_TEST_EQ(rc, 0);
+    }
+}
+
+void CertificateTestUtil::verifyCertificateEncoding(
+    const bsl::shared_ptr<ntci::EncryptionCertificate>& certificate,
+    const ntca::EncryptionCertificateOptions&           certificateConfig,
+    const ntca::EncryptionResourceOptions& certificateStorageOptions,
+    bslma::Allocator*                      allocator)
+{
+    ntsa::Error error;
+    int         rc;
+
+    bsl::shared_ptr<ntci::EncryptionDriver> driver;
+    ntctls::Plugin::load(&driver);
+
+    // Write the certificate to an output stream buffer.
+
+    bdlsb::MemOutStreamBuf osb(allocator);
+
+    error = certificate->encode(&osb, certificateStorageOptions);
+    NTSCFG_TEST_OK(error);
+
+    rc = osb.pubsync();
+    NTSCFG_TEST_EQ(rc, 0);
+
+    CertificateTestUtil::logHexDump("Certificate", osb);
+
+    NTSCFG_TEST_NE(osb.data(), 0);
+    NTSCFG_TEST_GT(osb.length(), 0);
+
+    // Read the certificate from an input stream buffer.
+
+    bdlsb::FixedMemInStreamBuf isb(osb.data(), osb.length());
+
+    bsl::shared_ptr<ntci::EncryptionCertificate> certificate1;
+    error = driver->decodeCertificate(&certificate1,
+                                      &isb,
+                                      certificateStorageOptions,
+                                      allocator);
+    NTSCFG_TEST_OK(error);
+
+    // Compare the two certificates.
+
+    bool equal = certificate->equals(*certificate1);
+    NTSCFG_TEST_TRUE(equal);
+
+    // Write the certificate just read back to another output stream
+    // buffer.
+
+    bdlsb::MemOutStreamBuf osb1(allocator);
+
+    error = certificate1->encode(&osb1, certificateStorageOptions);
+    NTSCFG_TEST_OK(error);
+
+    rc = osb1.pubsync();
+    NTSCFG_TEST_EQ(rc, 0);
+
+    CertificateTestUtil::logHexDump("Certificate", osb1);
+
+    // Compare the contents of the two streams .Note that recreating
+    // a PKCS12 container can result in a different encoding, even if
+    // the keys are the same.
+
+    if (certificateStorageOptions.type().isNull() ||
+        certificateStorageOptions.type().value() !=
+            ntca::EncryptionResourceType::e_PKCS12)
+    {
+        NTSCFG_TEST_EQ(osb.length(), osb1.length());
+
+        rc = bsl::memcmp(osb.data(), osb1.data(), osb1.length());
+        NTSCFG_TEST_EQ(rc, 0);
+    }
+}
+
+// Provide certificate tests.
+class CertificateTest
+{
+  private:
+    // Generate certificate authorities.
+    static void verifyAuthorityOptions(
+        ntca::EncryptionKeyType::Value         authorityKeyType,
+        const ntca::EncryptionResourceOptions& keyStorageOptions,
+        const ntca::EncryptionResourceOptions& certificateStorageOptions,
+        bslma::Allocator*                      allocator);
+
+    // Generate self-signed certificates.
+    static void verifyUserSignedBySelfOptions(
+        ntca::EncryptionKeyType::Value         userKeyType,
+        const ntca::EncryptionResourceOptions& keyStorageOptions,
+        const ntca::EncryptionResourceOptions& certificateStorageOptions,
+        bslma::Allocator*                      allocator);
+
+    // Generate a certificate signed by a certificate authority.
+    static void verifyUserSignedByAuthorityOptions(
+        ntca::EncryptionKeyType::Value         authorityKeyType,
+        ntca::EncryptionKeyType::Value         userKeyType,
+        const ntca::EncryptionResourceOptions& keyStorageOptions,
+        const ntca::EncryptionResourceOptions& certificateStorageOptions,
+        bslma::Allocator*                      allocator);
+
+  public:
+    // Generate certificate authorities.
+    static void verifyAuthority();
+
+    // Generate self-signed certificates.
+    static void verifyUserSignedBySelf();
+
+    // Generate a certificate signed by a certificate authority.
+    static void verifyUserSignedByAuthority();
+};
+
+void CertificateTest::verifyAuthorityOptions(
+    ntca::EncryptionKeyType::Value         authorityKeyType,
+    const ntca::EncryptionResourceOptions& keyStorageOptions,
+    const ntca::EncryptionResourceOptions& certificateStorageOptions,
+    bslma::Allocator*                      allocator)
+{
+    // TESTING 'generate' (CA)
+    //
+    // Concerns: The mechanism under test can successfully generate certificate
+    // authorities.
+    //
+    // Plan: Initialize the OpenSSL framework. Create a generator mechanism.
+    // Configure the identity of the certificate authority.  Ensure the
+    // generator can successfully generate a key used by the certificate
+    // authority.  Ensure the generator can successfully generate a certificate
+    // authority using the configured identity and generated key.
+
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_STREAM_INFO << "Testing authority key type " << authorityKeyType
+                         << " key storage " << keyStorageOptions
+                         << " certificate storage "
+                         << certificateStorageOptions << NTCI_LOG_STREAM_END;
+
+    // Define the authority subject.
+
+    ntsa::DistinguishedName authorityIdentity;
+    authorityIdentity["CN"] = "TEST.AUTHORITY";
+    authorityIdentity["O"]  = "Bloomberg LP";
+
+    // Define the authority private key generation configuration.
+
+    ntca::EncryptionKeyOptions authorityKeyConfig;
+    authorityKeyConfig.setType(authorityKeyType);
+
+    // Define the authority certificate generation configuration.
+
+    ntca::EncryptionCertificateOptions authorityCertificateConfig;
+    authorityCertificateConfig.setAuthority(true);
+
+    // Generate the authority private key.
+
+    bsl::shared_ptr<ntci::EncryptionKey> authorityPrivateKey;
+    CertificateTestUtil::verifyKeyGeneration(&authorityPrivateKey,
+                                             authorityKeyConfig,
+                                             allocator);
+
+    // Test that the authority private key can be encoded and decoded
+    // losslessly.
+
+    CertificateTestUtil::verifyKeyEncoding(authorityPrivateKey,
+                                           authorityKeyConfig,
+                                           keyStorageOptions,
+                                           allocator);
+
+    // Generate the authority certificated.
+
+    bsl::shared_ptr<ntci::EncryptionCertificate> authorityCertificate;
+    CertificateTestUtil::verifyCertificateGeneration(
+        &authorityCertificate,
+        authorityIdentity,
+        authorityPrivateKey,
+        authorityCertificateConfig,
+        allocator);
+
+    CertificateTestUtil::logCertificate("Trusted certificate",
+                                        authorityCertificate);
+
+    // Test that the authority certificate can be encoded and decoded
+    // losslessly.
+
+    CertificateTestUtil::verifyCertificateEncoding(authorityCertificate,
+                                                   authorityCertificateConfig,
+                                                   certificateStorageOptions,
+                                                   allocator);
+}
+
+void CertificateTest::verifyUserSignedBySelfOptions(
+    ntca::EncryptionKeyType::Value         userKeyType,
+    const ntca::EncryptionResourceOptions& keyStorageOptions,
+    const ntca::EncryptionResourceOptions& certificateStorageOptions,
+    bslma::Allocator*                      allocator)
+{
+    // TESTING 'generate' (self-signed)
+    //
+    // Concerns: The mechanism under test can successfully generate a
+    // certificate signed by a certificate authority.
+    //
+    // Plan: Initialize the OpenSSL framework. Create a generator mechanism.
+    // Configure the identity of a user certificate.  Ensure the generator can
+    // successfully generate a key used by the user certificate.  Ensure the
+    // generator can successfully generate a self-signed certificate using the
+    // configured user identity and user key.
+
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_STREAM_INFO << "Testing user key type " << userKeyType
+                         << " key storage " << keyStorageOptions
+                         << " certificate storage "
+                         << certificateStorageOptions << NTCI_LOG_STREAM_END;
+
+    // Define the user subject.
+
+    ntsa::DistinguishedName userIdentity;
+    userIdentity["CN"] = "TEST.USER";
+    userIdentity["O"]  = "Bloomberg LP";
+
+    // Define the user private key generation configuration.
+
+    ntca::EncryptionKeyOptions userKeyConfig;
+    userKeyConfig.setType(userKeyType);
+
+    // Define the user certificate generation configuration.
+
+    ntca::EncryptionCertificateOptions userCertificateConfig;
+    userCertificateConfig.setAuthority(false);
+
+    // Generate the user private key.
+
+    bsl::shared_ptr<ntci::EncryptionKey> userPrivateKey;
+    CertificateTestUtil::verifyKeyGeneration(&userPrivateKey,
+                                             userKeyConfig,
+                                             allocator);
+
+    // Test that the user private key can be encoded and decoded
+    // losslessly.
+
+    CertificateTestUtil::verifyKeyEncoding(userPrivateKey,
+                                           userKeyConfig,
+                                           keyStorageOptions,
+                                           allocator);
+
+    // Generate the certificate of the user, signed by itself.
+
+    bsl::shared_ptr<ntci::EncryptionCertificate> userCertificate;
+    CertificateTestUtil::verifyCertificateGeneration(&userCertificate,
+                                                     userIdentity,
+                                                     userPrivateKey,
+                                                     userCertificateConfig,
+                                                     allocator);
+
+    CertificateTestUtil::logCertificate("Self-signed user certificate",
+                                        userCertificate);
+
+    // Test that the user certificate can be encoded and decoded
+    // losslessly.
+
+    CertificateTestUtil::verifyCertificateEncoding(userCertificate,
+                                                   userCertificateConfig,
+                                                   certificateStorageOptions,
+                                                   allocator);
+}
+
+void CertificateTest::verifyUserSignedByAuthorityOptions(
+    ntca::EncryptionKeyType::Value         authorityKeyType,
+    ntca::EncryptionKeyType::Value         userKeyType,
+    const ntca::EncryptionResourceOptions& keyStorageOptions,
+    const ntca::EncryptionResourceOptions& certificateStorageOptions,
+    bslma::Allocator*                      allocator)
+{
+    // TESTING 'generate' (CA-signed)
+    //
+    // Concerns: The mechanism under test can successfully generate a
+    // certificate signed by a certificate authority.
+    //
+    // Plan: Initialize the OpenSSL framework. Create a generator mechanism.
+    // Configure the identity of the certificate authority.  Ensure the
+    // generator can successfully generate a key used by the certificate
+    // authority.  Ensure the generator can successfully generate a certificate
+    // authority using the configured identity and generated key.  Configure
+    // the identity of a user certificate.  Ensure the generator can
+    // successfully generate a key used by the user certificate.  Ensure the
+    // generator can successfully generate a certificate using the configured
+    // user identity and user key signed by the certificate authority.
+
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_STREAM_INFO << "Testing user key type " << userKeyType
+                         << " authority key type " << authorityKeyType
+                         << " key storage " << keyStorageOptions
+                         << " certificate storage "
+                         << certificateStorageOptions << NTCI_LOG_STREAM_END;
+
+    // Define the authority subject.
+
+    ntsa::DistinguishedName authorityIdentity;
+    authorityIdentity["CN"] = "TEST.AUTHORITY";
+    authorityIdentity["O"]  = "Bloomberg LP";
+
+    // Define the authority private key generation configuration.
+
+    ntca::EncryptionKeyOptions authorityKeyConfig;
+    authorityKeyConfig.setType(authorityKeyType);
+
+    // Define the authority certificate generation configuration.
+
+    ntca::EncryptionCertificateOptions authorityCertificateConfig;
+    authorityCertificateConfig.setAuthority(true);
+
+    // Define the user subject.
+
+    ntsa::DistinguishedName userIdentity;
+    userIdentity["CN"] = "TEST.USER";
+    userIdentity["O"]  = "Bloomberg LP";
+
+    // Define the user private key generation configuration.
+
+    ntca::EncryptionKeyOptions userKeyConfig;
+    userKeyConfig.setType(userKeyType);
+
+    // Define the user certificate generation configuration.
+
+    ntca::EncryptionCertificateOptions userCertificateConfig;
+    userCertificateConfig.setAuthority(false);
+
+    // Generate the authority private key.
+
+    bsl::shared_ptr<ntci::EncryptionKey> authorityPrivateKey;
+    CertificateTestUtil::verifyKeyGeneration(&authorityPrivateKey,
+                                             authorityKeyConfig,
+                                             allocator);
+
+    // Test that the authority private key can be encoded and decoded
+    // losslessly.
+
+    CertificateTestUtil::verifyKeyEncoding(authorityPrivateKey,
+                                           authorityKeyConfig,
+                                           keyStorageOptions,
+                                           allocator);
+
+    // Generate the authority certificated.
+
+    bsl::shared_ptr<ntci::EncryptionCertificate> authorityCertificate;
+    CertificateTestUtil::verifyCertificateGeneration(
+        &authorityCertificate,
+        authorityIdentity,
+        authorityPrivateKey,
+        authorityCertificateConfig,
+        allocator);
+
+    CertificateTestUtil::logCertificate("Trusted certificate",
+                                        authorityCertificate);
+
+    // Test that the authority certificate can be encoded and decoded
+    // losslessly.
+
+    CertificateTestUtil::verifyCertificateEncoding(authorityCertificate,
+                                                   authorityCertificateConfig,
+                                                   certificateStorageOptions,
+                                                   allocator);
+
+    // Generate the user private key.
+
+    bsl::shared_ptr<ntci::EncryptionKey> userPrivateKey;
+    CertificateTestUtil::verifyKeyGeneration(&userPrivateKey,
+                                             userKeyConfig,
+                                             allocator);
+
+    // Test that the user private key can be encoded and decoded
+    // losslessly.
+
+    CertificateTestUtil::verifyKeyEncoding(userPrivateKey,
+                                           userKeyConfig,
+                                           keyStorageOptions,
+                                           allocator);
+
+    // Generate the certificate of the user, signed by the authority.
+
+    bsl::shared_ptr<ntci::EncryptionCertificate> userCertificate;
+    CertificateTestUtil::verifyCertificateGeneration(&userCertificate,
+                                                     userIdentity,
+                                                     userPrivateKey,
+                                                     authorityCertificate,
+                                                     authorityPrivateKey,
+                                                     userCertificateConfig,
+                                                     allocator);
+
+    CertificateTestUtil::logCertificate("CA-signed user certificate",
+                                        userCertificate);
+
+    // Test that the user certificate can be encoded and decoded
+    // losslessly.
+
+    CertificateTestUtil::verifyCertificateEncoding(userCertificate,
+                                                   userCertificateConfig,
+                                                   certificateStorageOptions,
+                                                   allocator);
+}
+
+NTSCFG_TEST_FUNCTION(ntctls::CertificateTest::verifyAuthority)
+{
+    NTCI_LOG_CONTEXT();
+
+    NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_MAIN();
+
+    bslma::Allocator* allocator = NTSCFG_TEST_ALLOCATOR;
+
+    bsl::vector<ntca::EncryptionKeyType::Value> keyTypeVector(allocator);
+    CertificateTestUtil::loadKeyTypes(&keyTypeVector);
+
+    bsl::vector<ntca::EncryptionResourceOptions> keyStorageOptionsVector;
+    CertificateTestUtil::loadKeyStorageOptions(&keyStorageOptionsVector);
+
+    bsl::vector<ntca::EncryptionResourceOptions>
+        certificateStorageOptionsVector;
+    CertificateTestUtil::loadCertificateStorageOptions(
+        &certificateStorageOptionsVector);
+
+    for (bsl::size_t i = 0; i < keyTypeVector.size(); ++i) {
+        for (bsl::size_t j = 0; j < keyStorageOptionsVector.size(); ++j) {
+            for (bsl::size_t k = 0; k < certificateStorageOptionsVector.size();
+                 ++k)
+            {
+                CertificateTest::verifyAuthorityOptions(
+                    keyTypeVector[i],
+                    keyStorageOptionsVector[j],
+                    certificateStorageOptionsVector[k],
+                    allocator);
+            }
+        }
+    }
+}
+
+NTSCFG_TEST_FUNCTION(ntctls::CertificateTest::verifyUserSignedBySelf)
+{
+    NTCI_LOG_CONTEXT();
+
+    NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_MAIN();
+
+    bslma::Allocator* allocator = NTSCFG_TEST_ALLOCATOR;
+
+    bsl::vector<ntca::EncryptionKeyType::Value> keyTypeVector(allocator);
+    CertificateTestUtil::loadKeyTypes(&keyTypeVector);
+
+    bsl::vector<ntca::EncryptionResourceOptions> keyStorageOptionsVector;
+    CertificateTestUtil::loadKeyStorageOptions(&keyStorageOptionsVector);
+
+    bsl::vector<ntca::EncryptionResourceOptions>
+        certificateStorageOptionsVector;
+    CertificateTestUtil::loadCertificateStorageOptions(
+        &certificateStorageOptionsVector);
+
+    for (bsl::size_t i = 0; i < keyTypeVector.size(); ++i) {
+        for (bsl::size_t j = 0; j < keyStorageOptionsVector.size(); ++j) {
+            for (bsl::size_t k = 0; k < certificateStorageOptionsVector.size();
+                 ++k)
+            {
+                CertificateTest::verifyUserSignedBySelfOptions(
+                    keyTypeVector[i],
+                    keyStorageOptionsVector[j],
+                    certificateStorageOptionsVector[k],
+                    allocator);
+            }
+        }
+    }
+}
+
+NTSCFG_TEST_FUNCTION(ntctls::CertificateTest::verifyUserSignedByAuthority)
+{
+    NTCI_LOG_CONTEXT();
+
+    NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_MAIN();
+
+    bslma::Allocator* allocator = NTSCFG_TEST_ALLOCATOR;
+
+    bsl::vector<ntca::EncryptionKeyType::Value> keyTypeVector(allocator);
+    CertificateTestUtil::loadKeyTypes(&keyTypeVector);
+
+    bsl::vector<ntca::EncryptionResourceOptions> keyStorageOptionsVector;
+    CertificateTestUtil::loadKeyStorageOptions(&keyStorageOptionsVector);
+
+    bsl::vector<ntca::EncryptionResourceOptions>
+        certificateStorageOptionsVector;
+    CertificateTestUtil::loadCertificateStorageOptions(
+        &certificateStorageOptionsVector);
+
+    for (bsl::size_t i = 0; i < keyTypeVector.size(); ++i) {
+        for (bsl::size_t j = 0; j < keyTypeVector.size(); ++j) {
+            for (bsl::size_t k = 0; k < keyStorageOptionsVector.size(); ++k) {
+                for (bsl::size_t l = 0;
+                     l < certificateStorageOptionsVector.size();
+                     ++l)
+                {
+                    CertificateTest::verifyUserSignedByAuthorityOptions(
+                        keyTypeVector[i],
+                        keyTypeVector[j],
+                        keyStorageOptionsVector[k],
+                        certificateStorageOptionsVector[l],
+                        allocator);
+                }
+            }
+        }
+    }
+}
+
+// Uncomment to test a specific test case parameter variation.
+// #define NTCTLS_RESOURCE_TEST_CASE_ID 21505
+
+const ntca::EncryptionKeyType::Value k_DEFAULT_KEY_TYPE =
+    ntca::EncryptionKeyType::e_NIST_P256;
+
+const bsl::size_t k_DEFAULT_INCLUDE_PRIVATE_KEY = 1;
+const bsl::size_t k_DEFAULT_INCLUDE_CERTIFICATE = 1;
+
+const bsl::size_t k_DEFAULT_TRUST_CHAIN_COUNT = 1;
+const bsl::size_t k_MIN_TRUST_CHAIN_COUNT     = 0;
+const bsl::size_t k_MAX_TRUST_CHAIN_COUNT     = 1;
+
+const bsl::size_t k_DEFAULT_TRUST_CHAIN_DEPTH = 1;
+const bsl::size_t k_MIN_TRUST_CHAIN_DEPTH     = 0;
+const bsl::size_t k_MAX_TRUST_CHAIN_DEPTH     = 1;
+
+const char k_DEFAULT_SECRET[] = "abcdefghikjlkmopqrstuvwxyz";
+
+// Describe test parameters.
+class ResourceTestParameters
+{
+    bsl::size_t                     d_variationIndex;
+    bsl::size_t                     d_variationCount;
+    ntca::EncryptionKeyType::Value  d_keyType;
+    ntca::EncryptionResourceOptions d_resourceEncoderOptions;
+    ntca::EncryptionResourceOptions d_resourceDecoderOptions;
+    bool                            d_includePrivateKey;
+    bool                            d_includeCertificate;
+    bsl::size_t                     d_trustChainCount;
+    bsl::size_t                     d_trustChainDepth;
+
+  public:
+    // Create new test parameters having the default value. Optionally specify
+    // a 'basicAllocator' used to supply memory. If 'basicAllocator' is 0, the
+    // currently installed default allocator is used.
+    explicit ResourceTestParameters(bslma::Allocator* basicAllocator = 0);
+
+    // Create new test parameters having the same value as the specified
+    // 'original' object. Optionally specify a 'basicAllocator' used to supply
+    // memory. If 'basicAllocator' is 0, the currently installed default
+    // allocator is used.
+    ResourceTestParameters(const ResourceTestParameters& original,
+                           bslma::Allocator*             basicAllocator = 0);
+
+    // Destroy this object.
+    ~ResourceTestParameters();
+
+    // Assign the value of the specified 'other' object to this object. Return
+    // a reference to this object.
+    ResourceTestParameters& operator=(const ResourceTestParameters& other);
+
+    // Reset the value of this object to its value upon default construction.
+    void reset();
+
+    // Set the index of these parameters in the overall parameters set to the
+    // specified 'value'.
+    void setVariationIndex(bsl::size_t value);
+
+    // Set the total number of variations of parameters in the set of
+    // parameters being tested to the specified 'value'.
+    void setVariationCount(bsl::size_t value);
+
+    // Set the key type to the specified 'value'.
+    void setKeyType(ntca::EncryptionKeyType::Value value);
+
+    // Set the resource encoder options to the specified 'value'.
+    void setResourceEncoderOptions(
+        const ntca::EncryptionResourceOptions& value);
+
+    // Set the resource decoder options to the specified 'value'.
+    void setResourceDecoderOptions(
+        const ntca::EncryptionResourceOptions& value);
+
+    // Set the flag to include the user's private key in the resource to the to
+    // the specified 'value'.
+    void setIncludePrivateKey(bool value);
+
+    // Set the flag to include the user's certificate in the resource to the to
+    // the specified 'value'.
+    void setIncludeCertificate(bool value);
+
+    // Set the number of certificate authority chains to the specified 'value'.
+    void setTrustChainCount(bsl::size_t value);
+
+    // Set the depth of each certificate authority chain to the specified
+    // 'value'.
+    void setTrustChainDepth(bsl::size_t value);
+
+    // Return the index of these parameters in the overall parameters set.
+    bsl::size_t variationIndex() const;
+
+    // Return the total number of variations of parameters in the set of
+    // parameters being tested.
+    bsl::size_t variationCount() const;
+
+    // Return the key type.
+    ntca::EncryptionKeyType::Value keyType() const;
+
+    // Return the resource encoder options.
+    const ntca::EncryptionResourceOptions& resourceEncoderOptions() const;
+
+    // Return the resource decoder options.
+    const ntca::EncryptionResourceOptions& resourceDecoderOptions() const;
+
+    // Return the flag to include the user's certificate in the resource.
+    bool includePrivateKey() const;
+
+    // Return the flag to include the user's certificate in the resource.
+    bool includeCertificate() const;
+
+    // Return the number of certificate authority chains.
+    bsl::size_t trustChainCount() const;
+
+    // Return the depth of each certificate authority chain.
+    bsl::size_t trustChainDepth() const;
+
+    /// Format this object to the specified output 'stream' at the
+    /// optionally specified indentation 'level' and return a reference to
+    /// the modifiable 'stream'.  If 'level' is specified, optionally
+    /// specify 'spacesPerLevel', the number of spaces per indentation level
+    /// for this and all of its nested objects.  Each line is indented by
+    /// the absolute value of 'level * spacesPerLevel'.  If 'level' is
+    /// negative, suppress indentation of the first line.  If
+    /// 'spacesPerLevel' is negative, suppress line breaks and format the
+    /// entire output on one line.  If 'stream' is initially invalid, this
+    /// operation has no effect.  Note that a trailing newline is provided
+    /// in multiline mode only.
+    bsl::ostream& print(bsl::ostream& stream,
+                        int           level          = 0,
+                        int           spacesPerLevel = 4) const;
+
+    /// Defines the traits of this type. These traits can be used to select,
+    /// at compile-time, the most efficient algorithm to manipulate objects
+    /// of this type.
+    NTCCFG_DECLARE_NESTED_USES_ALLOCATOR_TRAITS(ResourceTestParameters);
+};
+
+// Write a formatted, human-readable description of the specified 'object' to
+// the specified 'stream'. Return a reference to the 'stream'.
+bsl::ostream& operator<<(bsl::ostream&                 stream,
+                         const ResourceTestParameters& object);
+
+// Define a type alias for a vector of test parameters.
+typedef bsl::vector<ResourceTestParameters> ResourceTestParametersVector;
+
+// Provide utilities for loading test parameters.
+class ResourceTestParametersUtil
+{
+  public:
+    // Load into the specified 'result' each supported key type.
+    static void loadKeyTypes(
+        bsl::vector<ntca::EncryptionKeyType::Value>* result);
+
+    // Load into the specified 'result' each supported resource type.
+    static void loadResourceTypes(
+        bsl::vector<ntca::EncryptionResourceType::Value>* result);
+
+    // Load into the specified 'result' each supported variation of resource
+    // storage options.
+    static void loadResourceOptions(
+        bsl::vector<ntca::EncryptionResourceOptions>* result);
+
+    // Load into the specified 'result' the test parameters.
+    static void loadParameters(
+        bsl::vector<ntctls::ResourceTestParameters>* result);
+
+    // Load into the specified 'result' the passphrase used when symmetrically
+    // encrypting a resource. Return the error.
+    static ntsa::Error loadSecret(ntca::EncryptionSecret* result);
+
+    // Load into the specified 'result' a resource containing private keys,
+    // certificates, and certificate authority chains according to the
+    // specified 'parameters'. Optionally specify a 'basicAllocator' used to
+    // supply memory. If 'basicAllocator' is 0, the currently installed default
+    // allocator is used.
+    static ntsa::Error loadResource(
+        bsl::shared_ptr<ntci::EncryptionResource>* result,
+        const ntctls::ResourceTestParameters&      parameters,
+        bslma::Allocator*                          basicAllocator = 0);
+
+    // Log the hex dump of the specified 'osb' stream buffer.
+    static void logHexDump(ntca::EncryptionResourceType::Value type,
+                           const bdlsb::MemOutStreamBuf&       osb);
+
+    // Log the speciifed 'key' with the specified 'label'.
+    static void logKey(const char*                                 label,
+                       const bsl::shared_ptr<ntci::EncryptionKey>& key);
+
+    // Log the speciifed 'key' with the specified 'label'.
+    static void logCertificate(
+        const char*                                         label,
+        const bsl::shared_ptr<ntci::EncryptionCertificate>& certificate);
+
+    // Verify the specified 'error' found when loading a resource according to
+    // the specified 'parameters'.
+    static void verifyLoadResult(
+        ntsa::Error                           error,
+        const ntctls::ResourceTestParameters& parameters);
+
+    // Verify the specified 'error' found when encoding a resource according to
+    // the specified 'parameters'.
+    static void verifyEncodeResult(
+        ntsa::Error                           error,
+        const ntctls::ResourceTestParameters& parameters);
+
+    // Verify the specified 'error' found when decoding a resource according to
+    // the specified 'parameters'.
+    static void verifyDecodeResult(
+        ntsa::Error                           error,
+        const ntctls::ResourceTestParameters& parameters);
+
+    // Verify the specified 'foundResource' has the private keys and
+    // certificates that are possible to decode from an encoding of the
+    // specified 'expectedResource' according to the specified 'paramters'.
+    static void verifyEquals(
+        const bsl::shared_ptr<ntci::EncryptionResource>& foundResource,
+        const bsl::shared_ptr<ntci::EncryptionResource>& expectedResource,
+        const ntctls::ResourceTestParameters&            parameters);
+
+    /// Return true if the specified 'lhsResource' contains the keys of the
+    /// specified 'other' 'rhsResource' (if the specified 'includePrivateKeys'
+    /// flag is true) and this resource contains the certificate and
+    /// certificate authorities of the 'other' resource (if the specified
+    /// 'includeCertificates' flag is true.
+    static bool verifyContains(
+        const bsl::shared_ptr<ntci::EncryptionResource>& lhsResource,
+        const bsl::shared_ptr<ntci::EncryptionResource>& rhsResource,
+        bool                                             includePrivateKeys,
+        bool                                             includeCertificates);
+};
+
+// Provide implementations of test cases.
+class ResourceTest
+{
+  private:
+    // Generate a resource, encode it, decode it, and verify the decoded
+    // resource matches the encoded resource. Perform the test according to the
+    // specified 'parameters'. Allocate memory using the specified 'allocator'.
+    static void verifyUsageParameters(
+        const ntctls::ResourceTestParameters& parameters,
+        bslma::Allocator*                     allocator);
+
+  public:
+    // Generate a resource, encode it, decode it, and verify the decoded
+    // resource matches the encoded resource. Repeat the test for a varitey of
+    // parameters.
+    static void verifyUsage();
+};
+
+ResourceTestParameters::ResourceTestParameters(
+    bslma::Allocator* basicAllocator)
+: d_variationIndex(0)
+, d_variationCount(0)
+, d_keyType(k_DEFAULT_KEY_TYPE)
+, d_resourceEncoderOptions(basicAllocator)
+, d_resourceDecoderOptions(basicAllocator)
+, d_includePrivateKey(k_DEFAULT_INCLUDE_PRIVATE_KEY)
+, d_includeCertificate(k_DEFAULT_INCLUDE_CERTIFICATE)
+, d_trustChainCount(k_DEFAULT_TRUST_CHAIN_COUNT)
+, d_trustChainDepth(k_DEFAULT_TRUST_CHAIN_DEPTH)
+{
+}
+
+ResourceTestParameters::ResourceTestParameters(
+    const ResourceTestParameters& original,
+    bslma::Allocator*             basicAllocator)
+: d_variationIndex(original.d_variationIndex)
+, d_variationCount(original.d_variationCount)
+, d_keyType(original.d_keyType)
+, d_resourceEncoderOptions(original.d_resourceEncoderOptions, basicAllocator)
+, d_resourceDecoderOptions(original.d_resourceDecoderOptions, basicAllocator)
+, d_includePrivateKey(original.d_includePrivateKey)
+, d_includeCertificate(original.d_includeCertificate)
+, d_trustChainCount(original.d_trustChainCount)
+, d_trustChainDepth(original.d_trustChainDepth)
+{
+}
+
+ResourceTestParameters::~ResourceTestParameters()
+{
+}
+
+ResourceTestParameters& ResourceTestParameters::operator=(
+    const ResourceTestParameters& other)
+{
+    if (this != &other) {
+        d_variationIndex         = other.d_variationIndex;
+        d_variationCount         = other.d_variationCount;
+        d_keyType                = other.d_keyType;
+        d_resourceEncoderOptions = other.d_resourceEncoderOptions;
+        d_resourceDecoderOptions = other.d_resourceDecoderOptions;
+        d_includePrivateKey      = other.d_includePrivateKey;
+        d_includeCertificate     = other.d_includeCertificate;
+        d_trustChainCount        = other.d_trustChainCount;
+        d_trustChainDepth        = other.d_trustChainDepth;
+    }
+
+    return *this;
+}
+
+void ResourceTestParameters::reset()
+{
+    d_variationIndex = 0;
+    d_variationCount = 0;
+    d_keyType        = k_DEFAULT_KEY_TYPE;
+    d_resourceEncoderOptions.reset();
+    d_resourceDecoderOptions.reset();
+    d_includePrivateKey  = k_DEFAULT_INCLUDE_PRIVATE_KEY;
+    d_includeCertificate = k_DEFAULT_INCLUDE_CERTIFICATE;
+    d_trustChainCount    = k_DEFAULT_TRUST_CHAIN_COUNT;
+    d_trustChainDepth    = k_DEFAULT_TRUST_CHAIN_DEPTH;
+}
+
+void ResourceTestParameters::setVariationIndex(bsl::size_t value)
+{
+    d_variationIndex = value;
+}
+
+void ResourceTestParameters::setVariationCount(bsl::size_t value)
+{
+    d_variationCount = value;
+}
+
+void ResourceTestParameters::setKeyType(ntca::EncryptionKeyType::Value value)
+{
+    d_keyType = value;
+}
+
+void ResourceTestParameters::setResourceEncoderOptions(
+    const ntca::EncryptionResourceOptions& value)
+{
+    d_resourceEncoderOptions = value;
+}
+
+void ResourceTestParameters::setResourceDecoderOptions(
+    const ntca::EncryptionResourceOptions& value)
+{
+    d_resourceDecoderOptions = value;
+}
+
+void ResourceTestParameters::setIncludePrivateKey(bool value)
+{
+    d_includePrivateKey = value;
+}
+
+void ResourceTestParameters::setIncludeCertificate(bool value)
+{
+    d_includeCertificate = value;
+}
+
+void ResourceTestParameters::setTrustChainCount(bsl::size_t value)
+{
+    d_trustChainCount = value;
+}
+
+void ResourceTestParameters::setTrustChainDepth(bsl::size_t value)
+{
+    d_trustChainDepth = value;
+}
+
+bsl::size_t ResourceTestParameters::variationIndex() const
+{
+    return d_variationIndex;
+}
+
+bsl::size_t ResourceTestParameters::variationCount() const
+{
+    return d_variationCount;
+}
+
+ntca::EncryptionKeyType::Value ResourceTestParameters::keyType() const
+{
+    return d_keyType;
+}
+
+const ntca::EncryptionResourceOptions& ResourceTestParameters::
+    resourceEncoderOptions() const
+{
+    return d_resourceEncoderOptions;
+}
+
+const ntca::EncryptionResourceOptions& ResourceTestParameters::
+    resourceDecoderOptions() const
+{
+    return d_resourceDecoderOptions;
+}
+
+bool ResourceTestParameters::includePrivateKey() const
+{
+    return d_includePrivateKey;
+}
+
+bool ResourceTestParameters::includeCertificate() const
+{
+    return d_includeCertificate;
+}
+
+bsl::size_t ResourceTestParameters::trustChainCount() const
+{
+    return d_trustChainCount;
+}
+
+bsl::size_t ResourceTestParameters::trustChainDepth() const
+{
+    return d_trustChainDepth;
+}
+
+bsl::ostream& ResourceTestParameters::print(bsl::ostream& stream,
+                                            int           level,
+                                            int           spacesPerLevel) const
+{
+    bslim::Printer printer(&stream, level, spacesPerLevel);
+    printer.start();
+
+    bsl::stringstream ss;
+    ss << d_variationIndex << '/' << d_variationCount;
+
+    printer.printAttribute("id", ss.str());
+    printer.printAttribute("keyType", d_keyType);
+    printer.printAttribute("resourceEncoderOptions", d_resourceEncoderOptions);
+    printer.printAttribute("resourceDecoderOptions", d_resourceDecoderOptions);
+    printer.printAttribute("includePrivateKey", d_includePrivateKey);
+    printer.printAttribute("includeCertificate", d_includeCertificate);
+    printer.printAttribute("trustChainCount", d_trustChainCount);
+    printer.printAttribute("trustChainDepth", d_trustChainDepth);
+
+    printer.end();
+    return stream;
+}
+
+bsl::ostream& operator<<(bsl::ostream&                 stream,
+                         const ResourceTestParameters& object)
+{
+    return object.print(stream, 0, -1);
+}
+
+void ResourceTestParametersUtil::loadKeyTypes(
+    bsl::vector<ntca::EncryptionKeyType::Value>* result)
+{
+    result->clear();
+
+    // result->push_back(ntca::EncryptionKeyType::e_DSA);
+    // result->push_back(ntca::EncryptionKeyType::e_RSA);
+    result->push_back(ntca::EncryptionKeyType::e_NIST_P256);
+    // result->push_back(ntca::EncryptionKeyType::e_NIST_P384);
+    // result->push_back(ntca::EncryptionKeyType::e_NIST_P521);
+    // result->push_back(ntca::EncryptionKeyType::e_ED25519);
+    // result->push_back(ntca::EncryptionKeyType::e_ED448);
+}
+
+void ResourceTestParametersUtil::loadResourceTypes(
+    bsl::vector<ntca::EncryptionResourceType::Value>* result)
+{
+    result->clear();
+
+    result->push_back(ntca::EncryptionResourceType::e_ASN1);
+    result->push_back(ntca::EncryptionResourceType::e_ASN1_PEM);
+    result->push_back(ntca::EncryptionResourceType::e_PKCS8);
+    result->push_back(ntca::EncryptionResourceType::e_PKCS8_PEM);
+    result->push_back(ntca::EncryptionResourceType::e_PKCS12);
+}
+
+void ResourceTestParametersUtil::loadResourceOptions(
+    bsl::vector<ntca::EncryptionResourceOptions>* result)
+{
+    bsl::vector<ntca::EncryptionResourceType::Value> resourceTypes;
+    ResourceTestParametersUtil::loadResourceTypes(&resourceTypes);
+
+    ntca::EncryptionSecret secret;
+    secret.append(k_DEFAULT_SECRET, sizeof k_DEFAULT_SECRET - 1);
+
+    {
+        ntca::EncryptionResourceOptions options;
+        result->push_back(options);
+    }
+
+    {
+        ntca::EncryptionResourceOptions options;
+        options.setEncrypted(true);
+        result->push_back(options);
+    }
+
+    {
+        ntca::EncryptionResourceOptions options;
+        options.setEncrypted(true);
+        options.setSecret(secret);
+        result->push_back(options);
+    }
+
+    {
+        ntca::EncryptionResourceOptions options;
+        options.setEncrypted(true);
+        options.setSecretCallback(
+            &ntctls::ResourceTestParametersUtil::loadSecret);
+        result->push_back(options);
+    }
+
+    for (bsl::size_t i = 0; i < resourceTypes.size(); ++i) {
+        ntca::EncryptionResourceType::Value resourceType = resourceTypes[i];
+
+        {
+            ntca::EncryptionResourceOptions options;
+            options.setType(resourceType);
+            result->push_back(options);
+        }
+
+#if 0
+        {
+            ntca::EncryptionResourceOptions options;
+            options.setType(resourceType);
+            options.setSecret(secret);
+            result->push_back(options);
+        }
+
+        {
+            ntca::EncryptionResourceOptions options;
+            options.setType(resourceType);
+            options.setSecretCallback(
+                &ntctls::ResourceTestParametersUtil::loadSecret);
+            result->push_back(options);
+        }
+
+        {
+            ntca::EncryptionResourceOptions options;
+            options.setType(resourceType);
+            options.setEncrypted(false);
+            result->push_back(options);
+        }
+
+        {
+            ntca::EncryptionResourceOptions options;
+            options.setType(resourceType);
+            options.setEncrypted(false);
+            options.setSecret(secret);
+            result->push_back(options);
+        }
+
+        {
+            ntca::EncryptionResourceOptions options;
+            options.setType(resourceType);
+            options.setEncrypted(false);
+            options.setSecretCallback(
+                &ntctls::ResourceTestParametersUtil::loadSecret);
+            result->push_back(options);
+        }
+#endif
+
+        {
+            ntca::EncryptionResourceOptions options;
+            options.setType(resourceType);
+            options.setEncrypted(true);
+            result->push_back(options);
+        }
+
+        {
+            ntca::EncryptionResourceOptions options;
+            options.setType(resourceType);
+            options.setEncrypted(true);
+            options.setSecret(secret);
+            result->push_back(options);
+        }
+
+        {
+            ntca::EncryptionResourceOptions options;
+            options.setType(resourceType);
+            options.setEncrypted(true);
+            options.setSecretCallback(
+                &ntctls::ResourceTestParametersUtil::loadSecret);
+            result->push_back(options);
+        }
+    }
+}
+
+void ResourceTestParametersUtil::loadParameters(
+    bsl::vector<ntctls::ResourceTestParameters>* result)
+{
+    bsl::vector<ntca::EncryptionKeyType::Value> keyTypeVector;
+    ntctls::ResourceTestParametersUtil::loadKeyTypes(&keyTypeVector);
+
+    bsl::vector<ntca::EncryptionResourceOptions> resourceOptionsVector;
+    ntctls::ResourceTestParametersUtil::loadResourceOptions(
+        &resourceOptionsVector);
+
+    for (bsl::size_t i = 0; i < keyTypeVector.size(); ++i) {
+        for (bsl::size_t j = 0; j < resourceOptionsVector.size(); ++j) {
+            for (bsl::size_t k = 0; k < resourceOptionsVector.size(); ++k) {
+                for (bsl::size_t chainCount = k_MIN_TRUST_CHAIN_COUNT;
+                     chainCount <= k_MAX_TRUST_CHAIN_COUNT;
+                     ++chainCount)
+                {
+                    for (bsl::size_t chainDepth = k_MIN_TRUST_CHAIN_DEPTH;
+                         chainDepth <= k_MAX_TRUST_CHAIN_DEPTH;
+                         ++chainDepth)
+                    {
+                        ntctls::ResourceTestParameters parameters;
+
+                        parameters.setKeyType(keyTypeVector[i]);
+                        parameters.setResourceEncoderOptions(
+                            resourceOptionsVector[j]);
+                        parameters.setResourceDecoderOptions(
+                            resourceOptionsVector[k]);
+
+                        parameters.setTrustChainCount(chainCount);
+                        parameters.setTrustChainDepth(chainDepth);
+
+                        parameters.setIncludePrivateKey(false);
+                        parameters.setIncludeCertificate(false);
+
+                        result->push_back(parameters);
+
+                        parameters.setIncludePrivateKey(true);
+                        parameters.setIncludeCertificate(false);
+
+                        result->push_back(parameters);
+
+                        parameters.setIncludePrivateKey(false);
+                        parameters.setIncludeCertificate(true);
+
+                        result->push_back(parameters);
+
+                        parameters.setIncludePrivateKey(true);
+                        parameters.setIncludeCertificate(true);
+
+                        result->push_back(parameters);
+                    }
+                }
+            }
+        }
+    }
+
+    BSLS_ASSERT_OPT(result->size() > 0);
+
+    for (bsl::size_t i = 0; i < result->size(); ++i) {
+        (*result)[i].setVariationIndex(i);
+        (*result)[i].setVariationCount(result->size());
+    }
+}
+
+ntsa::Error ResourceTestParametersUtil::loadSecret(
+    ntca::EncryptionSecret* result)
+{
+    result->reset();
+    result->append(k_DEFAULT_SECRET, sizeof k_DEFAULT_SECRET - 1);
+
+    return ntsa::Error();
+}
+
+ntsa::Error ResourceTestParametersUtil::loadResource(
+    bsl::shared_ptr<ntci::EncryptionResource>* result,
+    const ntctls::ResourceTestParameters&      parameters,
+    bslma::Allocator*                          basicAllocator)
+{
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntci::EncryptionDriver> driver;
+    ntctls::Plugin::load(&driver);
+
+    bsl::shared_ptr<ntci::EncryptionResource> resource;
+    error = driver->createEncryptionResource(&resource, allocator);
+    NTSCFG_TEST_OK(error);
+
+    bsl::shared_ptr<ntci::EncryptionKey>         authorityKeyDefault;
+    bsl::shared_ptr<ntci::EncryptionCertificate> authorityCertificateDefault;
+
+    const bsl::size_t chainCount = parameters.trustChainCount();
+    const bsl::size_t chainDepth = parameters.trustChainDepth();
+
+    BSLS_ASSERT_OPT(chainCount <= 9);
+    BSLS_ASSERT_OPT(chainDepth <= 26);
+
+    for (bsl::size_t i = 0; i < chainCount; ++i) {
+        typedef bsl::vector<bsl::shared_ptr<ntci::EncryptionKey> > KeyVector;
+        typedef bsl::vector<bsl::shared_ptr<ntci::EncryptionCertificate> >
+            CertificateVector;
+
+        KeyVector         authorityKeyVector;
+        CertificateVector authorityCertificateVector;
+
+        for (bsl::size_t j = 0; j < chainDepth; ++j) {
+            bsl::string authoritySubjectCommonName;
+            {
+                bsl::stringstream ss;
+                ss << "TEST.AUTHORITY." << i << ".";
+
+                if (j == 0) {
+                    ss << "ROOT";
+                }
+                else {
+                    ss << static_cast<char>('A' + j);
+                }
+                authoritySubjectCommonName = ss.str();
+            }
+
+            ntca::EncryptionKeyOptions authorityKeyOptions;
+            authorityKeyOptions.setType(parameters.keyType());
+
+            bsl::shared_ptr<ntci::EncryptionKey> authorityKey;
+            error = driver->generateKey(&authorityKey,
+                                        authorityKeyOptions,
+                                        allocator);
+            NTSCFG_TEST_OK(error);
+
+            ntsa::DistinguishedName authoritySubject;
+            authoritySubject["CN"] = authoritySubjectCommonName;
+            authoritySubject["O"]  = "Bloomberg LP";
+
+            ntca::EncryptionCertificateOptions authorityCertificateOptions;
+            authorityCertificateOptions.setAuthority(true);
+
+            bsl::shared_ptr<ntci::EncryptionCertificate> authorityCertificate;
+
+            if (j > 0) {
+                error = driver->generateCertificate(
+                    &authorityCertificate,
+                    authoritySubject,
+                    authorityKey,
+                    authorityCertificateVector[j - 1],
+                    authorityKeyVector[j - 1],
+                    authorityCertificateOptions,
+                    allocator);
+                NTSCFG_TEST_OK(error);
+            }
+            else {
+                error =
+                    driver->generateCertificate(&authorityCertificate,
+                                                authoritySubject,
+                                                authorityKey,
+                                                authorityCertificateOptions);
+                NTSCFG_TEST_OK(error);
+            }
+
+            if (!authorityKeyDefault) {
+                authorityKeyDefault = authorityKey;
+            }
+
+            if (!authorityCertificateDefault) {
+                authorityCertificate = authorityCertificate;
+            }
+
+            authorityKeyVector.push_back(authorityKey);
+            authorityCertificateVector.push_back(authorityCertificate);
+
+            error = resource->addCertificateAuthority(authorityCertificate);
+            NTSCFG_TEST_OK(error);
+        }
+    }
+
+    bsl::string userSubjectCommonName = "TEST.USER";
+
+    ntca::EncryptionKeyOptions userKeyOptions;
+    userKeyOptions.setType(parameters.keyType());
+
+    bsl::shared_ptr<ntci::EncryptionKey> userKey;
+    error = driver->generateKey(&userKey, userKeyOptions, allocator);
+    NTSCFG_TEST_OK(error);
+
+    ntsa::DistinguishedName userSubject;
+    userSubject["CN"] = userSubjectCommonName;
+    userSubject["O"]  = "Bloomberg LP";
+
+    ntca::EncryptionCertificateOptions userCertificateOptions;
+    userCertificateOptions.setAuthority(false);
+
+    bsl::shared_ptr<ntci::EncryptionCertificate> userCertificate;
+    if (authorityCertificateDefault && authorityKeyDefault) {
+        error = driver->generateCertificate(&userCertificate,
+                                            userSubject,
+                                            userKey,
+                                            authorityCertificateDefault,
+                                            authorityKeyDefault,
+                                            userCertificateOptions);
+        NTSCFG_TEST_OK(error);
+    }
+    else {
+        error = driver->generateCertificate(&userCertificate,
+                                            userSubject,
+                                            userKey,
+                                            userCertificateOptions);
+        NTSCFG_TEST_OK(error);
+    }
+
+    if (parameters.includePrivateKey()) {
+        error = resource->setPrivateKey(userKey);
+        NTSCFG_TEST_OK(error);
+    }
+
+    if (parameters.includeCertificate()) {
+        error = resource->setCertificate(userCertificate);
+        NTSCFG_TEST_OK(error);
+    }
+
+    *result = resource;
+    return ntsa::Error();
+}
+
+void ResourceTestParametersUtil::logHexDump(
+    ntca::EncryptionResourceType::Value type,
+    const bdlsb::MemOutStreamBuf&       osb)
+{
+    bsl::stringstream ss;
+    if (osb.length() > 0) {
+        ss << bdlb::PrintStringHexDumper(osb.data(),
+                                         static_cast<int>(osb.length()));
+    }
+
+    BSLS_LOG_TRACE("Encoded %s:\n%s",
+                   ntca::EncryptionResourceType::toString(type),
+                   ss.str().c_str());
+}
+
+void ResourceTestParametersUtil::logKey(
+    const char*                                 label,
+    const bsl::shared_ptr<ntci::EncryptionKey>& key)
+{
+    bsl::stringstream ss;
+    key->print(ss);
+
+    BSLS_LOG_DEBUG("%s = \n%s", label, ss.str().c_str());
+}
+
+void ResourceTestParametersUtil::logCertificate(
+    const char*                                         label,
+    const bsl::shared_ptr<ntci::EncryptionCertificate>& certificate)
+{
+    bsl::stringstream ss;
+    certificate->print(ss);
+
+    BSLS_LOG_DEBUG("%s = \n%s", label, ss.str().c_str());
+}
+
+void ResourceTestParametersUtil::verifyLoadResult(
+    ntsa::Error                           error,
+    const ntctls::ResourceTestParameters& parameters)
+{
+    ntsa::Error expectedError;
+
+    if (expectedError) {
+        NTSCFG_TEST_TRUE(error);
+    }
+    else {
+        NTSCFG_TEST_OK(error);
+    }
+}
+
+void ResourceTestParametersUtil::verifyEncodeResult(
+    ntsa::Error                           error,
+    const ntctls::ResourceTestParameters& parameters)
+{
+    if (!error) {
+        return;
+    }
+
+    ntsa::Error expectedError;
+
+    const ntca::EncryptionResourceType::Value type =
+        parameters.resourceEncoderOptions().type().value_or(
+            ntca::EncryptionResourceType::e_ASN1_PEM);
+
+    bsl::size_t numPrivateKeys = 0;
+    if (parameters.includePrivateKey()) {
+        ++numPrivateKeys;
+    }
+
+    bsl::size_t numCertificates = 0;
+    if (parameters.includeCertificate()) {
+        ++numCertificates;
+    }
+
+    numCertificates +=
+        parameters.trustChainCount() * parameters.trustChainDepth();
+
+    if (numPrivateKeys == 0 && numCertificates == 0) {
+        expectedError = ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    if (type == ntca::EncryptionResourceType::e_PKCS8 ||
+        type == ntca::EncryptionResourceType::e_PKCS8_PEM)
+    {
+        if (numPrivateKeys == 0) {
+            expectedError = ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        if (numCertificates > 0) {
+            expectedError = ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    if (type == ntca::EncryptionResourceType::e_PKCS7 ||
+        type == ntca::EncryptionResourceType::e_PKCS7_PEM)
+    {
+        if (numCertificates == 0) {
+            expectedError = ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        if (numPrivateKeys > 0) {
+            expectedError = ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    const bool encrypted =
+        parameters.resourceEncoderOptions().encrypted().value_or(false);
+
+    if (encrypted) {
+        if (parameters.resourceEncoderOptions().secret().isNull() &&
+            parameters.resourceEncoderOptions().secretCallback().isNull())
+        {
+            expectedError = ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    if (expectedError) {
+        NTSCFG_TEST_TRUE(error);
+    }
+    else {
+        NTSCFG_TEST_OK(error);
+    }
+}
+
+void ResourceTestParametersUtil::verifyDecodeResult(
+    ntsa::Error                           error,
+    const ntctls::ResourceTestParameters& parameters)
+{
+    if (!error) {
+        return;
+    }
+
+    ntsa::Error expectedError;
+
+    if (!parameters.resourceDecoderOptions().type().isNull()) {
+        ntca::EncryptionResourceType::Value decoderType =
+            parameters.resourceDecoderOptions().type().value_or(
+                ntca::EncryptionResourceType::e_ASN1_PEM);
+
+        ntca::EncryptionResourceType::Value encoderType =
+            parameters.resourceEncoderOptions().type().value_or(
+                ntca::EncryptionResourceType::e_ASN1_PEM);
+
+        if (decoderType != encoderType) {
+            expectedError = ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    const bool encrypted =
+        parameters.resourceEncoderOptions().encrypted().value_or(false);
+
+    if (encrypted) {
+        if (parameters.resourceDecoderOptions().secret().isNull() &&
+            parameters.resourceDecoderOptions().secretCallback().isNull())
+        {
+            expectedError = ntsa::Error(ntsa::Error::e_INVALID);
+        }
+    }
+
+    if (expectedError) {
+        NTSCFG_TEST_TRUE(error);
+    }
+    else {
+        NTSCFG_TEST_OK(error);
+    }
+}
+
+void ResourceTestParametersUtil::verifyEquals(
+    const bsl::shared_ptr<ntci::EncryptionResource>& foundResource,
+    const bsl::shared_ptr<ntci::EncryptionResource>& expectedResource,
+    const ntctls::ResourceTestParameters&            parameters)
+{
+    bool includePrivateKeys  = true;
+    bool includeCertificates = true;
+
+    if (!parameters.resourceDecoderOptions().type().isNull()) {
+        const ntca::EncryptionResourceType::Value type =
+            parameters.resourceDecoderOptions().type().value();
+
+        if (type == ntca::EncryptionResourceType::e_PKCS7 ||
+            type == ntca::EncryptionResourceType::e_PKCS7_PEM)
+        {
+            includePrivateKeys = false;
+        }
+        else if (type == ntca::EncryptionResourceType::e_PKCS8 ||
+                 type == ntca::EncryptionResourceType::e_PKCS8_PEM)
+        {
+            includeCertificates = false;
+        }
+    }
+    else {
+        includePrivateKeys  = true;
+        includeCertificates = true;
+    }
+
+    bool result =
+        ResourceTestParametersUtil::verifyContains(foundResource,
+                                                   expectedResource,
+                                                   includePrivateKeys,
+                                                   includeCertificates);
+
+    NTSCFG_TEST_TRUE(result);
+}
+
+bool ResourceTestParametersUtil::verifyContains(
+    const bsl::shared_ptr<ntci::EncryptionResource>& lhsResource,
+    const bsl::shared_ptr<ntci::EncryptionResource>& rhsResource,
+    bool                                             includePrivateKeys,
+    bool                                             includeCertificates)
+{
+    if (includePrivateKeys) {
+        bsl::shared_ptr<ntci::EncryptionKey> lhsKey;
+        lhsResource->getPrivateKey(&lhsKey);
+
+        bsl::shared_ptr<ntci::EncryptionKey> rhsKey;
+        rhsResource->getPrivateKey(&rhsKey);
+
+        if (lhsKey) {
+            if (!rhsKey) {
+                return false;
+            }
+        }
+
+        if (rhsKey) {
+            if (!lhsKey) {
+                return false;
+            }
+        }
+
+        if (lhsKey && rhsKey) {
+            if (!lhsKey->equals(*rhsKey)) {
+                return false;
+            }
+        }
+    }
+
+    if (includeCertificates) {
+        bsl::shared_ptr<ntci::EncryptionCertificate> lhsCertificate;
+        lhsResource->getCertificate(&lhsCertificate);
+
+        bsl::shared_ptr<ntci::EncryptionCertificate> rhsCertificate;
+        rhsResource->getCertificate(&rhsCertificate);
+
+        if (lhsCertificate) {
+            if (!rhsCertificate) {
+                return false;
+            }
+        }
+
+        if (rhsCertificate) {
+            if (!lhsCertificate) {
+                return false;
+            }
+        }
+
+        if (lhsCertificate && rhsCertificate) {
+            if (!lhsCertificate->equals(*rhsCertificate)) {
+                return false;
+            }
+        }
+
+        typedef bsl::vector<bsl::shared_ptr<ntci::EncryptionCertificate> >
+            CertificateVector;
+
+        CertificateVector lhsCaList;
+        lhsResource->getCertificateAuthoritySet(&lhsCaList);
+
+        CertificateVector rhsCaList;
+        rhsResource->getCertificateAuthoritySet(&rhsCaList);
+
+        if (lhsCaList.size() != rhsCaList.size()) {
+            return false;
+        }
+
+        for (bsl::size_t i = 0; i < lhsCaList.size(); ++i) {
+            if (!lhsCaList[i]->equals(*rhsCaList[i])) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+void ResourceTest::verifyUsageParameters(
+    const ntctls::ResourceTestParameters& parameters,
+    bslma::Allocator*                     allocator)
+{
+    ntsa::Error error;
+    int         rc;
+
+    NTSCFG_TEST_LOG_INFO << "Testing parameters " << parameters
+                         << NTSCFG_TEST_LOG_END;
+
+    bsl::shared_ptr<ntci::EncryptionDriver> driver;
+    ntctls::Plugin::load(&driver);
+
+    // Load the resource.
+
+    bsl::shared_ptr<ntci::EncryptionResource> resource1;
+
+    error = ntctls::ResourceTestParametersUtil::loadResource(&resource1,
+                                                             parameters,
+                                                             allocator);
+
+    ntctls::ResourceTestParametersUtil::verifyLoadResult(error, parameters);
+    if (error) {
+        return;
+    }
+
+    // Encode the resource.
+
+    bdlsb::MemOutStreamBuf osb(allocator);
+
+    error = resource1->encode(&osb, parameters.resourceEncoderOptions());
+    ntctls::ResourceTestParametersUtil::verifyEncodeResult(error, parameters);
+    if (error) {
+        return;
+    }
+
+    rc = osb.pubsync();
+    NTSCFG_TEST_EQ(rc, 0);
+
+    ntctls::ResourceTestParametersUtil::logHexDump(
+        parameters.resourceEncoderOptions().type().value_or(
+            ntca::EncryptionResourceType::e_ASN1_PEM),
+        osb);
+
+    NTSCFG_TEST_NE(osb.data(), 0);
+    NTSCFG_TEST_GT(osb.length(), 0);
+
+    // Decode the resource.
+
+    bdlsb::FixedMemInStreamBuf isb(osb.data(), osb.length());
+
+    bsl::shared_ptr<ntci::EncryptionResource> resource2;
+    error = driver->createEncryptionResource(&resource2, allocator);
+    NTSCFG_TEST_OK(error);
+
+    error = resource2->decode(&isb, parameters.resourceDecoderOptions());
+    ntctls::ResourceTestParametersUtil::verifyDecodeResult(error, parameters);
+    if (error) {
+        return;
+    }
+
+    // Ensure the decoded resource matches the encoded resource.
+
+    ntctls::ResourceTestParametersUtil::verifyEquals(resource2,
+                                                     resource1,
+                                                     parameters);
+}
+
+NTSCFG_TEST_FUNCTION(ntctls::ResourceTest::verifyUsage)
+{
+    NTCI_LOG_CONTEXT();
+
+    NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_MAIN();
+
+    bslma::Allocator* allocator = NTSCFG_TEST_ALLOCATOR;
+
+    bsl::vector<ntctls::ResourceTestParameters> parametersVector;
+    ntctls::ResourceTestParametersUtil::loadParameters(&parametersVector);
+
+    for (bsl::size_t i = 0; i < parametersVector.size(); ++i) {
+        const ntctls::ResourceTestParameters& parameters = parametersVector[i];
+
+#if defined(NTCTLS_RESOURCE_TEST_CASE_ID)
+        if (parameters.variationIndex() != NTCTLS_RESOURCE_TEST_CASE_ID) {
+            continue;
+        }
+#endif
+
+        ntctls::ResourceTest::verifyUsageParameters(parameters, allocator);
+    }
+}
+
+/// Describes the certificates and keys used in this test driver.
+class EncryptionTestEnvironment
+{
+    bsl::string                        d_domainName;
+    ntsa::IpAddress                    d_ipAddress;
+    ntca::EncryptionKey                d_roguePrivateKey;
+    ntca::EncryptionKeyOptions         d_roguePrivateKeyOptions;
+    ntca::EncryptionCertificate        d_rogueCertificate;
+    ntca::EncryptionCertificateOptions d_rogueCertificateOptions;
+    ntca::EncryptionKey                d_authorityPrivateKey;
+    ntca::EncryptionKeyOptions         d_authorityPrivateKeyOptions;
+    ntca::EncryptionCertificate        d_authorityCertificate;
+    ntca::EncryptionCertificateOptions d_authorityCertificateOptions;
+    ntca::EncryptionKey                d_clientPrivateKey;
+    ntca::EncryptionKeyOptions         d_clientPrivateKeyOptions;
+    ntca::EncryptionCertificate        d_clientCertificate;
+    ntca::EncryptionCertificateOptions d_clientCertificateOptions;
+    ntca::EncryptionKey                d_serverPrivateKey;
+    ntca::EncryptionKeyOptions         d_serverPrivateKeyOptions;
+    ntca::EncryptionCertificate        d_serverCertificate;
+    ntca::EncryptionCertificateOptions d_serverCertificateOptions;
+    bsl::string                        d_serverOneName;
+    ntca::EncryptionKey                d_serverOnePrivateKey;
+    ntca::EncryptionKeyOptions         d_serverOnePrivateKeyOptions;
+    ntca::EncryptionCertificate        d_serverOneCertificate;
+    ntca::EncryptionCertificateOptions d_serverOneCertificateOptions;
+    bsl::string                        d_serverTwoName;
+    ntca::EncryptionKey                d_serverTwoPrivateKey;
+    ntca::EncryptionKeyOptions         d_serverTwoPrivateKeyOptions;
+    ntca::EncryptionCertificate        d_serverTwoCertificate;
+    ntca::EncryptionCertificateOptions d_serverTwoCertificateOptions;
+    bslma::Allocator*                  d_allocator_p;
+
+  public:
+    // Create a new test environment. Optionally specify a 'basicAllocator'
+    // used to supply memory. If 'basicAllocator' is 0, the currently installed
+    // default allocator is used.
+    explicit EncryptionTestEnvironment(bslma::Allocator* basicAllocator);
+
+    // Destroy this object.
+    ~EncryptionTestEnvironment();
+
+    // Return the domain name of the machine on which the test is running.
+    const bsl::string& domainName() const;
+
+    // Return the IP address of the machine on which the test is running.
+    const ntsa::IpAddress& ipAddress() const;
+
+    // Return the certificate used by an untrusted certificate authority.
+    const ntca::EncryptionCertificate& rogueCertificate() const;
+
+    // Return the private key used by an untrusted certificate authority.
+    const ntca::EncryptionKey& roguePrivateKey() const;
+
+    // Return the certificate used by an trusted certificate authority.
+    const ntca::EncryptionCertificate& authorityCertificate() const;
+
+    // Return the private key used by an trusted certificate authority.
+    const ntca::EncryptionKey& authorityPrivateKey() const;
+
+    // Return the certificate used by an end-user acting as a client.
+    const ntca::EncryptionCertificate& clientCertificate() const;
+
+    // Return the private key used by an end-user acting as a client.
+    const ntca::EncryptionKey& clientPrivateKey() const;
+
+    // Return the certificate used by an end-user acting as a server.
+    const ntca::EncryptionCertificate& serverCertificate() const;
+
+    // Return the private key used by an end-user acting as a server.
+    const ntca::EncryptionKey& serverPrivateKey() const;
+
+    // Return the server name indication of the first name.
+    const bsl::string& serverOneName() const;
+
+    // Return the certificate used by an end-user acting as a server for the
+    // indication for the first name.
+    const ntca::EncryptionCertificate& serverOneCertificate() const;
+
+    // Return the private key used by an end-user acting as a server for the
+    // indidication of the first name.
+    const ntca::EncryptionKey& serverOnePrivateKey() const;
+
+    // Return the server name indication of the second name.
+    const bsl::string& serverTwoName() const;
+
+    // Return the certificate used by an end-user acting as a server for the
+    // indication for the second name.
+    const ntca::EncryptionCertificate& serverTwoCertificate() const;
+
+    // Return the private key used by an end-user acting as a server for the
+    // indidication of the second name.
+    const ntca::EncryptionKey& serverTwoPrivateKey() const;
+};
+
+EncryptionTestEnvironment::EncryptionTestEnvironment(
+    bslma::Allocator* basicAllocator)
+: d_domainName(basicAllocator)
+, d_ipAddress()
+, d_roguePrivateKey(basicAllocator)
+, d_roguePrivateKeyOptions(basicAllocator)
+, d_rogueCertificate(basicAllocator)
+, d_rogueCertificateOptions(basicAllocator)
+, d_authorityPrivateKey(basicAllocator)
+, d_authorityPrivateKeyOptions(basicAllocator)
+, d_authorityCertificate(basicAllocator)
+, d_authorityCertificateOptions(basicAllocator)
+, d_clientPrivateKey(basicAllocator)
+, d_clientPrivateKeyOptions(basicAllocator)
+, d_clientCertificate(basicAllocator)
+, d_clientCertificateOptions(basicAllocator)
+, d_serverPrivateKey(basicAllocator)
+, d_serverPrivateKeyOptions(basicAllocator)
+, d_serverCertificate(basicAllocator)
+, d_serverCertificateOptions(basicAllocator)
+, d_serverOneName(basicAllocator)
+, d_serverOnePrivateKey(basicAllocator)
+, d_serverOnePrivateKeyOptions(basicAllocator)
+, d_serverOneCertificate(basicAllocator)
+, d_serverOneCertificateOptions(basicAllocator)
+, d_serverTwoName(basicAllocator)
+, d_serverTwoPrivateKey(basicAllocator)
+, d_serverTwoPrivateKeyOptions(basicAllocator)
+, d_serverTwoCertificate(basicAllocator)
+, d_serverTwoCertificateOptions(basicAllocator)
+, d_allocator_p(bslma::Default::allocator(basicAllocator))
+{
+    ntsa::Error error;
+
+    bsl::shared_ptr<ntci::EncryptionDriver> driver;
+    ntctls::Plugin::load(&driver);
+
+    error = ntsf::System::getHostnameFullyQualified(&d_domainName);
+    NTSCFG_TEST_OK(error);
+
+    ntsa::IpAddressOptions ipAddressOptions;
+    ipAddressOptions.setIpAddressType(ntsa::IpAddressType::e_V4);
+
+    bsl::vector<ntsa::IpAddress> ipAddressList;
+    error = ntsf::System::getIpAddress(&ipAddressList,
+                                       d_domainName,
+                                       ipAddressOptions);
+    NTSCFG_TEST_OK(error);
+    NTSCFG_TEST_FALSE(ipAddressList.empty());
+
+    d_ipAddress = ipAddressList.front();
+
+    // Generate a certificate and private key for a certificate rogue.
+
+    d_roguePrivateKeyOptions.setType(ntca::EncryptionKeyType::e_NIST_P256);
+
+    error = driver->generateKey(&d_roguePrivateKey,
+                                d_roguePrivateKeyOptions,
+                                d_allocator_p);
+    NTSCFG_TEST_OK(error);
+
+    ntsa::DistinguishedName rogueIdentity;
+    rogueIdentity["CN"] = "Rogue";
+
+    d_rogueCertificateOptions.setSerialNumber(1);
+    d_rogueCertificateOptions.setAuthority(true);
+
+    error = driver->generateCertificate(&d_rogueCertificate,
+                                        rogueIdentity,
+                                        d_roguePrivateKey,
+                                        d_rogueCertificateOptions,
+                                        d_allocator_p);
+    NTSCFG_TEST_OK(error);
+
+    // Generate a certificate and private key for a certificate authority.
+
+    d_authorityPrivateKeyOptions.setType(ntca::EncryptionKeyType::e_NIST_P256);
+
+    error = driver->generateKey(&d_authorityPrivateKey,
+                                d_authorityPrivateKeyOptions,
+                                d_allocator_p);
+    NTSCFG_TEST_OK(error);
+
+    ntsa::DistinguishedName authorityIdentity;
+    authorityIdentity["CN"] = "Authority";
+
+    d_authorityCertificateOptions.setSerialNumber(2);
+    d_authorityCertificateOptions.setAuthority(true);
+
+    error = driver->generateCertificate(&d_authorityCertificate,
+                                        authorityIdentity,
+                                        d_authorityPrivateKey,
+                                        d_authorityCertificateOptions,
+                                        d_allocator_p);
+    NTSCFG_TEST_OK(error);
+
+    // Generate a certificate and private key for the client, signed by the
+    // certificate authority.
+
+    d_clientPrivateKeyOptions.setType(ntca::EncryptionKeyType::e_NIST_P256);
+
+    error = driver->generateKey(&d_clientPrivateKey,
+                                d_clientPrivateKeyOptions,
+                                d_allocator_p);
+    NTSCFG_TEST_OK(error);
+
+    ntsa::DistinguishedName clientIdentity;
+    clientIdentity["CN"] = "Client";
+
+    d_clientCertificateOptions.setSerialNumber(3);
+    d_clientCertificateOptions.addHost(d_domainName);
+    d_clientCertificateOptions.addHost(d_ipAddress);
+
+    error = driver->generateCertificate(&d_clientCertificate,
+                                        clientIdentity,
+                                        d_clientPrivateKey,
+                                        d_authorityCertificate,
+                                        d_authorityPrivateKey,
+                                        d_clientCertificateOptions,
+                                        d_allocator_p);
+    NTSCFG_TEST_OK(error);
+
+    // Generate a certificate and private key for the server, signed by the
+    // certificate authority.
+
+    d_serverPrivateKeyOptions.setType(ntca::EncryptionKeyType::e_NIST_P256);
+
+    error = driver->generateKey(&d_serverPrivateKey,
+                                d_serverPrivateKeyOptions,
+                                d_allocator_p);
+    NTSCFG_TEST_OK(error);
+
+    ntsa::DistinguishedName serverIdentity;
+    serverIdentity["CN"] = "Server";
+
+    d_serverCertificateOptions.setSerialNumber(4);
+    d_serverCertificateOptions.addHost(d_domainName);
+    d_serverCertificateOptions.addHost(d_ipAddress);
+
+    error = driver->generateCertificate(&d_serverCertificate,
+                                        serverIdentity,
+                                        d_serverPrivateKey,
+                                        d_authorityCertificate,
+                                        d_authorityPrivateKey,
+                                        d_serverCertificateOptions,
+                                        d_allocator_p);
+    NTSCFG_TEST_OK(error);
+
+    // Generate a certificate and private key for the server indication "one",
+    // signed by the certificate authority.
+
+    d_serverOneName = "one";
+
+    d_serverOnePrivateKeyOptions.setType(ntca::EncryptionKeyType::e_NIST_P256);
+
+    error = driver->generateKey(&d_serverOnePrivateKey,
+                                d_serverOnePrivateKeyOptions,
+                                d_allocator_p);
+    NTSCFG_TEST_OK(error);
+
+    ntsa::DistinguishedName serverOneIdentity;
+    serverOneIdentity["CN"] = "ServerOne";
+
+    d_serverOneCertificateOptions.setSerialNumber(5);
+    d_serverOneCertificateOptions.addHost(d_domainName);
+    d_serverOneCertificateOptions.addHost(d_ipAddress);
+
+    error = driver->generateCertificate(&d_serverOneCertificate,
+                                        serverOneIdentity,
+                                        d_serverOnePrivateKey,
+                                        d_authorityCertificate,
+                                        d_authorityPrivateKey,
+                                        d_serverOneCertificateOptions,
+                                        d_allocator_p);
+    NTSCFG_TEST_OK(error);
+
+    // Generate a certificate and private key for the server indication "two",
+    // signed by the certificate authority.
+
+    d_serverTwoName = "two";
+
+    d_serverTwoPrivateKeyOptions.setType(ntca::EncryptionKeyType::e_NIST_P256);
+
+    error = driver->generateKey(&d_serverTwoPrivateKey,
+                                d_serverTwoPrivateKeyOptions,
+                                d_allocator_p);
+    NTSCFG_TEST_OK(error);
+
+    ntsa::DistinguishedName serverTwoIdentity;
+    serverTwoIdentity["CN"] = "ServerTwo";
+
+    d_serverTwoCertificateOptions.setSerialNumber(6);
+    d_serverTwoCertificateOptions.addHost(d_domainName);
+    d_serverTwoCertificateOptions.addHost(d_ipAddress);
+
+    error = driver->generateCertificate(&d_serverTwoCertificate,
+                                        serverTwoIdentity,
+                                        d_serverTwoPrivateKey,
+                                        d_authorityCertificate,
+                                        d_authorityPrivateKey,
+                                        d_serverTwoCertificateOptions,
+                                        d_allocator_p);
+    NTSCFG_TEST_OK(error);
+}
+
+EncryptionTestEnvironment::~EncryptionTestEnvironment()
+{
+}
+
+const bsl::string& EncryptionTestEnvironment::domainName() const
+{
+    return d_domainName;
+}
+
+const ntsa::IpAddress& EncryptionTestEnvironment::ipAddress() const
+{
+    return d_ipAddress;
+}
+
+const ntca::EncryptionCertificate& EncryptionTestEnvironment::
+    rogueCertificate() const
+{
+    return d_rogueCertificate;
+}
+
+const ntca::EncryptionKey& EncryptionTestEnvironment::roguePrivateKey() const
+{
+    return d_roguePrivateKey;
+}
+
+const ntca::EncryptionCertificate& EncryptionTestEnvironment::
+    authorityCertificate() const
+{
+    return d_authorityCertificate;
+}
+
+const ntca::EncryptionKey& EncryptionTestEnvironment::authorityPrivateKey()
+    const
+{
+    return d_authorityPrivateKey;
+}
+
+const ntca::EncryptionCertificate& EncryptionTestEnvironment::
+    clientCertificate() const
+{
+    return d_clientCertificate;
+}
+
+const ntca::EncryptionKey& EncryptionTestEnvironment::clientPrivateKey() const
+{
+    return d_clientPrivateKey;
+}
+
+const ntca::EncryptionCertificate& EncryptionTestEnvironment::
+    serverCertificate() const
+{
+    return d_serverCertificate;
+}
+
+const ntca::EncryptionKey& EncryptionTestEnvironment::serverPrivateKey() const
+{
+    return d_serverPrivateKey;
+}
+
+const bsl::string& EncryptionTestEnvironment::serverOneName() const
+{
+    return d_serverOneName;
+}
+
+const ntca::EncryptionCertificate& EncryptionTestEnvironment::
+    serverOneCertificate() const
+{
+    return d_serverOneCertificate;
+}
+
+const ntca::EncryptionKey& EncryptionTestEnvironment::serverOnePrivateKey()
+    const
+{
+    return d_serverOnePrivateKey;
+}
+
+const bsl::string& EncryptionTestEnvironment::serverTwoName() const
+{
+    return d_serverTwoName;
+}
+
+const ntca::EncryptionCertificate& EncryptionTestEnvironment::
+    serverTwoCertificate() const
+{
+    return d_serverTwoCertificate;
+}
+
+const ntca::EncryptionKey& EncryptionTestEnvironment::serverTwoPrivateKey()
+    const
+{
+    return d_serverTwoPrivateKey;
+}
+
+// Describes the configurable parameters of the test driver.
+class EncryptionTestParameters
+{
+    bsl::size_t                           d_variationIndex;
+    bsl::size_t                           d_variationCount;
+    int                                   d_bufferSize;
+    ntca::EncryptionAuthentication::Value d_clientAuthentication;
+    ntca::EncryptionMethod::Value         d_clientMinMethod;
+    ntca::EncryptionMethod::Value         d_clientMaxMethod;
+    ntca::EncryptionAuthentication::Value d_serverAuthentication;
+    ntca::EncryptionMethod::Value         d_serverMinMethod;
+    ntca::EncryptionMethod::Value         d_serverMaxMethod;
+    bsl::string                           d_serverNameIndication;
+    bsl::size_t                           d_numReuses;
+    bool                                  d_success;
+
+  public:
+    // Create new test parameters. Optionally specify a 'basicAllocator' used
+    // to supply memory. If 'basicAllocator' is 0, the currently installed
+    // default allocator is used.
+    explicit EncryptionTestParameters(bslma::Allocator* basicAllocator = 0);
+
+    // Create new test parameters having the same value as the specified
+    // 'original' object. Optionally specify a 'basicAllocator' used to supply
+    // memory. If 'basicAllocator' is 0, the currently installed default
+    // allocator is used.
+    EncryptionTestParameters(const EncryptionTestParameters& original,
+                             bslma::Allocator* basicAllocator = 0);
+
+    // Destroy this object.
+    ~EncryptionTestParameters();
+
+    // Assign the value of the specified 'other' object to this object. Return
+    // a reference to this object.
+    EncryptionTestParameters& operator=(const EncryptionTestParameters& other);
+
+    // Reset the value of this object to its value upon default construction.
+    void reset();
+
+    // Set the variation index to the specified 'value'.
+    void setVariationIndex(bsl::size_t value);
+
+    // Set the variation count to the specified 'value'.
+    void setVariationCount(bsl::size_t value);
+
+    // Set the buffer size to the specified 'value'.
+    void setBufferSize(bsl::size_t value);
+
+    // Set the client authentication to the specified 'value'.
+    void setClientAuthentication(ntca::EncryptionAuthentication::Value value);
+
+    // Set the minimium supported client method to the specified 'value'.
+    void setClientMinMethod(ntca::EncryptionMethod::Value value);
+
+    // Set the maximum supported client method to the specified 'value'.
+    void setClientMaxMethod(ntca::EncryptionMethod::Value value);
+
+    // Set the server authentication to the specified 'value'.
+    void setServerAuthentication(ntca::EncryptionAuthentication::Value value);
+
+    // Set the minimium supported client method to the specified 'value'.
+    void setServerMinMethod(ntca::EncryptionMethod::Value value);
+
+    // Set the maximum supported client method to the specified 'value'.
+    void setServerMaxMethod(ntca::EncryptionMethod::Value value);
+
+    // Set the server name indication to the specified 'value'.
+    void setServerNameIndication(const bsl::string& value);
+
+    // Set the number of reuses to the specified 'value'.
+    void setReuseCount(bsl::size_t value);
+
+    // Set the flag that indicates the parameters should result in successful
+    // authentication and encryption to the specified 'value'.
+    void setSuccess(bool value);
+
+    // Return the variation index.
+    bsl::size_t variationIndex() const;
+
+    // Return the variation count.
+    bsl::size_t variationCount() const;
+
+    // Return the buffer size.
+    bsl::size_t bufferSize() const;
+
+    // Return the client authentication.
+    ntca::EncryptionAuthentication::Value clientAuthentication() const;
+
+    // Return the minimum supported client method.
+    ntca::EncryptionMethod::Value clientMinMethod() const;
+
+    // Return the maximum supported client method.
+    ntca::EncryptionMethod::Value clientMaxMethod() const;
+
+    // Return the server authentication.
+    ntca::EncryptionAuthentication::Value serverAuthentication() const;
+
+    // Return the minimum supported server method.
+    ntca::EncryptionMethod::Value serverMinMethod() const;
+
+    // Return the maximum supported server method.
+    ntca::EncryptionMethod::Value serverMaxMethod() const;
+
+    // Return the server name indication.
+    const bsl::string& serverNameIndication() const;
+
+    // Return the number of reuses.
+    bsl::size_t reuseCount() const;
+
+    // Return the flag that indicates the parameters should result in
+    // successful authentication and encryption.
+    bool success() const;
+
+    /// Format this object to the specified output 'stream' at the
+    /// optionally specified indentation 'level' and return a reference to
+    /// the modifiable 'stream'.  If 'level' is specified, optionally
+    /// specify 'spacesPerLevel', the number of spaces per indentation level
+    /// for this and all of its nested objects.  Each line is indented by
+    /// the absolute value of 'level * spacesPerLevel'.  If 'level' is
+    /// negative, suppress indentation of the first line.  If
+    /// 'spacesPerLevel' is negative, suppress line breaks and format the
+    /// entire output on one line.  If 'stream' is initially invalid, this
+    /// operation has no effect.  Note that a trailing newline is provided
+    /// in multiline mode only.
+    bsl::ostream& print(bsl::ostream& stream,
+                        int           level          = 0,
+                        int           spacesPerLevel = 4) const;
+
+    /// Defines the traits of this type. These traits can be used to select,
+    /// at compile-time, the most efficient algorithm to manipulate objects
+    /// of this type.
+    NTCCFG_DECLARE_NESTED_USES_ALLOCATOR_TRAITS(EncryptionTestParameters);
+};
+
+// Write a formatted, human-readable description of the specified 'object' to
+// the specified 'stream'. Return a reference to the 'stream'.
+bsl::ostream& operator<<(bsl::ostream&                   stream,
+                         const EncryptionTestParameters& object);
+
+EncryptionTestParameters::EncryptionTestParameters(
+    bslma::Allocator* basicAllocator)
+: d_variationIndex(0)
+, d_variationCount(0)
+, d_bufferSize(4096)
+, d_clientAuthentication(ntca::EncryptionAuthentication::e_DEFAULT)
+, d_clientMinMethod(ntca::EncryptionMethod::e_DEFAULT)
+, d_clientMaxMethod(ntca::EncryptionMethod::e_DEFAULT)
+, d_serverAuthentication(ntca::EncryptionAuthentication::e_DEFAULT)
+, d_serverMinMethod(ntca::EncryptionMethod::e_DEFAULT)
+, d_serverMaxMethod(ntca::EncryptionMethod::e_DEFAULT)
+, d_serverNameIndication(basicAllocator)
+, d_numReuses(0)
+, d_success(true)
+{
+}
+
+EncryptionTestParameters::EncryptionTestParameters(
+    const EncryptionTestParameters& original,
+    bslma::Allocator*               basicAllocator)
+: d_variationIndex(original.d_variationIndex)
+, d_variationCount(original.d_variationCount)
+, d_bufferSize(original.d_bufferSize)
+, d_clientAuthentication(original.d_clientAuthentication)
+, d_clientMinMethod(original.d_clientMinMethod)
+, d_clientMaxMethod(original.d_clientMaxMethod)
+, d_serverAuthentication(original.d_serverAuthentication)
+, d_serverMinMethod(original.d_serverMinMethod)
+, d_serverMaxMethod(original.d_serverMaxMethod)
+, d_serverNameIndication(original.d_serverNameIndication, basicAllocator)
+, d_numReuses(original.d_numReuses)
+, d_success(original.d_success)
+{
+}
+
+EncryptionTestParameters::~EncryptionTestParameters()
+{
+}
+
+EncryptionTestParameters& EncryptionTestParameters::operator=(
+    const EncryptionTestParameters& other)
+{
+    if (this != &other) {
+        d_variationIndex       = other.d_variationIndex;
+        d_variationCount       = other.d_variationCount;
+        d_bufferSize           = other.d_bufferSize;
+        d_clientAuthentication = other.d_clientAuthentication;
+        d_clientMinMethod      = other.d_clientMinMethod;
+        d_clientMaxMethod      = other.d_clientMaxMethod;
+        d_serverAuthentication = other.d_serverAuthentication;
+        d_serverMinMethod      = other.d_serverMinMethod;
+        d_serverMaxMethod      = other.d_serverMaxMethod;
+        d_serverNameIndication = other.d_serverNameIndication;
+        d_numReuses            = other.d_numReuses;
+        d_success              = other.d_success;
+    }
+
+    return *this;
+}
+
+void EncryptionTestParameters::reset()
+{
+    d_variationIndex       = 0;
+    d_variationCount       = 0;
+    d_bufferSize           = 4096;
+    d_clientAuthentication = ntca::EncryptionAuthentication::e_DEFAULT;
+    d_clientMinMethod      = ntca::EncryptionMethod::e_DEFAULT;
+    d_clientMaxMethod      = ntca::EncryptionMethod::e_DEFAULT;
+    d_serverAuthentication = ntca::EncryptionAuthentication::e_DEFAULT;
+    d_serverMinMethod      = ntca::EncryptionMethod::e_DEFAULT;
+    d_serverMaxMethod      = ntca::EncryptionMethod::e_DEFAULT;
+    d_serverNameIndication.clear();
+    d_numReuses = 0;
+    d_success   = true;
+}
+
+void EncryptionTestParameters::setVariationIndex(bsl::size_t value)
+{
+    d_variationIndex = value;
+}
+
+void EncryptionTestParameters::setVariationCount(bsl::size_t value)
+{
+    d_variationCount = value;
+}
+
+void EncryptionTestParameters::setBufferSize(bsl::size_t value)
+{
+    d_bufferSize = value;
+}
+
+void EncryptionTestParameters::setClientAuthentication(
+    ntca::EncryptionAuthentication::Value value)
+{
+    d_clientAuthentication = value;
+}
+
+void EncryptionTestParameters::setClientMinMethod(
+    ntca::EncryptionMethod::Value value)
+{
+    d_clientMinMethod = value;
+}
+
+void EncryptionTestParameters::setClientMaxMethod(
+    ntca::EncryptionMethod::Value value)
+{
+    d_clientMaxMethod = value;
+}
+
+void EncryptionTestParameters::setServerAuthentication(
+    ntca::EncryptionAuthentication::Value value)
+{
+    d_serverAuthentication = value;
+}
+
+void EncryptionTestParameters::setServerMinMethod(
+    ntca::EncryptionMethod::Value value)
+{
+    d_serverMinMethod = value;
+}
+
+void EncryptionTestParameters::setServerMaxMethod(
+    ntca::EncryptionMethod::Value value)
+{
+    d_serverMaxMethod = value;
+}
+
+void EncryptionTestParameters::setServerNameIndication(
+    const bsl::string& value)
+{
+    d_serverNameIndication = value;
+}
+
+void EncryptionTestParameters::setReuseCount(bsl::size_t value)
+{
+    d_numReuses = value;
+}
+
+void EncryptionTestParameters::setSuccess(bool value)
+{
+    d_success = value;
+}
+
+bsl::size_t EncryptionTestParameters::variationIndex() const
+{
+    return d_variationIndex;
+}
+
+bsl::size_t EncryptionTestParameters::variationCount() const
+{
+    return d_variationCount;
+}
+
+bsl::size_t EncryptionTestParameters::bufferSize() const
+{
+    return d_bufferSize;
+}
+
+ntca::EncryptionAuthentication::Value EncryptionTestParameters::
+    clientAuthentication() const
+{
+    return d_clientAuthentication;
+}
+
+ntca::EncryptionMethod::Value EncryptionTestParameters::clientMinMethod() const
+{
+    return d_clientMinMethod;
+}
+
+ntca::EncryptionMethod::Value EncryptionTestParameters::clientMaxMethod() const
+{
+    return d_clientMaxMethod;
+}
+
+ntca::EncryptionAuthentication::Value EncryptionTestParameters::
+    serverAuthentication() const
+{
+    return d_serverAuthentication;
+}
+
+ntca::EncryptionMethod::Value EncryptionTestParameters::serverMinMethod() const
+{
+    return d_serverMinMethod;
+}
+
+ntca::EncryptionMethod::Value EncryptionTestParameters::serverMaxMethod() const
+{
+    return d_serverMaxMethod;
+}
+
+const bsl::string& EncryptionTestParameters::serverNameIndication() const
+{
+    return d_serverNameIndication;
+}
+
+bsl::size_t EncryptionTestParameters::reuseCount() const
+{
+    return d_numReuses;
+}
+
+bool EncryptionTestParameters::success() const
+{
+    return d_success;
+}
+
+bsl::ostream& EncryptionTestParameters::print(bsl::ostream& stream,
+                                              int           level,
+                                              int spacesPerLevel) const
+{
+    bslim::Printer printer(&stream, level, spacesPerLevel);
+    printer.start();
+
+    bsl::stringstream ss;
+    ss << d_variationIndex << '/' << d_variationCount;
+
+    printer.printAttribute("id", ss.str());
+    printer.printAttribute("bufferSize", d_bufferSize);
+    printer.printAttribute("clientAuthentication", d_clientAuthentication);
+    printer.printAttribute("clientMinMethod", d_clientMinMethod);
+    printer.printAttribute("clientMaxMethod", d_clientMaxMethod);
+    printer.printAttribute("serverAuthentication", d_serverAuthentication);
+    printer.printAttribute("serverMinMethod", d_serverMinMethod);
+    printer.printAttribute("serverMaxMethod", d_serverMaxMethod);
+
+    if (!d_serverNameIndication.empty()) {
+        printer.printAttribute("serverNameIndication", d_serverNameIndication);
+    }
+
+    printer.printAttribute("reuseCount", d_numReuses);
+    printer.printAttribute("success", d_success);
+
+    printer.end();
+    return stream;
+}
+
+bsl::ostream& operator<<(bsl::ostream&                   stream,
+                         const EncryptionTestParameters& object)
+{
+    return object.print(stream, 0, -1);
+}
+
+// Define a type alias for a vector of test parameters.
+typedef bsl::vector<EncryptionTestParameters> EncryptionTestParametersVector;
+
+// Provide utiltities for generating test parameters.
+class EncryptionTestParametersUtil
+{
+  public:
+    static void generateForEach(
+        ntctls::EncryptionTestParametersVector* result);
+
+    static void generateForEachBufferSize(
+        ntctls::EncryptionTestParametersVector* result,
+        const ntctls::EncryptionTestParameters& prototype);
+
+    static void generateForEachClientAuthentication(
+        ntctls::EncryptionTestParametersVector* result,
+        const ntctls::EncryptionTestParameters& prototype);
+
+    static void generateForEachClientMinMethod(
+        ntctls::EncryptionTestParametersVector* result,
+        const ntctls::EncryptionTestParameters& prototype);
+
+    static void generateForEachClientMaxMethod(
+        ntctls::EncryptionTestParametersVector* result,
+        const ntctls::EncryptionTestParameters& prototype);
+
+    static void generateForEachServerAuthentication(
+        ntctls::EncryptionTestParametersVector* result,
+        const ntctls::EncryptionTestParameters& prototype);
+
+    static void generateForEachServerMinMethod(
+        ntctls::EncryptionTestParametersVector* result,
+        const ntctls::EncryptionTestParameters& prototype);
+
+    static void generateForEachServerMaxMethod(
+        ntctls::EncryptionTestParametersVector* result,
+        const ntctls::EncryptionTestParameters& prototype);
+
+    static void generateForEachServerNameIndication(
+        ntctls::EncryptionTestParametersVector* result,
+        const ntctls::EncryptionTestParameters& prototype);
+
+    static void generateForEachReuse(
+        ntctls::EncryptionTestParametersVector* result,
+        const ntctls::EncryptionTestParameters& prototype);
+
+    static void generateForEachEntry(
+        ntctls::EncryptionTestParametersVector* result,
+        const ntctls::EncryptionTestParameters& prototype);
+};
+
+void EncryptionTestParametersUtil::generateForEach(
+    ntctls::EncryptionTestParametersVector* result)
+{
+    result->clear();
+
+    ntctls::EncryptionTestParameters prototype;
+    EncryptionTestParametersUtil::generateForEachBufferSize(result, prototype);
+
+    for (bsl::size_t i = 0; i < result->size(); ++i) {
+        (*result)[i].setVariationIndex(i);
+        (*result)[i].setVariationCount(result->size());
+    }
+}
+
+void EncryptionTestParametersUtil::generateForEachBufferSize(
+    ntctls::EncryptionTestParametersVector* result,
+    const ntctls::EncryptionTestParameters& prototype)
+{
+    bsl::vector<int> bufferSizeVector;
+    bufferSizeVector.push_back(1);
+    bufferSizeVector.push_back(2);
+    bufferSizeVector.push_back(4);
+    bufferSizeVector.push_back(8);
+    bufferSizeVector.push_back(32);
+    bufferSizeVector.push_back(1024);
+    bufferSizeVector.push_back(4096);
+
+    for (bsl::size_t i = 0; i < bufferSizeVector.size(); ++i) {
+        ntctls::EncryptionTestParameters entry = prototype;
+        entry.setBufferSize(bufferSizeVector[i]);
+        EncryptionTestParametersUtil::generateForEachClientAuthentication(
+            result,
+            entry);
+    }
+}
+
+void EncryptionTestParametersUtil::generateForEachClientAuthentication(
+    ntctls::EncryptionTestParametersVector* result,
+    const ntctls::EncryptionTestParameters& prototype)
+{
+    bsl::vector<ntca::EncryptionAuthentication::Value> authenticationVector;
+
+    authenticationVector.push_back(ntca::EncryptionAuthentication::e_NONE);
+    authenticationVector.push_back(ntca::EncryptionAuthentication::e_VERIFY);
+
+    for (bsl::size_t i = 0; i < authenticationVector.size(); ++i) {
+        ntctls::EncryptionTestParameters entry = prototype;
+        entry.setClientAuthentication(authenticationVector[i]);
+        EncryptionTestParametersUtil::generateForEachClientMinMethod(result,
+                                                                     entry);
+    }
+}
+
+void EncryptionTestParametersUtil::generateForEachClientMinMethod(
+    ntctls::EncryptionTestParametersVector* result,
+    const ntctls::EncryptionTestParameters& prototype)
+{
+    bsl::vector<ntca::EncryptionMethod::Value> methodVector;
+
+    methodVector.push_back(ntca::EncryptionMethod::e_TLS_V1_2);
+    methodVector.push_back(ntca::EncryptionMethod::e_TLS_V1_3);
+    methodVector.push_back(ntca::EncryptionMethod::e_TLS_V1_X);
+
+    for (bsl::size_t i = 0; i < methodVector.size(); ++i) {
+        ntctls::EncryptionTestParameters entry = prototype;
+        entry.setClientMinMethod(methodVector[i]);
+        EncryptionTestParametersUtil::generateForEachClientMaxMethod(result,
+                                                                     entry);
+    }
+}
+
+void EncryptionTestParametersUtil::generateForEachClientMaxMethod(
+    ntctls::EncryptionTestParametersVector* result,
+    const ntctls::EncryptionTestParameters& prototype)
+{
+    bsl::vector<ntca::EncryptionMethod::Value> methodVector;
+
+    methodVector.push_back(ntca::EncryptionMethod::e_TLS_V1_2);
+    methodVector.push_back(ntca::EncryptionMethod::e_TLS_V1_3);
+    methodVector.push_back(ntca::EncryptionMethod::e_TLS_V1_X);
+
+    for (bsl::size_t i = 0; i < methodVector.size(); ++i) {
+        ntctls::EncryptionTestParameters entry = prototype;
+        entry.setClientMaxMethod(methodVector[i]);
+        EncryptionTestParametersUtil::generateForEachServerAuthentication(
+            result,
+            entry);
+    }
+}
+
+void EncryptionTestParametersUtil::generateForEachServerAuthentication(
+    ntctls::EncryptionTestParametersVector* result,
+    const ntctls::EncryptionTestParameters& prototype)
+{
+    bsl::vector<ntca::EncryptionAuthentication::Value> authenticationVector;
+
+    authenticationVector.push_back(ntca::EncryptionAuthentication::e_NONE);
+    authenticationVector.push_back(ntca::EncryptionAuthentication::e_VERIFY);
+
+    for (bsl::size_t i = 0; i < authenticationVector.size(); ++i) {
+        ntctls::EncryptionTestParameters entry = prototype;
+        entry.setServerAuthentication(authenticationVector[i]);
+        EncryptionTestParametersUtil::generateForEachServerMinMethod(result,
+                                                                     entry);
+    }
+}
+
+void EncryptionTestParametersUtil::generateForEachServerMinMethod(
+    ntctls::EncryptionTestParametersVector* result,
+    const ntctls::EncryptionTestParameters& prototype)
+{
+    bsl::vector<ntca::EncryptionMethod::Value> methodVector;
+
+    methodVector.push_back(ntca::EncryptionMethod::e_TLS_V1_2);
+    methodVector.push_back(ntca::EncryptionMethod::e_TLS_V1_3);
+    methodVector.push_back(ntca::EncryptionMethod::e_TLS_V1_X);
+
+    for (bsl::size_t i = 0; i < methodVector.size(); ++i) {
+        ntctls::EncryptionTestParameters entry = prototype;
+        entry.setServerMinMethod(methodVector[i]);
+        EncryptionTestParametersUtil::generateForEachServerMaxMethod(result,
+                                                                     entry);
+    }
+}
+
+void EncryptionTestParametersUtil::generateForEachServerMaxMethod(
+    ntctls::EncryptionTestParametersVector* result,
+    const ntctls::EncryptionTestParameters& prototype)
+{
+    bsl::vector<ntca::EncryptionMethod::Value> methodVector;
+
+    methodVector.push_back(ntca::EncryptionMethod::e_TLS_V1_2);
+    methodVector.push_back(ntca::EncryptionMethod::e_TLS_V1_3);
+    methodVector.push_back(ntca::EncryptionMethod::e_TLS_V1_X);
+
+    for (bsl::size_t i = 0; i < methodVector.size(); ++i) {
+        ntctls::EncryptionTestParameters entry = prototype;
+        entry.setServerMaxMethod(methodVector[i]);
+        EncryptionTestParametersUtil::generateForEachServerNameIndication(
+            result,
+            entry);
+    }
+}
+
+void EncryptionTestParametersUtil::generateForEachServerNameIndication(
+    ntctls::EncryptionTestParametersVector* result,
+    const ntctls::EncryptionTestParameters& prototype)
+{
+    bsl::vector<bsl::string> serverNameIndicationVector;
+
+    serverNameIndicationVector.push_back("");
+    serverNameIndicationVector.push_back("one");
+    serverNameIndicationVector.push_back("two");
+
+    for (bsl::size_t i = 0; i < serverNameIndicationVector.size(); ++i) {
+        ntctls::EncryptionTestParameters entry = prototype;
+        entry.setServerNameIndication(serverNameIndicationVector[i]);
+        EncryptionTestParametersUtil::generateForEachReuse(result, entry);
+    }
+}
+
+void EncryptionTestParametersUtil::generateForEachReuse(
+    ntctls::EncryptionTestParametersVector* result,
+    const ntctls::EncryptionTestParameters& prototype)
+{
+    bsl::vector<bsl::size_t> reuseVector;
+
+    reuseVector.push_back(0);
+    reuseVector.push_back(1);
+    reuseVector.push_back(2);
+
+    for (bsl::size_t i = 0; i < reuseVector.size(); ++i) {
+        ntctls::EncryptionTestParameters entry = prototype;
+        entry.setReuseCount(reuseVector[i]);
+        EncryptionTestParametersUtil::generateForEachEntry(result, entry);
+    }
+}
+
+void EncryptionTestParametersUtil::generateForEachEntry(
+    ntctls::EncryptionTestParametersVector* result,
+    const ntctls::EncryptionTestParameters& prototype)
+{
+    ntctls::EncryptionTestParameters parameters = prototype;
+
+    parameters.setSuccess(true);
+
+    // Verification by neither fails because no anonymous key exchange
+    // algorithm is supported.
+
+    if (parameters.clientAuthentication() ==
+            ntca::EncryptionAuthentication::e_NONE &&
+        parameters.serverAuthentication() ==
+            ntca::EncryptionAuthentication::e_NONE)
+    {
+        parameters.setSuccess(false);
+    }
+
+    // Server authentication of the client fails unless the client is also
+    // authenticating the server (or at least, it fails unless both the client
+    // and the server provide certificates during the handshake. This test
+    // driver implementation only loads a certificate if the other side is
+    // configured to verify it. Determine how to configure OpenSSL such that
+    // the client can verify the server without having to provide its own
+    // certificate.
+    //
+    // TODO: It appears there is no configuration available in OpenSSL that
+    // supports the server requesting and verifying the client's certificate
+    // without also providing its own certificate. See the OpenSSL
+    // documentation for SSL_VERIFY_NONE for the client mode.
+
+    if (parameters.clientAuthentication() ==
+            ntca::EncryptionAuthentication::e_NONE &&
+        parameters.serverAuthentication() ==
+            ntca::EncryptionAuthentication::e_VERIFY)
+    {
+        parameters.setSuccess(false);
+    }
+
+    // OpenSSL has an open issue where a resumed session by the client causes
+    // the server to fail the handshake with "session id context
+    // uninitialized". This error only occurs after the session is used once
+    // then attempt to be reused after it has been cleanly shut down. The error
+    // does not occur when only the client verifies the server, and the server
+    // does not verify the client.
+    //
+    // See https://github.com/openssl/openssl/issues/10168
+
+    if (parameters.clientAuthentication() ==
+            ntca::EncryptionAuthentication::e_VERIFY &&
+        parameters.serverAuthentication() ==
+            ntca::EncryptionAuthentication::e_VERIFY &&
+        parameters.reuseCount() > 0)
+    {
+        parameters.setSuccess(false);
+    }
+
+    if (parameters.clientMinMethod() > parameters.clientMaxMethod()) {
+        return;  // NON-SENSICAL
+    }
+
+    if (parameters.serverMinMethod() > parameters.serverMaxMethod()) {
+        return;  // NON-SENSICAL
+    }
+
+    if (parameters.clientMaxMethod() < parameters.serverMinMethod()) {
+        parameters.setSuccess(false);
+    }
+
+    if (parameters.serverMaxMethod() < parameters.clientMinMethod()) {
+        parameters.setSuccess(false);
+    }
+
+    result->push_back(parameters);
+}
+
+// Provide functions for implementing encryption tests.
+class EncryptionTestUtil
+{
+  public:
+    // Load the specified 'parameter's.
+    static void logParameters(
+        const char*                             label,
+        const ntctls::EncryptionTestParameters& parameters);
+
+    // Log the hex dump of the specified 'blob' prefixed by the specified
+    // 'label'.
+    static void logHexDump(const char* label, const bdlbb::Blob& blob);
+
+    // Authenticate the specified 'client' certificate'. Return the error.
+    static bool processClientAuthenticationByServer(
+        const ntctls::EncryptionTestEnvironment* environment,
+        const ntctls::EncryptionTestParameters*  parameters,
+        const ntca::EncryptionCertificate&       client);
+
+    // Authenticate the specified 'client' certificate'. Return the error.
+    static bool processServerAuthenticationByClient(
+        const ntctls::EncryptionTestEnvironment* environment,
+        const ntctls::EncryptionTestParameters*  parameters,
+        const ntca::EncryptionCertificate&       server);
+
+    // Process the completion or failure of the handshake of the specified
+    // 'clientSession' according to the specified 'error'. The session is
+    // established with server identified by the specified 'serverCertificate',
+    // if any. Set the specified 'clientCompleteFlag' to true.
+    static void processClientHandshakeComplete(
+        const ntsa::Error&                                  error,
+        const bsl::shared_ptr<ntci::Encryption>&            clientSession,
+        const bsl::shared_ptr<ntci::EncryptionCertificate>& serverCertificate,
+        const bsl::string&                                  details,
+        bool*                                               clientCompleteFlag,
+        const ntctls::EncryptionTestParameters&             parameters);
+
+    // Process the completion or failure of the handshake of the specified
+    // 'serverSession' according to the specified 'error'. The session is
+    // established with server identified by the specified 'serverCertificate',
+    // if any. Set the specified 'serverCompleteFlag' to true.
+    static void processServerHandshakeComplete(
+        const ntsa::Error&                                  error,
+        const bsl::shared_ptr<ntci::Encryption>&            serverSession,
+        const bsl::shared_ptr<ntci::EncryptionCertificate>& clientCertificate,
+        const bsl::string&                                  details,
+        bool*                                               serverCompleteFlag,
+        const ntctls::EncryptionTestParameters&             parameters);
+
+    // Repeatedly read and write from the specified 'clientSession' and
+    // 'serverSession' until both the specified 'clientCompleteFlag' and
+    // 'serverCompleteFlag' is set.
+    static ntsa::Error cycleHandshake(
+        const bsl::shared_ptr<ntci::Encryption>& clientSession,
+        const bsl::shared_ptr<ntci::Encryption>& serverSession,
+        const bsl::shared_ptr<ntci::DataPool>&   dataPool,
+        bdlbb::Blob*                             clientPlaintextRead,
+        bdlbb::Blob*                             serverPlaintextRead,
+        const ntctls::EncryptionTestParameters&  parameters);
+
+    // Repeatedly read and write from the specified 'clientSession' and
+    // 'serverSession' until both the specified 'clientCompleteFlag' and
+    // 'serverCompleteFlag' is set.
+    static ntsa::Error cycleShutdown(
+        const bsl::shared_ptr<ntci::Encryption>& clientSession,
+        const bsl::shared_ptr<ntci::Encryption>& serverSession,
+        const bsl::shared_ptr<ntci::DataPool>&   dataPool,
+        bdlbb::Blob*                             clientPlaintextRead,
+        bdlbb::Blob*                             serverPlaintextRead,
+        const ntctls::EncryptionTestParameters&  parameters);
+
+    // Execute the test described by the specified 'parameters' using the
+    // specified 'authorityCertificate' and 'authorityPrivateKey' for the
+    // trusted certificate authority, the specified 'clientCertificate' and
+    // 'clientPrivateKey' for the client, and the specified 'serverCertificate'
+    // and 'serverPrivateKey'. Optionally specify a 'basicAllocator' used to
+    // supply memory. If 'basicAllocator' is 0, the currently installed default
+    // allocator is used.
+    static void execute(const ntctls::EncryptionTestEnvironment& environment,
+                        const ntctls::EncryptionTestParameters&  parameters,
+                        bslma::Allocator* basicAllocator = 0);
+};
+
+void EncryptionTestUtil::logParameters(
+    const char*                             label,
+    const ntctls::EncryptionTestParameters& parameters)
+{
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_STREAM_INFO << label << " = " << parameters
+                         << NTCI_LOG_STREAM_END;
+}
+
+void EncryptionTestUtil::logHexDump(const char* label, const bdlbb::Blob& blob)
+{
+    NTCI_LOG_CONTEXT();
+
+    bsl::stringstream ss;
+    ss << bdlbb::BlobUtilHexDumper(&blob);
+
+    NTCI_LOG_DEBUG("%s %d bytes", label, (int)(blob.length()));
+
+    NTCI_LOG_TRACE("%s:\n%s", label, ss.str().c_str());
+}
+
+bool EncryptionTestUtil::processClientAuthenticationByServer(
+    const ntctls::EncryptionTestEnvironment* environment,
+    const ntctls::EncryptionTestParameters*  parameters,
+    const ntca::EncryptionCertificate&       client)
+{
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_STREAM_INFO << "Server authenticated client" << client
+                         << NTCI_LOG_STREAM_END;
+
+    return true;
+}
+
+bool EncryptionTestUtil::processServerAuthenticationByClient(
+    const ntctls::EncryptionTestEnvironment* environment,
+    const ntctls::EncryptionTestParameters*  parameters,
+    const ntca::EncryptionCertificate&       server)
+{
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_STREAM_INFO << "Client authenticated server" << server
+                         << NTCI_LOG_STREAM_END;
+
+    if (parameters->serverNameIndication().empty()) {
+        NTSCFG_TEST_EQ(server, environment->serverCertificate());
+    }
+    else {
+        if (parameters->serverNameIndication() == environment->serverOneName())
+        {
+            NTSCFG_TEST_EQ(server, environment->serverOneCertificate());
+        }
+        else if (parameters->serverNameIndication() ==
+                 environment->serverTwoName())
+        {
+            NTSCFG_TEST_EQ(server, environment->serverTwoCertificate());
+        }
+        else {
+            NTSCFG_TEST_TRUE(false);
+        }
+    }
+
+    return true;
+}
+
+void EncryptionTestUtil::processClientHandshakeComplete(
+    const ntsa::Error&                                  error,
+    const bsl::shared_ptr<ntci::Encryption>&            clientSession,
+    const bsl::shared_ptr<ntci::EncryptionCertificate>& serverCertificate,
+    const bsl::string&                                  details,
+    bool*                                               clientCompleteFlag,
+    const ntctls::EncryptionTestParameters&             parameters)
+{
+    NTCI_LOG_CONTEXT();
+
+    NTCCFG_WARNING_UNUSED(serverCertificate);
+    NTCCFG_WARNING_UNUSED(parameters);
+
+    if (!error) {
+        bsl::string cipher;
+        bool        found = clientSession->getCipher(&cipher);
+        NTSCFG_TEST_TRUE(found);
+
+        NTCI_LOG_INFO("Client handshake complete: %s", cipher.c_str());
+    }
+    else {
+        NTSCFG_TEST_EQ(error, ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED));
+        NTCI_LOG_INFO("Client handshake failed: %s", details.c_str());
+    }
+
+    *clientCompleteFlag = true;
+}
+
+void EncryptionTestUtil::processServerHandshakeComplete(
+    const ntsa::Error&                                  error,
+    const bsl::shared_ptr<ntci::Encryption>&            serverSession,
+    const bsl::shared_ptr<ntci::EncryptionCertificate>& clientCertificate,
+    const bsl::string&                                  details,
+    bool*                                               serverCompleteFlag,
+    const ntctls::EncryptionTestParameters&             parameters)
+{
+    NTCI_LOG_CONTEXT();
+
+    NTCCFG_WARNING_UNUSED(clientCertificate);
+    NTCCFG_WARNING_UNUSED(parameters);
+
+    if (!error) {
+        bsl::string cipher;
+        bool        found = serverSession->getCipher(&cipher);
+        NTSCFG_TEST_TRUE(found);
+
+        NTCI_LOG_INFO("Server handshake complete: %s", cipher.c_str());
+    }
+    else {
+        NTSCFG_TEST_EQ(error, ntsa::Error(ntsa::Error::e_NOT_AUTHORIZED));
+        NTCI_LOG_INFO("Server handshake failed: %s", details.c_str());
+    }
+
+    *serverCompleteFlag = true;
+}
+
+ntsa::Error EncryptionTestUtil::cycleHandshake(
+    const bsl::shared_ptr<ntci::Encryption>& clientSession,
+    const bsl::shared_ptr<ntci::Encryption>& serverSession,
+    const bsl::shared_ptr<ntci::DataPool>&   dataPool,
+    bdlbb::Blob*                             clientPlaintextRead,
+    bdlbb::Blob*                             serverPlaintextRead,
+    const ntctls::EncryptionTestParameters&  parameters)
+{
+    NTCI_LOG_CONTEXT();
+
+    NTCCFG_WARNING_UNUSED(parameters);
+
+    ntsa::Error error;
+
+    while (!clientSession->isHandshakeFinished() ||
+           !serverSession->isHandshakeFinished())
+    {
+        {
+            NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_CLIENT();
+
+            if (clientSession->hasOutgoingCipherText()) {
+                bdlbb::Blob data(dataPool->outgoingBlobBufferFactory().get());
+                clientSession->popOutgoingCipherText(&data);
+
+                EncryptionTestUtil::logHexDump("Client sending ciphertext",
+                                               data);
+
+                {
+                    NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_SERVER();
+
+                    error = serverSession->pushIncomingCipherText(data);
+                    if (parameters.success()) {
+                        NTSCFG_TEST_OK(error);
+                    }
+                    else {
+                        NTSCFG_TEST_NE(error, ntsa::Error());
+                        return error;
+                    }
+                }
+            }
+        }
+
+        {
+            NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_SERVER();
+
+            if (serverSession->hasOutgoingCipherText()) {
+                bdlbb::Blob data(dataPool->outgoingBlobBufferFactory().get());
+                serverSession->popOutgoingCipherText(&data);
+
+                EncryptionTestUtil::logHexDump("Server sending ciphertext",
+                                               data);
+
+                {
+                    NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_CLIENT();
+
+                    error = clientSession->pushIncomingCipherText(data);
+                    if (parameters.success()) {
+                        NTSCFG_TEST_OK(error);
+                    }
+                    else {
+                        NTSCFG_TEST_NE(error, ntsa::Error());
+                        return error;
+                    }
+                }
+            }
+        }
+
+        {
+            NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_CLIENT();
+
+            if (clientSession->hasIncomingPlainText()) {
+                bdlbb::Blob data(dataPool->incomingBlobBufferFactory().get());
+                error = clientSession->popIncomingPlainText(&data);
+                if (parameters.success()) {
+                    NTSCFG_TEST_OK(error);
+                }
+                else {
+                    NTSCFG_TEST_NE(error, ntsa::Error());
+                    return error;
+                }
+
+                EncryptionTestUtil::logHexDump("Client received plaintext",
+                                               data);
+
+                bdlbb::BlobUtil::append(clientPlaintextRead, data);
+            }
+        }
+
+        {
+            NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_SERVER();
+
+            if (serverSession->hasIncomingPlainText()) {
+                bdlbb::Blob data(dataPool->incomingBlobBufferFactory().get());
+                error = serverSession->popIncomingPlainText(&data);
+                if (parameters.success()) {
+                    NTSCFG_TEST_OK(error);
+                }
+                else {
+                    NTSCFG_TEST_NE(error, ntsa::Error());
+                    return error;
+                }
+
+                EncryptionTestUtil::logHexDump("Server received plaintext",
+                                               data);
+
+                bdlbb::BlobUtil::append(serverPlaintextRead, data);
+            }
+        }
+    }
+
+    return ntsa::Error();
+}
+
+ntsa::Error EncryptionTestUtil::cycleShutdown(
+    const bsl::shared_ptr<ntci::Encryption>& clientSession,
+    const bsl::shared_ptr<ntci::Encryption>& serverSession,
+    const bsl::shared_ptr<ntci::DataPool>&   dataPool,
+    bdlbb::Blob*                             clientPlaintextRead,
+    bdlbb::Blob*                             serverPlaintextRead,
+    const ntctls::EncryptionTestParameters&  parameters)
+{
+    NTCI_LOG_CONTEXT();
+
+    NTCCFG_WARNING_UNUSED(parameters);
+
+    ntsa::Error error;
+
+    while (!clientSession->isShutdownFinished() ||
+           !serverSession->isShutdownFinished())
+    {
+        {
+            NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_CLIENT();
+
+            if (clientSession->hasOutgoingCipherText()) {
+                bdlbb::Blob data(dataPool->outgoingBlobBufferFactory().get());
+                clientSession->popOutgoingCipherText(&data);
+
+                EncryptionTestUtil::logHexDump("Client sending ciphertext",
+                                               data);
+
+                {
+                    NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_SERVER();
+
+                    error = serverSession->pushIncomingCipherText(data);
+                    if (parameters.success()) {
+                        NTSCFG_TEST_OK(error);
+                    }
+                    else {
+                        NTSCFG_TEST_NE(error, ntsa::Error());
+                        return error;
+                    }
+                }
+            }
+        }
+
+        {
+            NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_SERVER();
+
+            if (serverSession->hasOutgoingCipherText()) {
+                bdlbb::Blob data(dataPool->outgoingBlobBufferFactory().get());
+                serverSession->popOutgoingCipherText(&data);
+
+                EncryptionTestUtil::logHexDump("Server sending ciphertext",
+                                               data);
+
+                {
+                    NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_CLIENT();
+
+                    error = clientSession->pushIncomingCipherText(data);
+                    if (parameters.success()) {
+                        NTSCFG_TEST_OK(error);
+                    }
+                    else {
+                        NTSCFG_TEST_NE(error, ntsa::Error());
+                        return error;
+                    }
+                }
+            }
+        }
+
+        {
+            NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_CLIENT();
+
+            if (clientSession->hasIncomingPlainText()) {
+                bdlbb::Blob data(dataPool->incomingBlobBufferFactory().get());
+                error = clientSession->popIncomingPlainText(&data);
+                if (parameters.success()) {
+                    NTSCFG_TEST_OK(error);
+                }
+                else {
+                    NTSCFG_TEST_NE(error, ntsa::Error());
+                    return error;
+                }
+
+                EncryptionTestUtil::logHexDump("Client received plaintext",
+                                               data);
+
+                bdlbb::BlobUtil::append(clientPlaintextRead, data);
+            }
+        }
+
+        {
+            NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_SERVER();
+
+            if (serverSession->hasIncomingPlainText()) {
+                bdlbb::Blob data(dataPool->incomingBlobBufferFactory().get());
+                error = serverSession->popIncomingPlainText(&data);
+                if (parameters.success()) {
+                    NTSCFG_TEST_OK(error);
+                }
+                else {
+                    NTSCFG_TEST_NE(error, ntsa::Error());
+                    return error;
+                }
+
+                EncryptionTestUtil::logHexDump("Server received plaintext",
+                                               data);
+
+                bdlbb::BlobUtil::append(serverPlaintextRead, data);
+            }
+        }
+    }
+
+    return ntsa::Error();
+}
+
+void EncryptionTestUtil::execute(
+    const ntctls::EncryptionTestEnvironment& environment,
+    const ntctls::EncryptionTestParameters&  parameters,
+    bslma::Allocator*                        basicAllocator)
+{
+    NTCI_LOG_CONTEXT();
+
+    EncryptionTestUtil::logParameters("Testing parameters", parameters);
+
+    ntsa::Error error;
+
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<ntci::EncryptionDriver> driver;
+    ntctls::Plugin::load(&driver);
+
+    // Create a data pool.
+
+    bsl::shared_ptr<ntci::DataPool> dataPool;
+    {
+        bsl::shared_ptr<ntcs::DataPool> concreteDataPool;
+        concreteDataPool.createInplace(allocator,
+                                       parameters.bufferSize(),
+                                       parameters.bufferSize(),
+                                       allocator);
+
+        dataPool = concreteDataPool;
+    }
+
+    // Create the client.
+
+    ntca::EncryptionClientOptions clientOptions;
+
+    clientOptions.setAuthentication(parameters.clientAuthentication());
+    clientOptions.setMinMethod(parameters.clientMinMethod());
+    clientOptions.setMaxMethod(parameters.clientMaxMethod());
+
+    if (parameters.clientAuthentication() ==
+        ntca::EncryptionAuthentication::e_VERIFY)
+    {
+        clientOptions.addAuthority(environment.authorityCertificate());
+    }
+
+    if (parameters.serverAuthentication() ==
+        ntca::EncryptionAuthentication::e_VERIFY)
+    {
+        clientOptions.setIdentity(environment.clientCertificate());
+        clientOptions.setPrivateKey(environment.clientPrivateKey());
+    }
+
+    ntca::EncryptionValidation clientValidation;
+    clientValidation.setCallback(
+        NTCCFG_BIND(&EncryptionTestUtil::processServerAuthenticationByClient,
+                    &environment,
+                    &parameters,
+                    NTCCFG_BIND_PLACEHOLDER_1));
+
+    clientOptions.setValidation(clientValidation);
+
+    bsl::shared_ptr<ntci::EncryptionClient> client;
+    error = driver->createEncryptionClient(&client,
+                                           clientOptions,
+                                           dataPool,
+                                           allocator);
+    NTSCFG_TEST_OK(error);
+
+    // Create the server.
+
+    ntca::EncryptionServerOptions serverOptions;
+
+    serverOptions.setAuthentication(parameters.serverAuthentication());
+    serverOptions.setMinMethod(parameters.serverMinMethod());
+    serverOptions.setMaxMethod(parameters.serverMaxMethod());
+
+    if (parameters.serverAuthentication() ==
+        ntca::EncryptionAuthentication::e_VERIFY)
+    {
+        serverOptions.addAuthority(environment.authorityCertificate());
+    }
+
+    if (parameters.clientAuthentication() ==
+        ntca::EncryptionAuthentication::e_VERIFY)
+    {
+        serverOptions.setIdentity(environment.serverCertificate());
+        serverOptions.setPrivateKey(environment.serverPrivateKey());
+    }
+
+    ntca::EncryptionValidation serverValidation;
+
+    serverValidation.setCallback(
+        NTCCFG_BIND(&EncryptionTestUtil::processClientAuthenticationByServer,
+                    &environment,
+                    &parameters,
+                    NTCCFG_BIND_PLACEHOLDER_1));
+
+    serverOptions.setValidation(serverValidation);
+
+    ntca::EncryptionOptions serverOneOptions;
+
+    serverOneOptions.setAuthentication(parameters.serverAuthentication());
+    serverOneOptions.setMinMethod(parameters.serverMinMethod());
+    serverOneOptions.setMaxMethod(parameters.serverMaxMethod());
+
+    if (parameters.serverAuthentication() ==
+        ntca::EncryptionAuthentication::e_VERIFY)
+    {
+        serverOneOptions.addAuthority(environment.authorityCertificate());
+    }
+
+    if (parameters.clientAuthentication() ==
+        ntca::EncryptionAuthentication::e_VERIFY)
+    {
+        serverOneOptions.setIdentity(environment.serverOneCertificate());
+        serverOneOptions.setPrivateKey(environment.serverOnePrivateKey());
+    }
+
+    serverOneOptions.setValidation(serverValidation);
+
+    serverOptions.addOverrides(environment.serverOneName(), serverOneOptions);
+
+    ntca::EncryptionOptions serverTwoOptions;
+
+    serverTwoOptions.setAuthentication(parameters.serverAuthentication());
+    serverTwoOptions.setMinMethod(parameters.serverMinMethod());
+    serverTwoOptions.setMaxMethod(parameters.serverMaxMethod());
+
+    if (parameters.serverAuthentication() ==
+        ntca::EncryptionAuthentication::e_VERIFY)
+    {
+        serverTwoOptions.addAuthority(environment.authorityCertificate());
+    }
+
+    if (parameters.clientAuthentication() ==
+        ntca::EncryptionAuthentication::e_VERIFY)
+    {
+        serverTwoOptions.setIdentity(environment.serverTwoCertificate());
+        serverTwoOptions.setPrivateKey(environment.serverTwoPrivateKey());
+    }
+
+    serverTwoOptions.setValidation(serverValidation);
+
+    serverOptions.addOverrides(environment.serverTwoName(), serverTwoOptions);
+
+    bsl::shared_ptr<ntci::EncryptionServer> server;
+    error = driver->createEncryptionServer(&server,
+                                           serverOptions,
+                                           dataPool,
+                                           allocator);
+    NTSCFG_TEST_OK(error);
+
+    // Create the client session.
+
+    bsl::shared_ptr<ntci::Encryption> clientSession;
+    error = client->createEncryption(&clientSession, dataPool, allocator);
+    NTSCFG_TEST_OK(error);
+
+    // Create the server session.
+
+    bsl::shared_ptr<ntci::Encryption> serverSession;
+    error = server->createEncryption(&serverSession, dataPool, allocator);
+    NTSCFG_TEST_OK(error);
+
+    // Create the test state variables.
+
+    bdlbb::Blob helloServer(dataPool->outgoingBlobBufferFactory().get());
+    bdlbb::BlobUtil::append(&helloServer, "Hello, server!", 0, 14);
+
+    bdlbb::Blob helloClient(dataPool->outgoingBlobBufferFactory().get());
+    bdlbb::BlobUtil::append(&helloClient, "Hello, client!", 0, 14);
+
+    bdlbb::Blob goodbyeServer(dataPool->outgoingBlobBufferFactory().get());
+    bdlbb::BlobUtil::append(&goodbyeServer, "Goodbye, server!", 0, 16);
+
+    bdlbb::Blob goodbyeClient(dataPool->outgoingBlobBufferFactory().get());
+    bdlbb::BlobUtil::append(&goodbyeClient, "Goodbye, client!", 0, 16);
+
+    bdlbb::Blob expectedClientPlaintextRead(
+        dataPool->incomingBlobBufferFactory().get(),
+        allocator);
+    bdlbb::BlobUtil::append(&expectedClientPlaintextRead, helloClient);
+    bdlbb::BlobUtil::append(&expectedClientPlaintextRead, goodbyeClient);
+
+    bdlbb::Blob expectedServerPlaintextRead(
+        dataPool->incomingBlobBufferFactory().get(),
+        allocator);
+    bdlbb::BlobUtil::append(&expectedServerPlaintextRead, helloServer);
+    bdlbb::BlobUtil::append(&expectedServerPlaintextRead, goodbyeServer);
+
+    for (bsl::size_t usageIteration = 0;
+         usageIteration < parameters.reuseCount() + 1;
+         ++usageIteration)
+    {
+        NTCI_LOG_INFO("Iteration %d/%d starting",
+                      usageIteration + 1,
+                      parameters.reuseCount() + 1);
+
+        bool clientHandshakeComplete = false;
+        bool serverHandshakeComplete = false;
+
+        bdlbb::Blob clientPlaintextRead(
+            dataPool->incomingBlobBufferFactory().get(),
+            allocator);
+
+        bdlbb::Blob serverPlaintextRead(
+            dataPool->incomingBlobBufferFactory().get(),
+            allocator);
+
+        // Initiate the handshake from the client.
+
+        {
+            NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_CLIENT();
+
+            NTCI_LOG_INFO("Client handshake initiating");
+
+            ntca::UpgradeOptions clientUpgradeOptions;
+            if (!parameters.serverNameIndication().empty()) {
+                clientUpgradeOptions.setServerName(
+                    parameters.serverNameIndication());
+            }
+
+            ntci::Encryption::HandshakeCallback clientUpgradeCallback =
+                NTCCFG_BIND(
+                    &EncryptionTestUtil::processClientHandshakeComplete,
+                    NTCCFG_BIND_PLACEHOLDER_1,
+                    clientSession,
+                    NTCCFG_BIND_PLACEHOLDER_2,
+                    NTCCFG_BIND_PLACEHOLDER_3,
+                    &clientHandshakeComplete,
+                    parameters);
+
+            error = clientSession->initiateHandshake(clientUpgradeOptions,
+                                                     clientUpgradeCallback);
+            if (parameters.success()) {
+                NTSCFG_TEST_OK(error);
+            }
+            else {
+                NTSCFG_TEST_NE(error, ntsa::Error());
+                return;
+            }
+        }
+
+        // Initiate the handshake from the server.
+
+        {
+            NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_SERVER();
+
+            NTCI_LOG_INFO("Server handshake initiating");
+
+            ntca::UpgradeOptions serverUpgradeOptions;
+
+            ntci::Encryption::HandshakeCallback serverUpgradeCallback =
+                NTCCFG_BIND(
+                    &EncryptionTestUtil::processServerHandshakeComplete,
+                    NTCCFG_BIND_PLACEHOLDER_1,
+                    serverSession,
+                    NTCCFG_BIND_PLACEHOLDER_2,
+                    NTCCFG_BIND_PLACEHOLDER_3,
+                    &serverHandshakeComplete,
+                    parameters);
+
+            error = serverSession->initiateHandshake(serverUpgradeOptions,
+                                                     serverUpgradeCallback);
+            if (parameters.success()) {
+                NTSCFG_TEST_OK(error);
+            }
+            else {
+                NTSCFG_TEST_NE(error, ntsa::Error());
+                return;
+            }
+        }
+
+        // Send data immediately after the handshake is initiated.
+
+        {
+            NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_CLIENT();
+
+            error = clientSession->pushOutgoingPlainText(helloServer);
+            if (parameters.success()) {
+                NTSCFG_TEST_OK(error);
+            }
+            else {
+                NTSCFG_TEST_NE(error, ntsa::Error());
+                return;
+            }
+        }
+
+        {
+            NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_SERVER();
+
+            error = serverSession->pushOutgoingPlainText(helloClient);
+            if (parameters.success()) {
+                NTSCFG_TEST_OK(error);
+            }
+            else {
+                NTSCFG_TEST_NE(error, ntsa::Error());
+                return;
+            }
+        }
+
+        // Process the TLS state machine until the handshake is complete.
+
+        error = EncryptionTestUtil::cycleHandshake(clientSession,
+                                                   serverSession,
+                                                   dataPool,
+                                                   &clientPlaintextRead,
+                                                   &serverPlaintextRead,
+                                                   parameters);
+
+        if (parameters.success()) {
+            NTSCFG_TEST_OK(error);
+        }
+        else {
+            NTSCFG_TEST_NE(error, ntsa::Error());
+            return;
+        }
+
+        NTSCFG_TEST_TRUE(clientHandshakeComplete);
+        NTSCFG_TEST_TRUE(serverHandshakeComplete);
+
+        // Send data immediately before the shutdown is initiated.
+
+        {
+            NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_CLIENT();
+
+            error = clientSession->pushOutgoingPlainText(goodbyeServer);
+            if (parameters.success()) {
+                NTSCFG_TEST_OK(error);
+            }
+            else {
+                NTSCFG_TEST_NE(error, ntsa::Error());
+                return;
+            }
+        }
+
+        {
+            NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_SERVER();
+
+            error = serverSession->pushOutgoingPlainText(goodbyeClient);
+            if (parameters.success()) {
+                NTSCFG_TEST_OK(error);
+            }
+            else {
+                NTSCFG_TEST_NE(error, ntsa::Error());
+                return;
+            }
+        }
+
+        // Initiate the shutdown from the client.
+
+        {
+            NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_CLIENT();
+
+            NTCI_LOG_INFO("Client shutdown initiating");
+
+            error = clientSession->shutdown();
+            NTSCFG_TEST_OK(error);
+        }
+
+        // Initiate the shutdown from the server.
+
+        {
+            NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_SERVER();
+
+            NTCI_LOG_INFO("Server shutdown initiating");
+
+            error = serverSession->shutdown();
+            NTSCFG_TEST_OK(error);
+        }
+
+        // Process the TLS state machine until the shutdown is complete.
+
+        error = EncryptionTestUtil::cycleShutdown(clientSession,
+                                                  serverSession,
+                                                  dataPool,
+                                                  &clientPlaintextRead,
+                                                  &serverPlaintextRead,
+                                                  parameters);
+        if (parameters.success()) {
+            NTSCFG_TEST_OK(error);
+        }
+        else {
+            NTSCFG_TEST_NE(error, ntsa::Error());
+            return;
+        }
+
+        // Ensure the plaintext received by the client matches the expected data.
+
+        NTSCFG_TEST_EQ(bdlbb::BlobUtil::compare(clientPlaintextRead,
+                                                expectedClientPlaintextRead),
+                       0);
+
+        // Ensure the plaintext received by the server matches the expected data.
+
+        NTSCFG_TEST_EQ(bdlbb::BlobUtil::compare(serverPlaintextRead,
+                                                expectedServerPlaintextRead),
+                       0);
+
+        NTCI_LOG_INFO("Iteration %d/%d complete",
+                      usageIteration + 1,
+                      parameters.reuseCount() + 1);
+    }
+
+    NTCI_LOG_INFO("Test complete");
+}
+
+// Provide utilities for executing test cases.
+class EncryptionTest
+{
+  public:
+    // Verify the behavior of encryption sessions with various configuration
+    // parameters.
+    static void verifyUsage();
+};
+
+void EncryptionTest::verifyUsage()
+{
+    // Concern: Verify the behavior of encryption sessions with various
+    // configuration parameters.
+
+    NTCI_LOG_CONTEXT();
+
+    NTCTLS_PLUGIN_TEST_LOG_CONTEXT_GUARD_MAIN();
+
+    bslma::Allocator* allocator = NTSCFG_TEST_ALLOCATOR;
+
+    ntctls::EncryptionTestEnvironment environment(allocator);
+
+    ntctls::EncryptionTestParametersVector parametersVector(allocator);
+    ntctls::EncryptionTestParametersUtil::generateForEach(&parametersVector);
+
+    for (bsl::size_t i = 0; i < parametersVector.size(); ++i) {
+        const ntctls::EncryptionTestParameters& parameters =
+            parametersVector[i];
+
+        if (!parameters.success()) {
+            continue;
+        }
+
+        ntctls::EncryptionTestUtil::execute(environment,
+                                            parameters,
+                                            allocator);
+    }
+}
+
+}  // close namespace ntctls
+}  // close namespace BloombergLP
+
+#endif

--- a/groups/ntc/ntctls/package/ntctls.dep
+++ b/groups/ntc/ntctls/package/ntctls.dep
@@ -7,4 +7,3 @@ ntcs
 ntcq
 ntcd
 ntcdns
-ntctls

--- a/groups/ntc/ntctls/package/ntctls.mem
+++ b/groups/ntc/ntctls/package/ntctls.mem
@@ -1,0 +1,1 @@
+ntctls_plugin

--- a/groups/nts/group/nts.dep
+++ b/groups/nts/group/nts.dep
@@ -1,3 +1,4 @@
 bal
 bdl
 bsl
+openssl

--- a/licenses-binary/LICENSE-bde.txt
+++ b/licenses-binary/LICENSE-bde.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses-binary/LICENSE-ntf-core.txt
+++ b/licenses-binary/LICENSE-ntf-core.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses-binary/LICENSE-openssl.txt
+++ b/licenses-binary/LICENSE-openssl.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/licenses-binary/LICENSE-zlib.txt
+++ b/licenses-binary/LICENSE-zlib.txt
@@ -1,0 +1,23 @@
+zlib.h -- interface of the 'zlib' general purpose compression library
+version 1.2.13, October 13th, 2022
+
+Copyright (C) 1995-2022 Jean-loup Gailly and Mark Adler
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+    claim that you wrote the original software. If you use this software
+    in a product, an acknowledgment in the product documentation would be
+    appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+    misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+
+Jean-loup Gailly        Mark Adler
+jloup@gzip.org          madler@alumni.caltech.edu

--- a/licenses/LICENSE-bde.txt
+++ b/licenses/LICENSE-bde.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/LICENSE-ntf-core.txt
+++ b/licenses/LICENSE-ntf-core.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/LICENSE-openssl.txt
+++ b/licenses/LICENSE-openssl.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/licenses/LICENSE-zlib.txt
+++ b/licenses/LICENSE-zlib.txt
@@ -1,0 +1,23 @@
+zlib.h -- interface of the 'zlib' general purpose compression library
+version 1.2.13, October 13th, 2022
+
+Copyright (C) 1995-2022 Jean-loup Gailly and Mark Adler
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+    claim that you wrote the original software. If you use this software
+    in a product, an acknowledgment in the product documentation would be
+    appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+    misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+
+Jean-loup Gailly        Mark Adler
+jloup@gzip.org          madler@alumni.caltech.edu

--- a/targets.cmake
+++ b/targets.cmake
@@ -64,6 +64,10 @@ if (${NTF_BUILD_WITH_NTS})
         ntf_group_requires(NAME nts DEPENDENCY bsl)
     endif()
 
+    if (${NTF_BUILD_WITH_OPENSSL})
+        ntf_group_requires(NAME nts DEPENDENCY openssl)
+    endif()
+
     ntf_package(NAME ntsscm)
 
     ntf_component(NAME ntsscm_version)
@@ -320,6 +324,10 @@ if (${NTF_BUILD_WITH_NTC})
 
     if (${NTF_BUILD_WITH_BSL})
         ntf_group_requires(NAME ntc DEPENDENCY bsl)
+    endif()
+
+    if (${NTF_BUILD_WITH_OPENSSL})
+        ntf_group_requires(NAME ntc DEPENDENCY openssl)
     endif()
 
     ntf_package(NAME ntcscm)
@@ -777,6 +785,26 @@ if (${NTF_BUILD_WITH_NTC})
 
     ntf_package(
         NAME
+            ntctls
+        REQUIRES
+            ntcscm
+            ntccfg
+            ntca
+            ntci
+            ntcm
+            ntcs
+            ntcq
+            ntcd
+            ntcdns
+        PRIVATE
+    )
+
+    ntf_component(NAME ntctls_plugin)
+
+    ntf_package_end(NAME ntctls)
+
+    ntf_package(
+        NAME
             ntcu
         REQUIRES
             ntcscm
@@ -788,6 +816,7 @@ if (${NTF_BUILD_WITH_NTC})
             ntcq
             ntcd
             ntcdns
+            ntctls
         PRIVATE
     )
 
@@ -817,6 +846,7 @@ if (${NTF_BUILD_WITH_NTC})
             ntcq
             ntcd
             ntcdns
+            ntctls
             ntcu
         PRIVATE
     )
@@ -842,6 +872,7 @@ if (${NTF_BUILD_WITH_NTC})
             ntcq
             ntcd
             ntcdns
+            ntctls
             ntcu
         PRIVATE
     )
@@ -867,6 +898,7 @@ if (${NTF_BUILD_WITH_NTC})
             ntcq
             ntcd
             ntcdns
+            ntctls
             ntcu
             ntcr
             ntcp
@@ -899,6 +931,7 @@ if (${NTF_BUILD_WITH_NTC})
             ntcq
             ntcd
             ntcdns
+            ntctls
             ntcu
             ntcr
             ntcp

--- a/variables.cmake
+++ b/variables.cmake
@@ -559,6 +559,18 @@ if (NOT DEFINED NTF_BUILD_WITH_IORING)
     endif()
 endif()
 
+if (NOT DEFINED NTF_BUILD_WITH_OPENSSL)
+    if (DEFINED NTF_CONFIGURE_WITH_OPENSSL)
+        set(NTF_BUILD_WITH_OPENSSL
+            ${NTF_CONFIGURE_WITH_OPENSSL} CACHE INTERNAL "")
+    elseif (DEFINED ENV{NTF_CONFIGURE_WITH_OPENSSL})
+        set(NTF_BUILD_WITH_OPENSSL
+            $ENV{NTF_CONFIGURE_WITH_OPENSSL} CACHE INTERNAL "")
+    else()
+        set(NTF_BUILD_WITH_OPENSSL TRUE CACHE INTERNAL "")
+    endif()
+endif()
+
 if (NOT DEFINED NTF_BUILD_WITH_DYNAMIC_LOAD_BALANCING)
     if (DEFINED NTF_CONFIGURE_WITH_DYNAMIC_LOAD_BALANCING)
         set(NTF_BUILD_WITH_DYNAMIC_LOAD_BALANCING
@@ -968,6 +980,12 @@ if (${NTF_BUILD_WITH_IOCP})
     message(STATUS "NTF: Building with I/O completion ports:        yes")
 else()
     message(STATUS "NTF: Building with I/O completion ports:        no")
+endif()
+
+if (${NTF_BUILD_WITH_OPENSSL})
+    message(STATUS "NTF: Building with OpenSSL:                     yes")
+else()
+    message(STATUS "NTF: Building with OpenSSL:                     no")
 endif()
 
 if (${NTF_BUILD_WITH_DYNAMIC_LOAD_BALANCING})


### PR DESCRIPTION
This PR adds an internally-provided implementation of an `ntci::EncryptionDriver` implemented using OpenSSL. This encryption driver is automatically registered the first time a TLS-related API function is called and becomes effective if the user has no explicitly registered any other encryption driver. This PR adds a dependency on OpenSSL to `nts` and `ntc`, though this whole feature can be removed at build time by specifying `./configure --without-openssl`.