### PR TITLE
Avoid overflowing max connect attempts

### DIFF
--- a/groups/ntc/ntcp/ntcp_streamsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.cpp
@@ -4032,8 +4032,10 @@ ntsa::Error StreamSocket::connect(const ntsa::Endpoint&        endpoint,
         d_connectOptions.setRetryCount(1);
     }
     else {
-        d_connectOptions.setRetryCount(d_connectOptions.retryCount().value() +
-                                       1);
+        const bsl::size_t retryCount = d_connectOptions.retryCount().value();
+        if (retryCount != bsl::numeric_limits<bsl::size_t>::max()) {
+            d_connectOptions.setRetryCount(retryCount + 1);
+        }
     }
 
     if (d_connectOptions.retryCount().value() > 1) {

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -5263,8 +5263,10 @@ ntsa::Error StreamSocket::connect(const ntsa::Endpoint&        endpoint,
         d_connectOptions.setRetryCount(1);
     }
     else {
-        d_connectOptions.setRetryCount(d_connectOptions.retryCount().value() +
-                                       1);
+        const bsl::size_t retryCount = d_connectOptions.retryCount().value();
+        if (retryCount != bsl::numeric_limits<bsl::size_t>::max()) {
+            d_connectOptions.setRetryCount(retryCount + 1);
+        }
     }
 
     if (d_connectOptions.retryCount().value() > 1) {


### PR DESCRIPTION
This PR avoid overflowing the maximum number of connection attempts when the user requests `std::numeric_limits<size_t>::max()` number of retries.