### PR TITLE
Fix[ntsf_system.cpp]: use MovableRefUtil to build with C++03

### DIFF
--- a/groups/nts/ntsf/ntsf_system.cpp
+++ b/groups/nts/ntsf/ntsf_system.cpp
@@ -39,6 +39,7 @@ BSLS_IDENT_RCSID(ntsf_system_cpp, "$Id$ $CSID$")
 #include <bslma_allocator.h>
 #include <bslma_default.h>
 #include <bslma_newdeleteallocator.h>
+#include <bslmf_movableref.h>
 #include <bslmt_lockguard.h>
 #include <bslmt_mutex.h>
 #include <bslmt_once.h>
@@ -1419,7 +1420,7 @@ ntsa::Error System::loadTcpCongestionControlAlgorithmSupport(
     bsl::string algorithmName;
     while (ssline >> algorithmName) {
         result->push_back(
-            BloombergLP::bslmf::MovableRef<bsl::string>(algorithmName));
+            BloombergLP::bslmf::MovableRefUtil::move(algorithmName));
     }
     return ntsa::Error();
 #else


### PR DESCRIPTION
When tried to build NTF on Linux with C++03, got the following compilation error:
```
FAILED: CMakeFiles/ntsf.dir/groups/nts/ntsf/ntsf_system.cpp.o 
/usr/bin/g++ -DBDE_BUILD_TARGET_CPP03 -DBDE_BUILD_TARGET_EXC -DBDE_BUILD_TARGET_MT -DBDE_BUILD_TARGET_OPT -DNDEBUG -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT -D_THREAD_SAFE -I/home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/build/Linux/opt_64_cpp03 -I/home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/groups/nts/ntsf -I/home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/groups/nts/ntsscm -I/home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/groups/nts/ntscfg -I/home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/groups/nts/ntsa -I/home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/groups/nts/ntsi -I/home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/groups/nts/ntsd -I/home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/groups/nts/ntsu -I/home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/groups/nts/ntsb -I/home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/groups/nts/ntso -isystem //opt/bb/include -std=c++98 -O2 -g0 -m64 -mar
/home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/groups/nts/ntsf/ntsf_system.cpp: In static member function ‘static BloombergLP::ntsa::Error BloombergLP::ntsf::System::loadTcpCongestionControlAlgorithmSupport(bsl::vector<bsl::basic_string<char> >*)’:
/home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/groups/nts/ntsf/ntsf_system.cpp:1393:70: error: no matching function for call to ‘BloombergLP::bslmf::MovableRef<bsl::basic_string<char> >::MovableRef(bsl::string&)’
 1393 |             BloombergLP::bslmf::MovableRef<bsl::string>(algorithmName));
      |                                                                      ^
In file included from /opt/bb/include/bslmf_util.h:144,
                 from /opt/bb/include/bslmf_isswappable.h:83,
                 from /opt/bb/include/bslmf_isnothrowswappable.h:81,
                 from /opt/bb/include/bslstl_pair.h:292,
                 from /opt/bb/include/bslstl_defaultsearcher.h:305,
                 from /opt/bb/include/bsl_functional.h:126,
                 from /home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/groups/nts/ntscfg/ntscfg_platform.h:33,
                 from /home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/groups/nts/ntsa/ntsa_ipv4address.h:22,
                 from /home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/groups/nts/ntsa/ntsa_adapter.h:22,
                 from /home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/groups/nts/ntsf/ntsf_system.h:22,
                 from /home/runner/work/blazingmq/blazingmq/deps/srcs/ntf-core/groups/nts/ntsf/ntsf_system.cpp:16:
/opt/bb/include/bslmf_movableref.h:947:1: note: candidate: ‘BloombergLP::bslmf::MovableRef<t_TYPE>::MovableRef(t_TYPE*) [with t_TYPE = bsl::basic_string<char>]’
  947 | MovableRef<t_TYPE>::MovableRef(t_TYPE *pointer)
      | ^~~~~~~~~~~~~~~~~~
/opt/bb/include/bslmf_movableref.h:947:40: note:   no known conversion for argument 1 from ‘bsl::string’ {aka ‘bsl::basic_string<char>’} to ‘bsl::basic_string<char>*’
  947 | MovableRef<t_TYPE>::MovableRef(t_TYPE *pointer)
      |                                ~~~~~~~~^~~~~~~
/opt/bb/include/bslmf_movableref.h:701:7: note: candidate: ‘BloombergLP::bslmf::MovableRef<bsl::basic_string<char> >::MovableRef(const BloombergLP::bslmf::MovableRef<bsl::basic_string<char> >&)’
  701 | class MovableRef {
      |       ^~~~~~~~~~
/opt/bb/include/bslmf_movableref.h:701:7: note:   no known conversion for argument 1 from ‘bsl::string’ {aka ‘bsl::basic_string<char>’} to ‘const BloombergLP::bslmf::MovableRef<bsl::basic_string<char> >&’`
```

This PR replaces `bslmf::MovableRef` direct construction with `bslmf::MovableRefUtil::move` which is a portable way of working with rvalues