### PR TITLE
Deliver a chain of intermediary CAs that sign an end-entity certifacate to the validating TLS peer

### DIFF
--- a/groups/ntc/ntca/ntca_encryptionclientoptions.cpp
+++ b/groups/ntc/ntca/ntca_encryptionclientoptions.cpp
@@ -162,6 +162,38 @@ void EncryptionClientOptions::setIdentityFile(
     d_options.setIdentityFile(resourcePath, resourceOptions);
 }
 
+void EncryptionClientOptions::addIntermediary(
+    const ntca::EncryptionCertificate& certificate)
+{
+    d_options.addIntermediary(certificate);
+}
+
+void EncryptionClientOptions::addIntermediaryData(
+    const bsl::vector<char>& resourceData)
+{
+    d_options.addIntermediaryData(resourceData);
+}
+
+void EncryptionClientOptions::addIntermediaryData(
+    const bsl::vector<char>&               resourceData,
+    const ntca::EncryptionResourceOptions& resourceOptions)
+{
+    d_options.addIntermediaryData(resourceData, resourceOptions);
+}
+
+void EncryptionClientOptions::addIntermediaryFile(
+    const bsl::string& resourcePath)
+{
+    d_options.addIntermediaryFile(resourcePath);
+}
+
+void EncryptionClientOptions::addIntermediaryFile(
+    const bsl::string&                     resourcePath,
+    const ntca::EncryptionResourceOptions& resourceOptions)
+{
+    d_options.addIntermediaryFile(resourcePath, resourceOptions);
+}
+
 void EncryptionClientOptions::setPrivateKey(const ntca::EncryptionKey& key)
 {
     d_options.setPrivateKey(key);

--- a/groups/ntc/ntca/ntca_encryptionclientoptions.h
+++ b/groups/ntc/ntca/ntca_encryptionclientoptions.h
@@ -422,6 +422,47 @@ class EncryptionClientOptions
         const bsl::string&                     resourcePath,
         const ntca::EncryptionResourceOptions& resourceOptions);
 
+    /// Add the specified 'certificate' as an intermediate signer in the chain
+    /// of trust used by the end-entity certificate. Note that the effect of
+    /// calling this function is identical to simply calling 'addResource' with
+    /// resource options that indicate the resource contains an intermediate
+    /// certificate.
+    void addIntermediary(const ntca::EncryptionCertificate& certificate);
+
+    /// Add the specified encoded 'resourceData' as an intermediate signer in
+    /// the chain of trust used by the end-entity certificate. Note that the
+    /// effect of calling this function is identical to simply calling
+    /// 'addResourceData' with resource options that indicate the resource
+    /// contains an intermediate certificate.
+    void addIntermediaryData(const bsl::vector<char>& resourceData);
+
+    /// Add the specified encoded 'resourceData' decoded according to the
+    /// specified 'resourceOptions' as an intermediate signer in the chain of
+    /// trust used by the end-entity certificate. Note that the effect of
+    /// calling this function is identical to simply calling 'addResourceData'
+    /// with resource options that indicate the resource contains an
+    /// intermediate certificate.
+    void addIntermediaryData(
+        const bsl::vector<char>&               resourceData,
+        const ntca::EncryptionResourceOptions& resourceOptions);
+
+    /// Set the path to the encoded intermediate signer in the chain of trust
+    /// used by the end-entity certificate data on disk to the specified
+    /// 'resourcePath'. Note that the effect of calling this function is
+    /// identical to simply calling 'addResourcePath' with resource options
+    /// that indicate the resource contains an intermediate certificate.
+    void addIntermediaryFile(const bsl::string& resourcePath);
+
+    /// Set the path to the encoded intermediate signer in the chain of trust
+    /// used by the end-entity certificate  data on disk to the specified
+    /// 'resourcePath' decoded according to the specified 'resourceOptions'.
+    /// Note that the effect of calling this function is identical to simply
+    /// calling 'addResourcePath' with resource options that indicate the
+    /// resource contains an end-user certificate.
+    void addIntermediaryFile(
+        const bsl::string&                     resourcePath,
+        const ntca::EncryptionResourceOptions& resourceOptions);
+
     /// Set the private key to the specified 'certificate'. Note that the
     /// effect of calling this function is identical to simply calling
     /// 'addResource' with resource options that indicate the resource contains

--- a/groups/ntc/ntca/ntca_encryptionoptions.cpp
+++ b/groups/ntc/ntca/ntca_encryptionoptions.cpp
@@ -314,6 +314,92 @@ void EncryptionOptions::setIdentityFile(
     this->addResource(resource);
 }
 
+void EncryptionOptions::addIntermediary(
+    const ntca::EncryptionCertificate& certificate)
+{
+    ntca::EncryptionResourceOptions effectiveResourceOptions;
+    effectiveResourceOptions.setHint(
+        ntca::EncryptionResourceOptions::e_CERTIFICATE_INTERMEDIARY);
+
+    ntca::EncryptionResourceDescriptor resourceDescriptor;
+    resourceDescriptor.makeCertificate(certificate);
+
+    ntca::EncryptionResource resource;
+    resource.setDescriptor(resourceDescriptor);
+    resource.setOptions(effectiveResourceOptions);
+
+    this->addResource(resource);
+}
+
+void EncryptionOptions::addIntermediaryData(
+    const bsl::vector<char>& resourceData)
+{
+    ntca::EncryptionResourceOptions effectiveResourceOptions;
+    effectiveResourceOptions.setHint(
+        ntca::EncryptionResourceOptions::e_CERTIFICATE_INTERMEDIARY);
+
+    ntca::EncryptionResourceDescriptor resourceDescriptor;
+    resourceDescriptor.makeData(resourceData);
+
+    ntca::EncryptionResource resource;
+    resource.setDescriptor(resourceDescriptor);
+    resource.setOptions(effectiveResourceOptions);
+
+    this->addResource(resource);
+}
+
+void EncryptionOptions::addIntermediaryData(
+    const bsl::vector<char>&               resourceData,
+    const ntca::EncryptionResourceOptions& resourceOptions)
+{
+    ntca::EncryptionResourceOptions effectiveResourceOptions = resourceOptions;
+    effectiveResourceOptions.setHint(
+        ntca::EncryptionResourceOptions::e_CERTIFICATE_INTERMEDIARY);
+
+    ntca::EncryptionResourceDescriptor resourceDescriptor;
+    resourceDescriptor.makeData(resourceData);
+
+    ntca::EncryptionResource resource;
+    resource.setDescriptor(resourceDescriptor);
+    resource.setOptions(effectiveResourceOptions);
+
+    this->addResource(resource);
+}
+
+void EncryptionOptions::addIntermediaryFile(const bsl::string& resourcePath)
+{
+    ntca::EncryptionResourceOptions effectiveResourceOptions;
+    effectiveResourceOptions.setHint(
+        ntca::EncryptionResourceOptions::e_CERTIFICATE_INTERMEDIARY);
+
+    ntca::EncryptionResourceDescriptor resourceDescriptor;
+    resourceDescriptor.makePath(resourcePath);
+
+    ntca::EncryptionResource resource;
+    resource.setDescriptor(resourceDescriptor);
+    resource.setOptions(effectiveResourceOptions);
+
+    this->addResource(resource);
+}
+
+void EncryptionOptions::addIntermediaryFile(
+    const bsl::string&                     resourcePath,
+    const ntca::EncryptionResourceOptions& resourceOptions)
+{
+    ntca::EncryptionResourceOptions effectiveResourceOptions = resourceOptions;
+    effectiveResourceOptions.setHint(
+        ntca::EncryptionResourceOptions::e_CERTIFICATE_INTERMEDIARY);
+
+    ntca::EncryptionResourceDescriptor resourceDescriptor;
+    resourceDescriptor.makePath(resourcePath);
+
+    ntca::EncryptionResource resource;
+    resource.setDescriptor(resourceDescriptor);
+    resource.setOptions(effectiveResourceOptions);
+
+    this->addResource(resource);
+}
+
 void EncryptionOptions::setPrivateKey(const ntca::EncryptionKey& key)
 {
     ntca::EncryptionResourceOptions effectiveResourceOptions;

--- a/groups/ntc/ntca/ntca_encryptionoptions.h
+++ b/groups/ntc/ntca/ntca_encryptionoptions.h
@@ -227,6 +227,47 @@ class EncryptionOptions
         const bsl::string&                     resourcePath,
         const ntca::EncryptionResourceOptions& resourceOptions);
 
+    /// Add the specified 'certificate' as an intermediate signer in the chain
+    /// of trust used by the end-entity certificate. Note that the effect of
+    /// calling this function is identical to simply calling 'addResource' with
+    /// resource options that indicate the resource contains an intermediate
+    /// certificate.
+    void addIntermediary(const ntca::EncryptionCertificate& certificate);
+
+    /// Add the specified encoded 'resourceData' as an intermediate signer in
+    /// the chain of trust used by the end-entity certificate. Note that the
+    /// effect of calling this function is identical to simply calling
+    /// 'addResourceData' with resource options that indicate the resource
+    /// contains an intermediate certificate.
+    void addIntermediaryData(const bsl::vector<char>& resourceData);
+
+    /// Add the specified encoded 'resourceData' decoded according to the
+    /// specified 'resourceOptions' as an intermediate signer in the chain of
+    /// trust used by the end-entity certificate. Note that the effect of
+    /// calling this function is identical to simply calling 'addResourceData'
+    /// with resource options that indicate the resource contains an
+    /// intermediate certificate.
+    void addIntermediaryData(
+        const bsl::vector<char>&               resourceData,
+        const ntca::EncryptionResourceOptions& resourceOptions);
+
+    /// Set the path to the encoded intermediate signer in the chain of trust
+    /// used by the end-entity certificate data on disk to the specified
+    /// 'resourcePath'. Note that the effect of calling this function is
+    /// identical to simply calling 'addResourcePath' with resource options
+    /// that indicate the resource contains an intermediate certificate.
+    void addIntermediaryFile(const bsl::string& resourcePath);
+
+    /// Set the path to the encoded intermediate signer in the chain of trust
+    /// used by the end-entity certificate  data on disk to the specified
+    /// 'resourcePath' decoded according to the specified 'resourceOptions'.
+    /// Note that the effect of calling this function is identical to simply
+    /// calling 'addResourcePath' with resource options that indicate the
+    /// resource contains an end-user certificate.
+    void addIntermediaryFile(
+        const bsl::string&                     resourcePath,
+        const ntca::EncryptionResourceOptions& resourceOptions);
+
     /// Set the private key to the specified 'certificate'. Note that the
     /// effect of calling this function is identical to simply calling
     /// 'addResource' with resource options that indicate the resource contains

--- a/groups/ntc/ntca/ntca_encryptionresourceoptions.h
+++ b/groups/ntc/ntca/ntca_encryptionresourceoptions.h
@@ -73,15 +73,21 @@ class EncryptionResourceOptions
         /// The resource should contain a private key.
         e_PRIVATE_KEY = 0,
 
-        /// The resource should contain an end-user certificate.
+        /// The resource should contain an end-entity certificate.
         e_CERTIFICATE = 1,
+
+        /// The resource should contain a certificate authority that 
+        /// participates in the chain of trust necessary to validate an 
+        /// end-user certificate, but which may not be explicitly trusted by 
+        /// the peer.
+        e_CERTIFICATE_INTERMEDIARY = 2,
 
         /// The resource should contain one or more trusted certificate
         /// authorities.
-        e_CERTIFICATE_AUTHORITY = 2,
+        e_CERTIFICATE_AUTHORITY = 3,
 
         /// The contents of the resource are unknown.
-        e_ANY = 3
+        e_ANY = 4
     };
 
     Hint                                                     d_hint;

--- a/groups/ntc/ntca/ntca_encryptionserveroptions.cpp
+++ b/groups/ntc/ntca/ntca_encryptionserveroptions.cpp
@@ -162,6 +162,59 @@ void EncryptionServerOptions::setIdentityFile(
     d_options.setIdentityFile(resourcePath, resourceOptions);
 }
 
+
+
+
+
+
+
+
+
+
+
+void EncryptionServerOptions::addIntermediary(
+    const ntca::EncryptionCertificate& certificate)
+{
+    d_options.addIntermediary(certificate);
+}
+
+
+void EncryptionServerOptions::addIntermediaryData(
+    const bsl::vector<char>& resourceData)
+{
+    d_options.addIntermediaryData(resourceData);
+}
+
+void EncryptionServerOptions::addIntermediaryData(
+    const bsl::vector<char>&               resourceData,
+    const ntca::EncryptionResourceOptions& resourceOptions)
+{
+    d_options.addIntermediaryData(resourceData, resourceOptions);
+}
+
+void EncryptionServerOptions::addIntermediaryFile(
+    const bsl::string& resourcePath)
+{
+    d_options.addIntermediaryFile(resourcePath);
+}
+
+void EncryptionServerOptions::addIntermediaryFile(
+    const bsl::string&                     resourcePath,
+    const ntca::EncryptionResourceOptions& resourceOptions)
+{
+    d_options.addIntermediaryFile(resourcePath, resourceOptions);
+}
+
+
+
+
+
+
+
+
+
+
+
 void EncryptionServerOptions::setPrivateKey(const ntca::EncryptionKey& key)
 {
     d_options.setPrivateKey(key);

--- a/groups/ntc/ntca/ntca_encryptionserveroptions.h
+++ b/groups/ntc/ntca/ntca_encryptionserveroptions.h
@@ -405,6 +405,47 @@ class EncryptionServerOptions
         const bsl::string&                     resourcePath,
         const ntca::EncryptionResourceOptions& resourceOptions);
 
+    /// Add the specified 'certificate' as an intermediate signer in the chain
+    /// of trust used by the end-entity certificate. Note that the effect of
+    /// calling this function is identical to simply calling 'addResource' with
+    /// resource options that indicate the resource contains an intermediate
+    /// certificate.
+    void addIntermediary(const ntca::EncryptionCertificate& certificate);
+
+    /// Add the specified encoded 'resourceData' as an intermediate signer in
+    /// the chain of trust used by the end-entity certificate. Note that the
+    /// effect of calling this function is identical to simply calling
+    /// 'addResourceData' with resource options that indicate the resource
+    /// contains an intermediate certificate.
+    void addIntermediaryData(const bsl::vector<char>& resourceData);
+
+    /// Add the specified encoded 'resourceData' decoded according to the
+    /// specified 'resourceOptions' as an intermediate signer in the chain of
+    /// trust used by the end-entity certificate. Note that the effect of
+    /// calling this function is identical to simply calling 'addResourceData'
+    /// with resource options that indicate the resource contains an
+    /// intermediate certificate.
+    void addIntermediaryData(
+        const bsl::vector<char>&               resourceData,
+        const ntca::EncryptionResourceOptions& resourceOptions);
+
+    /// Set the path to the encoded intermediate signer in the chain of trust
+    /// used by the end-entity certificate data on disk to the specified
+    /// 'resourcePath'. Note that the effect of calling this function is
+    /// identical to simply calling 'addResourcePath' with resource options
+    /// that indicate the resource contains an intermediate certificate.
+    void addIntermediaryFile(const bsl::string& resourcePath);
+
+    /// Set the path to the encoded intermediate signer in the chain of trust
+    /// used by the end-entity certificate  data on disk to the specified
+    /// 'resourcePath' decoded according to the specified 'resourceOptions'.
+    /// Note that the effect of calling this function is identical to simply
+    /// calling 'addResourcePath' with resource options that indicate the
+    /// resource contains an end-user certificate.
+    void addIntermediaryFile(
+        const bsl::string&                     resourcePath,
+        const ntca::EncryptionResourceOptions& resourceOptions);
+
     /// Set the private key to the specified 'certificate'. Note that the
     /// effect of calling this function is identical to simply calling
     /// 'addResource' with resource options that indicate the resource contains

--- a/groups/ntc/ntci/ntci_encryptionresource.cpp
+++ b/groups/ntc/ntci/ntci_encryptionresource.cpp
@@ -33,6 +33,13 @@ EncryptionResource::~EncryptionResource()
 }
 
 ntsa::Error EncryptionResource::setPrivateKey(
+    const ntca::EncryptionKey& key)
+{
+    NTCCFG_WARNING_UNUSED(key);
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error EncryptionResource::setPrivateKey(
     const bsl::shared_ptr<ntci::EncryptionKey>& key)
 {
     NTCCFG_WARNING_UNUSED(key);
@@ -40,7 +47,21 @@ ntsa::Error EncryptionResource::setPrivateKey(
 }
 
 ntsa::Error EncryptionResource::setCertificate(
+    const ntca::EncryptionCertificate& certificate)
+{
+    NTCCFG_WARNING_UNUSED(certificate);
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error EncryptionResource::setCertificate(
     const bsl::shared_ptr<ntci::EncryptionCertificate>& certificate)
+{
+    NTCCFG_WARNING_UNUSED(certificate);
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error EncryptionResource::addCertificateAuthority(
+    const ntca::EncryptionCertificate& certificate)
 {
     NTCCFG_WARNING_UNUSED(certificate);
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);

--- a/groups/ntc/ntci/ntci_encryptionresource.h
+++ b/groups/ntc/ntci/ntci_encryptionresource.h
@@ -19,6 +19,8 @@
 #include <bsls_ident.h>
 BSLS_IDENT("$Id: $")
 
+#include <ntca_encryptioncertificate.h>
+#include <ntca_encryptionkey.h>
 #include <ntca_encryptionresourceoptions.h>
 #include <ntca_encryptionresourcetype.h>
 #include <ntccfg_platform.h>
@@ -49,12 +51,26 @@ class EncryptionResource
 
     /// Set the private key to the specified 'key'. Return the error.
     virtual ntsa::Error setPrivateKey(
+        const ntca::EncryptionKey& key);
+
+    /// Set the private key to the specified 'key'. Return the error.
+    virtual ntsa::Error setPrivateKey(
         const bsl::shared_ptr<ntci::EncryptionKey>& key);
 
     /// Set the user's certificate to the specified 'certificate'. Return the
     /// error.
     virtual ntsa::Error setCertificate(
+        const ntca::EncryptionCertificate& certificate);
+
+    /// Set the user's certificate to the specified 'certificate'. Return the
+    /// error.
+    virtual ntsa::Error setCertificate(
         const bsl::shared_ptr<ntci::EncryptionCertificate>& certificate);
+
+    /// Add the specified 'certificate' to the list of trusted certificates.
+    /// Return the error.
+    virtual ntsa::Error addCertificateAuthority(
+        const ntca::EncryptionCertificate& certificate);
 
     /// Add the specified 'certificate' to the list of trusted certificates.
     /// Return the error.


### PR DESCRIPTION
This PR introduces the API and establishes the conventions necessary to transmit  a chain of intermediary CAs that sign an end-entity certifacate to the validating TLS peer. This functionality is required for those circumstances where the signer of an end-entity certificate is not intended to be trusted directly by the peer, only the signer of the signer.