### PR TITLE
Allow socket handles to be "exported" from an established ntci::ListenerSocket, ntci::StreamSocket, and ntci::DatagramSocket

### DIFF
--- a/groups/ntc/ntci/ntci_datagramsocket.cpp
+++ b/groups/ntc/ntci/ntci_datagramsocket.cpp
@@ -64,6 +64,30 @@ ntsa::Error DatagramSocket::timestampIncomingData(bool enable)
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 
+ntsa::Error DatagramSocket::release(ntsa::Handle* result)
+{
+    *result = ntsa::k_INVALID_HANDLE;
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error DatagramSocket::release(ntsa::Handle*              result, 
+                                    const ntci::CloseFunction& callback)
+{
+    NTCCFG_WARNING_UNUSED(callback);
+
+    *result = ntsa::k_INVALID_HANDLE;
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error DatagramSocket::release(ntsa::Handle*              result,
+                                    const ntci::CloseCallback& callback)
+{
+    NTCCFG_WARNING_UNUSED(callback);
+
+    *result = ntsa::k_INVALID_HANDLE;
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
 void DatagramSocketCloseGuard::complete(bslmt::Semaphore* semaphore)
 {
     semaphore->post();

--- a/groups/ntc/ntci/ntci_datagramsocket.h
+++ b/groups/ntc/ntci/ntci_datagramsocket.h
@@ -902,6 +902,37 @@ class DatagramSocket : public ntsi::Descriptor,
     virtual ntsa::Error shutdown(ntsa::ShutdownType::Value direction,
                                  ntsa::ShutdownMode::Value mode) = 0;
 
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', and close this object.
+    /// Return the result. Note that the caller has the responsibility for
+    /// closing '*result'. Also note that this function automatically closes
+    /// this object, but neither shuts down nor closes '*result'. 
+    virtual ntsa::Error release(ntsa::Handle* result);
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also tote that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    virtual ntsa::Error release(ntsa::Handle*              result, 
+                                const ntci::CloseFunction& callback);
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also note that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    virtual ntsa::Error release(ntsa::Handle*              result,
+                                const ntci::CloseCallback& callback);
+
     /// Close the datagram socket.
     virtual void close() = 0;
 

--- a/groups/ntc/ntci/ntci_listenersocket.cpp
+++ b/groups/ntc/ntci/ntci_listenersocket.cpp
@@ -27,6 +27,30 @@ ListenerSocket::~ListenerSocket()
 {
 }
 
+ntsa::Error ListenerSocket::release(ntsa::Handle* result)
+{
+    *result = ntsa::k_INVALID_HANDLE;
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error ListenerSocket::release(ntsa::Handle*              result, 
+                                    const ntci::CloseFunction& callback)
+{
+    NTCCFG_WARNING_UNUSED(callback);
+
+    *result = ntsa::k_INVALID_HANDLE;
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error ListenerSocket::release(ntsa::Handle*              result,
+                                    const ntci::CloseCallback& callback)
+{
+    NTCCFG_WARNING_UNUSED(callback);
+
+    *result = ntsa::k_INVALID_HANDLE;
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
 void ListenerSocketCloseGuard::complete(bslmt::Semaphore* semaphore)
 {
     semaphore->post();

--- a/groups/ntc/ntci/ntci_listenersocket.h
+++ b/groups/ntc/ntci/ntci_listenersocket.h
@@ -331,6 +331,37 @@ class ListenerSocket : public ntsi::Descriptor,
     /// Shutdown the listener socket. Return the error.
     virtual ntsa::Error shutdown() = 0;
 
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', and close this object.
+    /// Return the result. Note that the caller has the responsibility for
+    /// closing '*result'. Also note that this function automatically closes
+    /// this object, but neither shuts down nor closes '*result'. 
+    virtual ntsa::Error release(ntsa::Handle* result);
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also tote that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    virtual ntsa::Error release(ntsa::Handle*              result, 
+                                const ntci::CloseFunction& callback);
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also note that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    virtual ntsa::Error release(ntsa::Handle*              result,
+                                const ntci::CloseCallback& callback);
+
     /// Close the listener socket.
     virtual void close() = 0;
 

--- a/groups/ntc/ntci/ntci_streamsocket.cpp
+++ b/groups/ntc/ntci/ntci_streamsocket.cpp
@@ -64,6 +64,30 @@ ntsa::Error StreamSocket::timestampIncomingData(bool enable)
     return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 
+ntsa::Error StreamSocket::release(ntsa::Handle* result)
+{
+    *result = ntsa::k_INVALID_HANDLE;
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error StreamSocket::release(ntsa::Handle*              result, 
+                                  const ntci::CloseFunction& callback)
+{
+    NTCCFG_WARNING_UNUSED(callback);
+
+    *result = ntsa::k_INVALID_HANDLE;
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error StreamSocket::release(ntsa::Handle*              result,
+                                  const ntci::CloseCallback& callback)
+{
+    NTCCFG_WARNING_UNUSED(callback);
+
+    *result = ntsa::k_INVALID_HANDLE;
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
 void StreamSocketCloseGuard::complete(bslmt::Semaphore* semaphore)
 {
     semaphore->post();

--- a/groups/ntc/ntci/ntci_streamsocket.h
+++ b/groups/ntc/ntci/ntci_streamsocket.h
@@ -1588,6 +1588,37 @@ class StreamSocket : public ntsi::Descriptor,
     virtual ntsa::Error shutdown(ntsa::ShutdownType::Value direction,
                                  ntsa::ShutdownMode::Value mode) = 0;
 
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', and close this object.
+    /// Return the result. Note that the caller has the responsibility for
+    /// closing '*result'. Also note that this function automatically closes
+    /// this object, but neither shuts down nor closes '*result'. 
+    virtual ntsa::Error release(ntsa::Handle* result);
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also tote that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    virtual ntsa::Error release(ntsa::Handle*              result, 
+                                const ntci::CloseFunction& callback);
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also note that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    virtual ntsa::Error release(ntsa::Handle*              result,
+                                const ntci::CloseCallback& callback);
+
     /// Close the stream socket.
     virtual void close() = 0;
 

--- a/groups/ntc/ntcp/ntcp_datagramsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_datagramsocket.cpp
@@ -177,8 +177,8 @@ void DatagramSocket::processSocketReceived(const ntsa::Error&          error,
 
     LockGuard lock(&d_mutex);
 
-    if (NTCCFG_UNLIKELY(d_detachState.get() ==
-                        ntcs::DetachState::e_DETACH_INITIATED))
+    if (NTCCFG_UNLIKELY(d_detachState.mode() ==
+                        ntcs::DetachMode::e_INITIATED))
     {
         return;
     }
@@ -231,8 +231,8 @@ void DatagramSocket::processSocketSent(const ntsa::Error&       error,
 
     LockGuard lock(&d_mutex);
 
-    if (NTCCFG_UNLIKELY(d_detachState.get() ==
-                        ntcs::DetachState::e_DETACH_INITIATED))
+    if (NTCCFG_UNLIKELY(d_detachState.mode() ==
+                        ntcs::DetachMode::e_INITIATED))
     {
         return;
     }
@@ -267,8 +267,8 @@ void DatagramSocket::processSocketError(const ntsa::Error& error)
 
     LockGuard lock(&d_mutex);
 
-    if (NTCCFG_UNLIKELY(d_detachState.get() ==
-                        ntcs::DetachState::e_DETACH_INITIATED))
+    if (NTCCFG_UNLIKELY(d_detachState.mode() ==
+                        ntcs::DetachMode::e_INITIATED))
     {
         return;
     }
@@ -291,8 +291,8 @@ void DatagramSocket::processSocketDetached()
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
 
-    BSLS_ASSERT(d_detachState.get() == ntcs::DetachState::e_DETACH_INITIATED);
-    d_detachState.set(ntcs::DetachState::e_DETACH_IDLE);
+    BSLS_ASSERT(d_detachState.mode() == ntcs::DetachMode::e_INITIATED);
+    d_detachState.setMode(ntcs::DetachMode::e_IDLE);
     BSLS_ASSERT(d_deferredCall);
     if (NTCCFG_LIKELY(d_deferredCall)) {
         NTCCFG_FUNCTION() deferredCall;
@@ -1080,14 +1080,18 @@ void DatagramSocket::privateShutdownSequencePart2(
     // Second handle socket shutdown.
 
     if (context.shutdownSend()) {
-        if (d_socket_sp) {
-            d_socket_sp->shutdown(ntsa::ShutdownType::e_SEND);
+        if (d_detachState.goal() == ntcs::DetachGoal::e_CLOSE) {
+            if (d_socket_sp) {
+                d_socket_sp->shutdown(ntsa::ShutdownType::e_SEND);
+            }
         }
     }
 
     if (context.shutdownReceive()) {
-        if (d_socket_sp) {
-            d_socket_sp->shutdown(ntsa::ShutdownType::e_RECEIVE);
+        if (d_detachState.goal() == ntcs::DetachGoal::e_CLOSE) {
+            if (d_socket_sp) {
+                d_socket_sp->shutdown(ntsa::ShutdownType::e_RECEIVE);
+            }
         }
     }
 
@@ -1303,7 +1307,13 @@ void DatagramSocket::privateShutdownSequencePart2(
             }
         }
 
-        d_socket_sp.reset();
+        if (d_detachState.goal() == ntcs::DetachGoal::e_CLOSE) {
+            d_socket_sp->close();
+        }
+        else {
+            d_socket_sp->release();
+        }
+
         d_systemHandle = ntsa::k_INVALID_HANDLE;
 
         NTCI_LOG_TRACE("Datagram socket closed descriptor %d",
@@ -1554,15 +1564,15 @@ bool DatagramSocket::privateCloseFlowControl(
     if (d_systemHandle != ntsa::k_INVALID_HANDLE) {
         ntcs::ObserverRef<ntci::Proactor> proactorRef(&d_proactor);
         if (proactorRef) {
-            BSLS_ASSERT(d_detachState.get() !=
-                        ntcs::DetachState::e_DETACH_INITIATED);
+            BSLS_ASSERT(d_detachState.mode() !=
+                        ntcs::DetachMode::e_INITIATED);
             proactorRef->cancel(self);
             const ntsa::Error error = proactorRef->detachSocket(self);
             if (NTCCFG_UNLIKELY(error)) {
                 return false;
             }
             else {
-                d_detachState.set(ntcs::DetachState::e_DETACH_INITIATED);
+                d_detachState.setMode(ntcs::DetachMode::e_INITIATED);
                 return true;
             }
         }
@@ -2098,6 +2108,33 @@ void DatagramSocket::processRemoteEndpointResolution(
     }
 }
 
+void DatagramSocket::privateClose(
+    const bsl::shared_ptr<DatagramSocket>& self,
+    const ntci::CloseCallback&             callback)
+{
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+
+    if (d_detachState.mode() == ntcs::DetachMode::e_INITIATED) {
+        d_deferredCalls.push_back(NTCCFG_BIND(
+            static_cast<void (DatagramSocket::*)(
+                const ntci::CloseCallback& callback)>(&DatagramSocket::close),
+            self,
+            callback));
+        return;
+    }
+
+    BSLS_ASSERT(!d_closeCallback);
+    d_closeCallback = callback;
+
+    this->privateShutdown(self,
+                          ntsa::ShutdownType::e_BOTH,
+                          ntsa::ShutdownMode::e_IMMEDIATE,
+                          true);
+}
+
 DatagramSocket::DatagramSocket(
     const ntca::DatagramSocketOptions&         options,
     const bsl::shared_ptr<ntci::Resolver>&     resolver,
@@ -2149,7 +2186,7 @@ DatagramSocket::DatagramSocket(
 , d_receiveBlob_sp()
 , d_maxDatagramSize(NTCCFG_DEFAULT_DATAGRAM_SOCKET_MAX_MESSAGE_SIZE)
 , d_options(options)
-, d_detachState(ntcs::DetachState::e_DETACH_IDLE)
+, d_detachState()
 , d_deferredCall()
 , d_closeCallback(bslma::Default::allocator(basicAllocator))
 , d_deferredCalls(bslma::Default::allocator(basicAllocator))
@@ -3745,6 +3782,41 @@ ntsa::Error DatagramSocket::shutdown(ntsa::ShutdownType::Value direction,
     return ntsa::Error();
 }
 
+ntsa::Error DatagramSocket::release(ntsa::Handle* result)
+{
+    return this->release(result, ntci::CloseCallback());
+}
+
+ntsa::Error DatagramSocket::release(ntsa::Handle*              result, 
+                                    const ntci::CloseFunction& callback)
+{
+    return this->release(
+        result, this->createCloseCallback(callback, d_allocator_p));
+}
+
+ntsa::Error DatagramSocket::release(ntsa::Handle*              result,
+                                    const ntci::CloseCallback& callback)
+{
+    bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
+    
+    LockGuard lock(&d_mutex);
+
+    *result = ntsa::k_INVALID_HANDLE;
+
+    if (d_socket_sp) {
+        *result = d_socket_sp->handle();
+    }
+
+    if (*result == ntsa::k_INVALID_HANDLE) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    d_detachState.setGoal(ntcs::DetachGoal::e_EXPORT);
+    this->privateClose(self, callback);
+
+    return ntsa::Error();
+}
+
 void DatagramSocket::close()
 {
     this->close(ntci::CloseCallback());
@@ -3761,27 +3833,7 @@ void DatagramSocket::close(const ntci::CloseCallback& callback)
 
     LockGuard lock(&d_mutex);
 
-    NTCI_LOG_CONTEXT();
-
-    NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-
-    if (d_detachState.get() == ntcs::DetachState::e_DETACH_INITIATED) {
-        d_deferredCalls.push_back(NTCCFG_BIND(
-            static_cast<void (DatagramSocket::*)(
-                const ntci::CloseCallback& callback)>(&DatagramSocket::close),
-            self,
-            callback));
-        return;
-    }
-
-    BSLS_ASSERT(!d_closeCallback);
-    d_closeCallback = callback;
-
-    this->privateShutdown(self,
-                          ntsa::ShutdownType::e_BOTH,
-                          ntsa::ShutdownMode::e_IMMEDIATE,
-                          true);
+    this->privateClose(self, callback);
 }
 
 void DatagramSocket::execute(const Functor& functor)

--- a/groups/ntc/ntcp/ntcp_datagramsocket.h
+++ b/groups/ntc/ntcp/ntcp_datagramsocket.h
@@ -355,6 +355,11 @@ class DatagramSocket : public ntci::DatagramSocket,
         const ntca::ConnectOptions&            connectOptions,
         const ntci::ConnectCallback&           connectCallback);
 
+    /// Close the socket and invoke the specified 'callback' when the socket
+    /// is closed.
+    void privateClose(const bsl::shared_ptr<DatagramSocket>& self,
+                      const ntci::CloseCallback&             callback);
+
   public:
     /// Create a new, initially uninitialized datagram socket. Optionally
     /// specify a 'basicAllocator' used to supply memory. If
@@ -940,6 +945,39 @@ class DatagramSocket : public ntci::DatagramSocket,
     /// to the specified 'mode' of shutdown. Return the error.
     ntsa::Error shutdown(ntsa::ShutdownType::Value direction,
                          ntsa::ShutdownMode::Value mode) BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', and close this object.
+    /// Return the result. Note that the caller has the responsibility for
+    /// closing '*result'. Also note that this function automatically closes
+    /// this object, but neither shuts down nor closes '*result'. 
+    ntsa::Error release(ntsa::Handle* result) BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also tote that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    ntsa::Error release(ntsa::Handle*              result, 
+                        const ntci::CloseFunction& callback) 
+                        BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also note that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    ntsa::Error release(ntsa::Handle*              result,
+                        const ntci::CloseCallback& callback) 
+                        BSLS_KEYWORD_OVERRIDE;
 
     /// Close the datagram socket.
     void close() BSLS_KEYWORD_OVERRIDE;

--- a/groups/ntc/ntcp/ntcp_listenersocket.h
+++ b/groups/ntc/ntcp/ntcp_listenersocket.h
@@ -287,6 +287,11 @@ class ListenerSocket : public ntci::ListenerSocket,
         const ntca::BindOptions&               bindOptions,
         const ntci::BindCallback&              bindCallback);
 
+    /// Close the socket and invoke the specified 'callback' when the socket
+    /// is closed.
+    void privateClose(const bsl::shared_ptr<ListenerSocket>& self,
+                      const ntci::CloseCallback&             callback);
+
   public:
     /// Create a new, initially uninitilialized listener socket. Optionally
     /// specify a 'basicAllocator' used to supply memory. If
@@ -525,6 +530,39 @@ class ListenerSocket : public ntci::ListenerSocket,
 
     /// Shutdown the listener socket. Return the error.
     ntsa::Error shutdown() BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', and close this object.
+    /// Return the result. Note that the caller has the responsibility for
+    /// closing '*result'. Also note that this function automatically closes
+    /// this object, but neither shuts down nor closes '*result'. 
+    ntsa::Error release(ntsa::Handle* result) BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also tote that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    ntsa::Error release(ntsa::Handle*              result, 
+                        const ntci::CloseFunction& callback) 
+                        BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also note that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    ntsa::Error release(ntsa::Handle*              result,
+                        const ntci::CloseCallback& callback) 
+                        BSLS_KEYWORD_OVERRIDE;
 
     /// Close the listener socket.
     void close() BSLS_KEYWORD_OVERRIDE;

--- a/groups/ntc/ntcp/ntcp_streamsocket.h
+++ b/groups/ntc/ntcp/ntcp_streamsocket.h
@@ -515,6 +515,11 @@ class StreamSocket : public ntci::StreamSocket,
     ntsa::Error privateRetryConnectToEndpoint(
         const bsl::shared_ptr<StreamSocket>& self);
 
+    /// Close the socket and invoke the specified 'callback' when the socket
+    /// is closed.
+    void privateClose(const bsl::shared_ptr<StreamSocket>& self,
+                      const ntci::CloseCallback&           callback);
+
   public:
     /// Create a new, initially uninitilialized stream socket. Optionally
     /// specify a 'basicAllocator' used to supply memory. If
@@ -1180,6 +1185,39 @@ class StreamSocket : public ntci::StreamSocket,
     /// to the specified 'mode' of shutdown. Return the error.
     ntsa::Error shutdown(ntsa::ShutdownType::Value direction,
                          ntsa::ShutdownMode::Value mode) BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', and close this object.
+    /// Return the result. Note that the caller has the responsibility for
+    /// closing '*result'. Also note that this function automatically closes
+    /// this object, but neither shuts down nor closes '*result'. 
+    ntsa::Error release(ntsa::Handle* result) BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also tote that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    ntsa::Error release(ntsa::Handle*              result, 
+                        const ntci::CloseFunction& callback) 
+                        BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also note that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    ntsa::Error release(ntsa::Handle*              result,
+                        const ntci::CloseCallback& callback) 
+                        BSLS_KEYWORD_OVERRIDE;
 
     /// Close the stream socket.
     void close() BSLS_KEYWORD_OVERRIDE;

--- a/groups/ntc/ntcr/ntcr_datagramsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.cpp
@@ -239,8 +239,8 @@ void DatagramSocket::processSocketReadable(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
     NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
 
-    if (NTCCFG_UNLIKELY(d_detachState.get() ==
-                        ntcs::DetachState::e_DETACH_INITIATED))
+    if (NTCCFG_UNLIKELY(d_detachState.mode() ==
+                        ntcs::DetachMode::e_INITIATED))
     {
         return;
     }
@@ -297,8 +297,8 @@ void DatagramSocket::processSocketWritable(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
     NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
 
-    if (NTCCFG_UNLIKELY(d_detachState.get() ==
-                        ntcs::DetachState::e_DETACH_INITIATED))
+    if (NTCCFG_UNLIKELY(d_detachState.mode() ==
+                        ntcs::DetachMode::e_INITIATED))
     {
         return;
     }
@@ -353,8 +353,8 @@ void DatagramSocket::processSocketError(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
     NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
 
-    if (NTCCFG_UNLIKELY(d_detachState.get() ==
-                        ntcs::DetachState::e_DETACH_INITIATED))
+    if (NTCCFG_UNLIKELY(d_detachState.mode() ==
+                        ntcs::DetachMode::e_INITIATED))
     {
         return;
     }
@@ -1328,25 +1328,29 @@ void DatagramSocket::privateShutdownSequenceComplete(
 
     if (lock) {
         d_mutex.lock();
-        BSLS_ASSERT(d_detachState.get() ==
-                    ntcs::DetachState::e_DETACH_INITIATED);
-        d_detachState.set(ntcs::DetachState::e_DETACH_IDLE);
+        BSLS_ASSERT(d_detachState.mode() ==
+                    ntcs::DetachMode::e_INITIATED);
+        d_detachState.setMode(ntcs::DetachMode::e_IDLE);
     }
     else {
-        BSLS_ASSERT(d_detachState.get() == ntcs::DetachState::e_DETACH_IDLE);
+        BSLS_ASSERT(d_detachState.mode() == ntcs::DetachMode::e_IDLE);
     }
 
     // Second, handle socket shutdown.
 
     if (context.shutdownSend()) {
-        if (d_socket_sp) {
-            d_socket_sp->shutdown(ntsa::ShutdownType::e_SEND);
+        if (d_detachState.goal() == ntcs::DetachGoal::e_CLOSE) {
+            if (d_socket_sp) {
+                d_socket_sp->shutdown(ntsa::ShutdownType::e_SEND);
+            }
         }
     }
 
     if (context.shutdownReceive()) {
-        if (d_socket_sp) {
-            d_socket_sp->shutdown(ntsa::ShutdownType::e_RECEIVE);
+        if (d_detachState.goal() == ntcs::DetachGoal::e_CLOSE) {
+            if (d_socket_sp) {
+                d_socket_sp->shutdown(ntsa::ShutdownType::e_RECEIVE);
+            }
         }
     }
 
@@ -1574,7 +1578,13 @@ void DatagramSocket::privateShutdownSequenceComplete(
             }
         }
 
-        d_socket_sp.reset();
+        if (d_detachState.goal() == ntcs::DetachGoal::e_CLOSE) {
+            d_socket_sp->close();
+        }
+        else {
+            d_socket_sp->release();
+        }
+
         d_systemHandle = ntsa::k_INVALID_HANDLE;
 
         NTCI_LOG_TRACE("Datagram socket closed descriptor %d",
@@ -1844,15 +1854,15 @@ bool DatagramSocket::privateCloseFlowControl(
     if (d_systemHandle != ntsa::k_INVALID_HANDLE) {
         ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
         if (reactorRef) {
-            BSLS_ASSERT(d_detachState.get() !=
-                        ntcs::DetachState::e_DETACH_INITIATED);
+            BSLS_ASSERT(d_detachState.mode() !=
+                        ntcs::DetachMode::e_INITIATED);
             const ntsa::Error error =
                 reactorRef->detachSocket(self, detachCallback);
             if (NTCCFG_UNLIKELY(error)) {
                 return false;
             }
             else {
-                d_detachState.set(ntcs::DetachState::e_DETACH_INITIATED);
+                d_detachState.setMode(ntcs::DetachMode::e_INITIATED);
                 return true;
             }
         }
@@ -3023,6 +3033,34 @@ void DatagramSocket::processRemoteEndpointResolution(
     }
 }
 
+void DatagramSocket::privateClose(
+    const bsl::shared_ptr<DatagramSocket>& self,
+    const ntci::CloseCallback&             callback)
+{
+    NTCI_LOG_CONTEXT();
+
+    NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+
+    if (d_detachState.mode() == ntcs::DetachMode::e_INITIATED) {
+        d_deferredCalls.push_back(NTCCFG_BIND(
+            static_cast<void (DatagramSocket::*)(
+                const ntci::CloseCallback& callback)>(&DatagramSocket::close),
+            self,
+            callback));
+
+        return;
+    }
+
+    BSLS_ASSERT(!d_closeCallback);
+    d_closeCallback = callback;
+
+    this->privateShutdown(self,
+                          ntsa::ShutdownType::e_BOTH,
+                          ntsa::ShutdownMode::e_IMMEDIATE,
+                          true);
+}
+
 DatagramSocket::DatagramSocket(
     const ntca::DatagramSocketOptions&        options,
     const bsl::shared_ptr<ntci::Resolver>&    resolver,
@@ -3080,7 +3118,7 @@ DatagramSocket::DatagramSocket(
 , d_timestampCounter(0)
 , d_maxDatagramSize(NTCCFG_DEFAULT_DATAGRAM_SOCKET_MAX_MESSAGE_SIZE)
 , d_oneShot(reactor->oneShot())
-, d_detachState(ntcs::DetachState::e_DETACH_IDLE)
+, d_detachState()
 , d_closeCallback(bslma::Default::allocator(basicAllocator))
 , d_deferredCalls(bslma::Default::allocator(basicAllocator))
 , d_totalBytesSent(0)
@@ -4679,6 +4717,41 @@ ntsa::Error DatagramSocket::shutdown(ntsa::ShutdownType::Value direction,
     return ntsa::Error();
 }
 
+ntsa::Error DatagramSocket::release(ntsa::Handle* result)
+{
+    return this->release(result, ntci::CloseCallback());
+}
+
+ntsa::Error DatagramSocket::release(ntsa::Handle*              result, 
+                                    const ntci::CloseFunction& callback)
+{
+    return this->release(
+        result, this->createCloseCallback(callback, d_allocator_p));
+}
+
+ntsa::Error DatagramSocket::release(ntsa::Handle*              result,
+                                  const ntci::CloseCallback& callback)
+{
+    bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
+    
+    LockGuard lock(&d_mutex);
+
+    *result = ntsa::k_INVALID_HANDLE;
+
+    if (d_socket_sp) {
+        *result = d_socket_sp->handle();
+    }
+
+    if (*result == ntsa::k_INVALID_HANDLE) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    d_detachState.setGoal(ntcs::DetachGoal::e_EXPORT);
+    this->privateClose(self, callback);
+
+    return ntsa::Error();
+}
+
 void DatagramSocket::close()
 {
     this->close(ntci::CloseCallback());
@@ -4695,28 +4768,7 @@ void DatagramSocket::close(const ntci::CloseCallback& callback)
 
     LockGuard lock(&d_mutex);
 
-    NTCI_LOG_CONTEXT();
-
-    NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-
-    if (d_detachState.get() == ntcs::DetachState::e_DETACH_INITIATED) {
-        d_deferredCalls.push_back(NTCCFG_BIND(
-            static_cast<void (DatagramSocket::*)(
-                const ntci::CloseCallback& callback)>(&DatagramSocket::close),
-            self,
-            callback));
-
-        return;
-    }
-
-    BSLS_ASSERT(!d_closeCallback);
-    d_closeCallback = callback;
-
-    this->privateShutdown(self,
-                          ntsa::ShutdownType::e_BOTH,
-                          ntsa::ShutdownMode::e_IMMEDIATE,
-                          true);
+    this->privateClose(self, callback);
 }
 
 void DatagramSocket::execute(const Functor& functor)

--- a/groups/ntc/ntcr/ntcr_datagramsocket.h
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.h
@@ -435,16 +435,21 @@ class DatagramSocket : public ntci::DatagramSocket,
     void privateTimestampUpdate(const bsl::shared_ptr<DatagramSocket>& self,
                                 const ntsa::Timestamp& timestamp);
 
-    // Engage zero-copy transmissions for data whose size is greater than or
-    // equal to the specified 'threshold', in bytes. Return the error.
+    /// Engage zero-copy transmissions for data whose size is greater than or
+    /// equal to the specified 'threshold', in bytes. Return the error.
     ntsa::Error privateZeroCopyEngage(
         const bsl::shared_ptr<DatagramSocket>& self,
         bsl::size_t                            threshold);
 
-    // Process the completion of one or more zero-copy transmissions described
-    // by the specified 'zeroCopy' notification.
+    /// Process the completion of one or more zero-copy transmissions described
+    /// by the specified 'zeroCopy' notification.
     void privateZeroCopyUpdate(const bsl::shared_ptr<DatagramSocket>& self,
                                const ntsa::ZeroCopy& zeroCopy);
+
+    /// Close the socket and invoke the specified 'callback' when the socket
+    /// is closed.
+    void privateClose(const bsl::shared_ptr<DatagramSocket>& self,
+                      const ntci::CloseCallback&             callback);
 
   public:
     /// Create a new, initially uninitilialized datagram socket. Optionally
@@ -1047,6 +1052,39 @@ class DatagramSocket : public ntci::DatagramSocket,
     /// to the specified 'mode' of shutdown. Return the error.
     ntsa::Error shutdown(ntsa::ShutdownType::Value direction,
                          ntsa::ShutdownMode::Value mode) BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', and close this object.
+    /// Return the result. Note that the caller has the responsibility for
+    /// closing '*result'. Also note that this function automatically closes
+    /// this object, but neither shuts down nor closes '*result'. 
+    ntsa::Error release(ntsa::Handle* result) BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also tote that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    ntsa::Error release(ntsa::Handle*              result, 
+                        const ntci::CloseFunction& callback) 
+                        BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also note that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    ntsa::Error release(ntsa::Handle*              result,
+                        const ntci::CloseCallback& callback) 
+                        BSLS_KEYWORD_OVERRIDE;
 
     /// Close the datagram socket.
     void close() BSLS_KEYWORD_OVERRIDE;

--- a/groups/ntc/ntcr/ntcr_listenersocket.h
+++ b/groups/ntc/ntcr/ntcr_listenersocket.h
@@ -285,6 +285,11 @@ class ListenerSocket : public ntci::ListenerSocket,
         const ntca::BindOptions&               bindOptions,
         const ntci::BindCallback&              bindCallback);
 
+    /// Close the socket and invoke the specified 'callback' when the socket
+    /// is closed.
+    void privateClose(const bsl::shared_ptr<ListenerSocket>& self,
+                      const ntci::CloseCallback&             callback);
+
   public:
     /// Create a new, initially uninitilialized listener socket. Optionally
     /// specify a 'basicAllocator' used to supply memory. If
@@ -523,6 +528,39 @@ class ListenerSocket : public ntci::ListenerSocket,
 
     /// Shutdown the listener socket. Return the error.
     ntsa::Error shutdown() BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', and close this object.
+    /// Return the result. Note that the caller has the responsibility for
+    /// closing '*result'. Also note that this function automatically closes
+    /// this object, but neither shuts down nor closes '*result'. 
+    ntsa::Error release(ntsa::Handle* result) BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also tote that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    ntsa::Error release(ntsa::Handle*              result, 
+                        const ntci::CloseFunction& callback) 
+                        BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also note that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    ntsa::Error release(ntsa::Handle*              result,
+                        const ntci::CloseCallback& callback) 
+                        BSLS_KEYWORD_OVERRIDE;
 
     /// Close the listener socket.
     void close() BSLS_KEYWORD_OVERRIDE;

--- a/groups/ntc/ntcr/ntcr_streamsocket.h
+++ b/groups/ntc/ntcr/ntcr_streamsocket.h
@@ -563,16 +563,21 @@ class StreamSocket : public ntci::StreamSocket,
     void privateTimestampUpdate(const bsl::shared_ptr<StreamSocket>& self,
                                 const ntsa::Timestamp& timestamp);
 
-    // Engage zero-copy transmissions for data whose size is greater than or
-    // equal to the specified 'threshold', in bytes. Return the error.
+    /// Engage zero-copy transmissions for data whose size is greater than or
+    /// equal to the specified 'threshold', in bytes. Return the error.
     ntsa::Error privateZeroCopyEngage(
         const bsl::shared_ptr<StreamSocket>& self,
         bsl::size_t                          threshold);
 
-    // Process the completion of one or more zero-copy transmissions described
-    // by the specified 'zeroCopy' notification.
+    /// Process the completion of one or more zero-copy transmissions described
+    /// by the specified 'zeroCopy' notification.
     void privateZeroCopyUpdate(const bsl::shared_ptr<StreamSocket>& self,
                                const ntsa::ZeroCopy&                zeroCopy);
+
+    /// Close the socket and invoke the specified 'callback' when the socket
+    /// is closed.
+    void privateClose(const bsl::shared_ptr<StreamSocket>& self,
+                      const ntci::CloseCallback&           callback);
 
   public:
     /// Create a new, initially uninitilialized stream socket. Optionally
@@ -1253,6 +1258,39 @@ class StreamSocket : public ntci::StreamSocket,
     /// to the specified 'mode' of shutdown. Return the error.
     ntsa::Error shutdown(ntsa::ShutdownType::Value direction,
                          ntsa::ShutdownMode::Value mode) BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', and close this object.
+    /// Return the result. Note that the caller has the responsibility for
+    /// closing '*result'. Also note that this function automatically closes
+    /// this object, but neither shuts down nor closes '*result'. 
+    ntsa::Error release(ntsa::Handle* result) BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also tote that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    ntsa::Error release(ntsa::Handle*              result, 
+                        const ntci::CloseFunction& callback) 
+                        BSLS_KEYWORD_OVERRIDE;
+
+    /// Release the underlying socket from ownership by this object, load the
+    /// socket handle into the specified 'result', close this object, and
+    /// invoke the specified 'callback' on the callback's strand, if any, when
+    /// this object is closed. Return the result. Note that the caller has the
+    /// responsibility for closing '*result'. Also note that this function
+    /// automatically closes this object, but neither shuts down nor closes
+    /// '*result'. Also note that callbacks created by this object will
+    /// automatically be invoked on this object's strand unless an explicit
+    /// strand is specified at the time the callback is created.
+    ntsa::Error release(ntsa::Handle*              result,
+                        const ntci::CloseCallback& callback) 
+                        BSLS_KEYWORD_OVERRIDE;
 
     /// Close the stream socket.
     void close() BSLS_KEYWORD_OVERRIDE;

--- a/groups/ntc/ntcs/ntcs_detachstate.h
+++ b/groups/ntc/ntcs/ntcs_detachstate.h
@@ -26,50 +26,120 @@ namespace BloombergLP {
 namespace ntcs {
 
 /// @internal @brief
+/// Provide a enumeration that indicates the detachment status of a socket from
+/// its reactor or proactor.
+///
+/// @par Thread Safety
+/// This class is not thread safe.
+///
+/// @ingroup module_ntcs
+class DetachMode
+{
+public:
+    /// Provide a enumeration that indicates the detachment status of a socket
+    /// from its reactor or proactor.
+    enum Value {
+        /// The socket is attached.
+        e_IDLE, 
+
+        /// The socket detachment has been initiated.
+        e_INITIATED
+    };
+};
+
+/// @internal @brief
+/// Provide a enumeration that indicates why a socket is being detached from
+/// its reactor or proactor.
+///
+/// @par Thread Safety
+/// This class is not thread safe.
+///
+/// @ingroup module_ntcs
+class DetachGoal
+{
+public:
+    /// Provide a enumeration that indicates why a socket is being detached
+    /// from its reactor or proactor.
+    enum Value {
+        /// The socket is being detached to be shutdown and closed.
+        e_CLOSE = 0,
+
+        /// The socket is being detached to be exported.
+        e_EXPORT = 1
+    };
+};
+
+/// @internal @brief
 /// Provide a enumeration that indicates state of a socket detachment process.
 ///
 /// @par Thread Safety
 /// This class is not thread safe.
 ///
 /// @ingroup module_ntcs
-
 class DetachState
 {
-  public:
-    enum Value { e_DETACH_IDLE, e_DETACH_INITIATED };
-
-    /// Create a new detachment state initially in idle state.
-    DetachState();
-
-    /// Create a new detachment state initially in the specified 'state'.
-    explicit DetachState(Value state);
-
-    /// Returns current value of socket detachment state
-    Value get() const
-    {
-        return d_state;
-    }
-
-    /// Sets socket detachment state to the specified 'state'
-    void set(Value state)
-    {
-        d_state = state;
-    }
+    ntcs::DetachMode::Value d_mode;
+    ntcs::DetachGoal::Value d_goal;
 
   private:
-    Value d_state;
+    DetachState(const DetachState&) BSLS_KEYWORD_DELETED;
+    DetachState& operator=(const DetachState&) BSLS_KEYWORD_DELETED;
+
+  public:
+    /// Create a new detachment state initially in idle state with the goal
+    /// to close the socket.
+    DetachState();
+
+    /// Destroy this object.
+    ~DetachState();
+
+    /// Set the mode to the specified 'mode'.
+    void setMode(ntcs::DetachMode::Value mode);
+
+    /// Set the goal to the specified 'goal'.
+    void setGoal(ntcs::DetachGoal::Value goal);
+
+    /// Return the mode.
+    ntcs::DetachMode::Value mode() const;
+
+    /// Return the goal.
+    ntcs::DetachGoal::Value goal() const;
 };
 
 NTCCFG_INLINE
 DetachState::DetachState()
-: d_state(e_DETACH_IDLE)
+: d_mode(ntcs::DetachMode::e_IDLE)
+, d_goal(ntcs::DetachGoal::e_CLOSE)
 {
 }
 
 NTCCFG_INLINE
-DetachState::DetachState(DetachState::Value state)
-: d_state(state)
+DetachState::~DetachState()
 {
+}
+
+NTCCFG_INLINE
+void DetachState::setMode(ntcs::DetachMode::Value mode)
+{
+    d_mode = mode;
+}
+
+NTCCFG_INLINE
+void DetachState::setGoal(ntcs::DetachGoal::Value goal)
+{
+    d_goal = goal;
+}
+
+NTCCFG_INLINE
+ntcs::DetachMode::Value DetachState::mode() const
+{
+    return d_mode;
+}
+
+NTCCFG_INLINE
+ntcs::DetachGoal::Value DetachState::goal() const
+{
+    return d_goal;
 }
 
 }  // end namespace ntcs

--- a/groups/ntc/ntcs/ntcs_detachstate.t.cpp
+++ b/groups/ntc/ntcs/ntcs_detachstate.t.cpp
@@ -30,25 +30,20 @@ class DetachStateTest
 {
   public:
     // TODO
-    static void verifyCase1();
-
-    // TODO
-    static void verifyCase2();
+    static void verify();
 };
 
-NTSCFG_TEST_FUNCTION(ntcs::DetachStateTest::verifyCase1)
+NTSCFG_TEST_FUNCTION(ntcs::DetachStateTest::verify)
 {
     ntcs::DetachState state;
-    NTSCFG_TEST_EQ(state.get(), ntcs::DetachState::e_DETACH_IDLE);
+    NTSCFG_TEST_EQ(state.mode(), ntcs::DetachMode::e_IDLE);
+    NTSCFG_TEST_EQ(state.goal(), ntcs::DetachGoal::e_CLOSE);
 
-    state.set(ntcs::DetachState::e_DETACH_INITIATED);
-    NTSCFG_TEST_EQ(state.get(), ntcs::DetachState::e_DETACH_INITIATED);
-}
+    state.setMode(ntcs::DetachMode::e_INITIATED);
+    NTSCFG_TEST_EQ(state.mode(), ntcs::DetachMode::e_INITIATED);
 
-NTSCFG_TEST_FUNCTION(ntcs::DetachStateTest::verifyCase2)
-{
-    ntcs::DetachState state(ntcs::DetachState::e_DETACH_INITIATED);
-    NTSCFG_TEST_EQ(state.get(), ntcs::DetachState::e_DETACH_INITIATED);
+    state.setGoal(ntcs::DetachGoal::e_EXPORT);
+    NTSCFG_TEST_EQ(state.goal(), ntcs::DetachGoal::e_EXPORT);
 }
 
 }  // close namespace ntcs


### PR DESCRIPTION
Some applications desire to transfer a file descriptor for an established socket from one process to another by sending it through a Unix domain socket. For convenience, these applications want to use the asynchronous facilities provided by `ntci::StreamSocket` and `ntci::DatagramSocket` to connect/accept the sockets and perhaps do a bit of asynchronous sending and receiving. After which, responsibility for using the (still connected) socket should be transferred to another process.

To support this usage, this PR adds the new functions `ntci::DatagramSocket::release()` and `ntci::StreamSocket::release()`. Functionaly, these functions pluck out the internal socket handle implementing the asynchronous socket object then asynchronously close the object, taking care to preserve the connection by not shutting down the socket nor closing the file descriptor (which normally happens during asynchronous socket closure.) The user then  takes ownership of the file descriptor (including the responsibility to close it) to do whatever they wish with it.
