### PR TITLE
Clamp the maximum timespec supplied to kevent to avoid exceeding the maximum supported wait time

### DIFF
--- a/groups/ntc/ntco/ntco_kqueue.cpp
+++ b/groups/ntc/ntco/ntco_kqueue.cpp
@@ -207,6 +207,9 @@ class Kqueue : public ntci::Reactor,
     typedef ntci::LockGuard LockGuard;
     // This typedef defines a mutex lock guard.
 
+    // The maximum number of seconds to wait.
+    static const bsls::Types::Int64 k_MAX_SECONDS = 2147483647LL;
+
     ntccfg::Object                           d_object;
     int                                      d_kqueue;
     ntcs::RegistryEntryCatalog::EntryFunctor d_detachFunctor;
@@ -1981,7 +1984,16 @@ void Kqueue::run(ntci::Waiter waiter)
         struct ::timespec  ts;
 
         if (!timeoutInterval.isNull()) {
+            const bsls::TimeInterval timeoutIntervalMax(k_MAX_SECONDS, 0);
+
+            if (timeoutInterval.value() > timeoutIntervalMax) {
+                timeoutInterval.value() = timeoutIntervalMax;
+            }
+
             NTCO_KQUEUE_LOG_WAIT_TIMED_HIGH_PRECISION(timeoutInterval.value());
+
+            BSLMF_ASSERT(sizeof ts.tv_sec == 8);
+            BSLMF_ASSERT(sizeof ts.tv_nsec == 8);
 
             ts.tv_sec  = timeoutInterval.value().seconds();
             ts.tv_nsec = timeoutInterval.value().nanoseconds();
@@ -2184,7 +2196,16 @@ void Kqueue::poll(ntci::Waiter waiter)
     struct ::timespec  ts;
 
     if (!timeoutInterval.isNull()) {
+        const bsls::TimeInterval timeoutIntervalMax(k_MAX_SECONDS, 0);
+
+        if (timeoutInterval.value() > timeoutIntervalMax) {
+            timeoutInterval.value() = timeoutIntervalMax;
+        }
+
         NTCO_KQUEUE_LOG_WAIT_TIMED_HIGH_PRECISION(timeoutInterval.value());
+
+        BSLMF_ASSERT(sizeof ts.tv_sec == 8);
+        BSLMF_ASSERT(sizeof ts.tv_nsec == 8);
 
         ts.tv_sec  = timeoutInterval.value().seconds();
         ts.tv_nsec = timeoutInterval.value().nanoseconds();


### PR DESCRIPTION
Calling `kevent` on Darwin with a timeout greater than some undocumented amount results in the system call return EINVAL. This causes problems if users register timers very very far in the future. This PR clamps the maximum relative wait time given to `kevent` to something reasonable. Note that waking up prematurely is innocuous, for any reason, because no timers will fire unless they are due regardless of the wakeup time. But not that it matters for this issue; these timers scheduled very very far into the future are never practically expected to fire anyways.