### PR TITLE
Use level triggering for accept and receive queues for static load balancing, edge triggering for dynamic load balancing

### DIFF
--- a/groups/ntc/ntcp/ntcp_datagramsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_datagramsocket.cpp
@@ -2210,6 +2210,10 @@ DatagramSocket::DatagramSocket(
         d_sendGreedily = d_options.sendGreedily().value();
     }
 
+    if (proactor->maxThreads() > 1) {
+        d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+    }
+
     if (!d_options.readQueueLowWatermark().isNull()) {
         d_receiveQueue.setLowWatermark(
             d_options.readQueueLowWatermark().value());
@@ -3178,6 +3182,13 @@ ntsa::Error DatagramSocket::registerSession(
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_proactorStrand_sp;
         }
+
+        if (d_sessionStrand_sp) {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
+        }
     }
     else {
         d_session_sp.reset();
@@ -3207,6 +3218,13 @@ ntsa::Error DatagramSocket::registerSessionCallback(
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_proactorStrand_sp;
         }
+
+        if (d_sessionStrand_sp) {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
+        }
     }
     else {
         d_session_sp.reset();
@@ -3233,6 +3251,13 @@ ntsa::Error DatagramSocket::registerSessionCallback(
 
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_proactorStrand_sp;
+        }
+
+        if (d_sessionStrand_sp) {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
         }
     }
     else {

--- a/groups/ntc/ntcp/ntcp_listenersocket.cpp
+++ b/groups/ntc/ntcp/ntcp_listenersocket.cpp
@@ -1619,6 +1619,10 @@ ListenerSocket::ListenerSocket(
 , d_deferredCalls(bslma::Default::allocator(basicAllocator))
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
+    if (proactor->maxThreads() > 1) {
+        d_acceptQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+    }
+
     if (!d_options.acceptQueueLowWatermark().isNull()) {
         d_acceptQueue.setLowWatermark(
             d_options.acceptQueueLowWatermark().value());
@@ -2137,6 +2141,13 @@ ntsa::Error ListenerSocket::registerSession(
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_proactorStrand_sp;
         }
+
+        if (d_sessionStrand_sp) {
+            d_acceptQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_acceptQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
+        }
     }
     else {
         d_session_sp.reset();
@@ -2166,6 +2177,13 @@ ntsa::Error ListenerSocket::registerSessionCallback(
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_proactorStrand_sp;
         }
+
+        if (d_sessionStrand_sp) {
+            d_acceptQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_acceptQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
+        }
     }
     else {
         d_session_sp.reset();
@@ -2192,6 +2210,13 @@ ntsa::Error ListenerSocket::registerSessionCallback(
 
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_proactorStrand_sp;
+        }
+
+        if (d_sessionStrand_sp) {
+            d_acceptQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_acceptQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
         }
     }
     else {

--- a/groups/ntc/ntcp/ntcp_streamsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.cpp
@@ -3729,6 +3729,10 @@ StreamSocket::StreamSocket(
         d_sendGreedily = d_options.sendGreedily().value();
     }
 
+    if (proactor->maxThreads() > 1) {
+        d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+    }
+
     if (!d_options.readQueueLowWatermark().isNull()) {
         d_receiveQueue.setLowWatermark(
             d_options.readQueueLowWatermark().value());
@@ -4969,6 +4973,13 @@ ntsa::Error StreamSocket::registerSession(
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_proactorStrand_sp;
         }
+
+        if (d_sessionStrand_sp) {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
+        }
     }
     else {
         d_session_sp.reset();
@@ -4998,6 +5009,13 @@ ntsa::Error StreamSocket::registerSessionCallback(
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_proactorStrand_sp;
         }
+
+        if (d_sessionStrand_sp) {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
+        }
     }
     else {
         d_session_sp.reset();
@@ -5024,6 +5042,13 @@ ntsa::Error StreamSocket::registerSessionCallback(
 
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_proactorStrand_sp;
+        }
+
+        if (d_sessionStrand_sp) {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
         }
     }
     else {

--- a/groups/ntc/ntcq/ntcq_accept.cpp
+++ b/groups/ntc/ntcq/ntcq_accept.cpp
@@ -130,6 +130,7 @@ AcceptQueue::AcceptQueue(bslma::Allocator* basicAllocator)
 , d_watermarkLowWanted(true)
 , d_watermarkHigh(NTCCFG_DEFAULT_LISTENER_SOCKET_ACCEPT_QUEUE_HIGH_WATERMARK)
 , d_watermarkHighWanted(true)
+, d_trigger(ntca::ReactorEventTrigger::e_LEVEL)
 , d_callbackQueue(basicAllocator)
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {

--- a/groups/ntc/ntcq/ntcq_accept.t.cpp
+++ b/groups/ntc/ntcq/ntcq_accept.t.cpp
@@ -29,12 +29,270 @@ namespace ntcq {
 class AcceptQueueTest
 {
   public:
-    // TODO
-    static void verify();
+    // Verify the queue with level-triggered semantics.
+    static void verifyTriggerByLevel();
+
+    // Verify the queue with edge-triggered semantics.
+    static void verifyTriggerAtEdge();
 };
 
-NTSCFG_TEST_FUNCTION(ntcq::AcceptQueueTest::verify)
+NTSCFG_TEST_FUNCTION(ntcq::AcceptQueueTest::verifyTriggerByLevel)
 {
+    const bsl::size_t k_LOW_WATERMARK = 1;
+    const bsl::size_t k_HIGH_WATERMARK = 3;
+
+    ntcq::AcceptQueue acceptQueue(NTSCFG_TEST_ALLOCATOR);
+
+    NTSCFG_TEST_EQ(acceptQueue.lowWatermark(), 
+                   NTCCFG_DEFAULT_LISTENER_SOCKET_ACCEPT_QUEUE_LOW_WATERMARK);
+
+    NTSCFG_TEST_EQ(acceptQueue.highWatermark(), 
+                   NTCCFG_DEFAULT_LISTENER_SOCKET_ACCEPT_QUEUE_HIGH_WATERMARK);
+
+    NTSCFG_TEST_EQ(acceptQueue.size(), 0);
+    NTSCFG_TEST_FALSE(acceptQueue.isLowWatermarkSatisfied());
+    NTSCFG_TEST_FALSE(acceptQueue.isHighWatermarkViolated());
+
+    acceptQueue.setLowWatermark(k_LOW_WATERMARK);
+    acceptQueue.setHighWatermark(k_HIGH_WATERMARK);
+
+    NTSCFG_TEST_EQ(acceptQueue.lowWatermark(), k_LOW_WATERMARK);
+    NTSCFG_TEST_EQ(acceptQueue.highWatermark(), k_HIGH_WATERMARK);
+
+    for (bsl::size_t iteration = 0; iteration < 3; ++iteration) {
+        NTSCFG_TEST_EQ(acceptQueue.size(), 0);
+        NTSCFG_TEST_FALSE(acceptQueue.isLowWatermarkSatisfied());
+        NTSCFG_TEST_FALSE(acceptQueue.isHighWatermarkViolated());
+
+        {
+            ntcq::AcceptQueueEntry entry;
+            entry.setTimestamp(1);
+
+            bool becameNonEmpty = acceptQueue.pushEntry(entry);
+            NTSCFG_TEST_TRUE(becameNonEmpty);
+        }
+
+        NTSCFG_TEST_EQ(acceptQueue.size(), 1);
+        NTSCFG_TEST_TRUE(acceptQueue.isLowWatermarkSatisfied());
+        NTSCFG_TEST_FALSE(acceptQueue.isHighWatermarkViolated());
+
+        NTSCFG_TEST_TRUE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+
+        NTSCFG_TEST_TRUE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+
+        {
+            ntcq::AcceptQueueEntry entry;
+            entry.setTimestamp(2);
+
+            bool becameNonEmpty = acceptQueue.pushEntry(entry);
+            NTSCFG_TEST_FALSE(becameNonEmpty);
+        }
+
+        NTSCFG_TEST_EQ(acceptQueue.size(), 2);
+        NTSCFG_TEST_TRUE(acceptQueue.isLowWatermarkSatisfied());
+        NTSCFG_TEST_FALSE(acceptQueue.isHighWatermarkViolated());
+
+        NTSCFG_TEST_TRUE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+        
+        NTSCFG_TEST_TRUE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+
+        {
+            ntcq::AcceptQueueEntry entry;
+            entry.setTimestamp(3);
+
+            bool becameNonEmpty = acceptQueue.pushEntry(entry);
+            NTSCFG_TEST_FALSE(becameNonEmpty);
+        }
+
+        NTSCFG_TEST_EQ(acceptQueue.size(), 3);
+        NTSCFG_TEST_TRUE(acceptQueue.isLowWatermarkSatisfied());
+        NTSCFG_TEST_TRUE(acceptQueue.isHighWatermarkViolated());
+
+        NTSCFG_TEST_TRUE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_TRUE(acceptQueue.authorizeHighWatermarkEvent());
+        
+        NTSCFG_TEST_TRUE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_TRUE(acceptQueue.authorizeHighWatermarkEvent());
+
+        {
+            bool becameEmpty = acceptQueue.popEntry();
+            NTSCFG_TEST_FALSE(becameEmpty);
+        }
+
+        NTSCFG_TEST_EQ(acceptQueue.size(), 2);
+        NTSCFG_TEST_TRUE(acceptQueue.isLowWatermarkSatisfied());
+        NTSCFG_TEST_FALSE(acceptQueue.isHighWatermarkViolated());
+
+        NTSCFG_TEST_TRUE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+        
+        NTSCFG_TEST_TRUE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+
+        {
+            bool becameEmpty = acceptQueue.popEntry();
+            NTSCFG_TEST_FALSE(becameEmpty);
+        }
+
+        NTSCFG_TEST_EQ(acceptQueue.size(), 1);
+        NTSCFG_TEST_TRUE(acceptQueue.isLowWatermarkSatisfied());
+        NTSCFG_TEST_FALSE(acceptQueue.isHighWatermarkViolated());
+
+        NTSCFG_TEST_TRUE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+        
+        NTSCFG_TEST_TRUE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+
+        {
+            bool becameEmpty = acceptQueue.popEntry();
+            NTSCFG_TEST_TRUE(becameEmpty);
+        }
+
+        NTSCFG_TEST_EQ(acceptQueue.size(), 0);
+        NTSCFG_TEST_FALSE(acceptQueue.isLowWatermarkSatisfied());
+        NTSCFG_TEST_FALSE(acceptQueue.isHighWatermarkViolated());
+
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+        
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+    }
+}
+
+NTSCFG_TEST_FUNCTION(ntcq::AcceptQueueTest::verifyTriggerAtEdge)
+{
+    const bsl::size_t k_LOW_WATERMARK = 1;
+    const bsl::size_t k_HIGH_WATERMARK = 3;
+
+    ntcq::AcceptQueue acceptQueue(NTSCFG_TEST_ALLOCATOR);
+
+    NTSCFG_TEST_EQ(acceptQueue.lowWatermark(), 
+                   NTCCFG_DEFAULT_LISTENER_SOCKET_ACCEPT_QUEUE_LOW_WATERMARK);
+
+    NTSCFG_TEST_EQ(acceptQueue.highWatermark(), 
+                   NTCCFG_DEFAULT_LISTENER_SOCKET_ACCEPT_QUEUE_HIGH_WATERMARK);
+
+    NTSCFG_TEST_EQ(acceptQueue.size(), 0);
+    NTSCFG_TEST_FALSE(acceptQueue.isLowWatermarkSatisfied());
+    NTSCFG_TEST_FALSE(acceptQueue.isHighWatermarkViolated());
+
+    acceptQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+    acceptQueue.setLowWatermark(k_LOW_WATERMARK);
+    acceptQueue.setHighWatermark(k_HIGH_WATERMARK);
+
+    NTSCFG_TEST_EQ(acceptQueue.lowWatermark(), k_LOW_WATERMARK);
+    NTSCFG_TEST_EQ(acceptQueue.highWatermark(), k_HIGH_WATERMARK);
+
+    for (bsl::size_t iteration = 0; iteration < 3; ++iteration) {
+        NTSCFG_TEST_EQ(acceptQueue.size(), 0);
+        NTSCFG_TEST_FALSE(acceptQueue.isLowWatermarkSatisfied());
+        NTSCFG_TEST_FALSE(acceptQueue.isHighWatermarkViolated());
+
+        {
+            ntcq::AcceptQueueEntry entry;
+            entry.setTimestamp(1);
+
+            bool becameNonEmpty = acceptQueue.pushEntry(entry);
+            NTSCFG_TEST_TRUE(becameNonEmpty);
+        }
+
+        NTSCFG_TEST_EQ(acceptQueue.size(), 1);
+        NTSCFG_TEST_TRUE(acceptQueue.isLowWatermarkSatisfied());
+        NTSCFG_TEST_FALSE(acceptQueue.isHighWatermarkViolated());
+
+        NTSCFG_TEST_TRUE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+
+        {
+            ntcq::AcceptQueueEntry entry;
+            entry.setTimestamp(2);
+
+            bool becameNonEmpty = acceptQueue.pushEntry(entry);
+            NTSCFG_TEST_FALSE(becameNonEmpty);
+        }
+
+        NTSCFG_TEST_EQ(acceptQueue.size(), 2);
+        NTSCFG_TEST_TRUE(acceptQueue.isLowWatermarkSatisfied());
+        NTSCFG_TEST_FALSE(acceptQueue.isHighWatermarkViolated());
+
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+        
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+
+        {
+            ntcq::AcceptQueueEntry entry;
+            entry.setTimestamp(3);
+
+            bool becameNonEmpty = acceptQueue.pushEntry(entry);
+            NTSCFG_TEST_FALSE(becameNonEmpty);
+        }
+
+        NTSCFG_TEST_EQ(acceptQueue.size(), 3);
+        NTSCFG_TEST_TRUE(acceptQueue.isLowWatermarkSatisfied());
+        NTSCFG_TEST_TRUE(acceptQueue.isHighWatermarkViolated());
+
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_TRUE(acceptQueue.authorizeHighWatermarkEvent());
+        
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+
+        {
+            bool becameEmpty = acceptQueue.popEntry();
+            NTSCFG_TEST_FALSE(becameEmpty);
+        }
+
+        NTSCFG_TEST_EQ(acceptQueue.size(), 2);
+        NTSCFG_TEST_TRUE(acceptQueue.isLowWatermarkSatisfied());
+        NTSCFG_TEST_FALSE(acceptQueue.isHighWatermarkViolated());
+
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+        
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+
+        {
+            bool becameEmpty = acceptQueue.popEntry();
+            NTSCFG_TEST_FALSE(becameEmpty);
+        }
+
+        NTSCFG_TEST_EQ(acceptQueue.size(), 1);
+        NTSCFG_TEST_TRUE(acceptQueue.isLowWatermarkSatisfied());
+        NTSCFG_TEST_FALSE(acceptQueue.isHighWatermarkViolated());
+
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+        
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+
+        {
+            bool becameEmpty = acceptQueue.popEntry();
+            NTSCFG_TEST_TRUE(becameEmpty);
+        }
+
+        NTSCFG_TEST_EQ(acceptQueue.size(), 0);
+        NTSCFG_TEST_FALSE(acceptQueue.isLowWatermarkSatisfied());
+        NTSCFG_TEST_FALSE(acceptQueue.isHighWatermarkViolated());
+
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+        
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeLowWatermarkEvent());
+        NTSCFG_TEST_FALSE(acceptQueue.authorizeHighWatermarkEvent());
+    }
 }
 
 }  // close namespace ntcq

--- a/groups/ntc/ntcq/ntcq_receive.cpp
+++ b/groups/ntc/ntcq/ntcq_receive.cpp
@@ -130,6 +130,7 @@ ReceiveQueue::ReceiveQueue(bslma::Allocator* basicAllocator)
 , d_watermarkLowWanted(true)
 , d_watermarkHigh(NTCCFG_DEFAULT_STREAM_SOCKET_READ_QUEUE_HIGH_WATERMARK)
 , d_watermarkHighWanted(true)
+, d_trigger(ntca::ReactorEventTrigger::e_LEVEL)
 , d_callbackQueue(basicAllocator)
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {

--- a/groups/ntc/ntcr/ntcr_datagramsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.cpp
@@ -3209,6 +3209,10 @@ DatagramSocket::DatagramSocket(
         d_sendGreedily = d_options.sendGreedily().value();
     }
 
+    if (reactor->maxThreads() > 1) {
+        d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+    }
+
     if (!d_options.readQueueLowWatermark().isNull()) {
         d_receiveQueue.setLowWatermark(
             d_options.readQueueLowWatermark().value());
@@ -4149,6 +4153,13 @@ ntsa::Error DatagramSocket::registerSession(
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_reactorStrand_sp;
         }
+
+        if (d_sessionStrand_sp) {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
+        }
     }
     else {
         d_session_sp.reset();
@@ -4178,6 +4189,13 @@ ntsa::Error DatagramSocket::registerSessionCallback(
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_reactorStrand_sp;
         }
+
+        if (d_sessionStrand_sp) {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
+        }
     }
     else {
         d_session_sp.reset();
@@ -4204,6 +4222,13 @@ ntsa::Error DatagramSocket::registerSessionCallback(
 
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_reactorStrand_sp;
+        }
+
+        if (d_sessionStrand_sp) {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
         }
     }
     else {

--- a/groups/ntc/ntcr/ntcr_listenersocket.cpp
+++ b/groups/ntc/ntcr/ntcr_listenersocket.cpp
@@ -1675,6 +1675,10 @@ ListenerSocket::ListenerSocket(
         }
     }
 
+    if (reactor->maxThreads() > 1) {
+        d_acceptQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+    }
+
     if (!d_options.acceptQueueLowWatermark().isNull()) {
         d_acceptQueue.setLowWatermark(
             d_options.acceptQueueLowWatermark().value());
@@ -2260,6 +2264,13 @@ ntsa::Error ListenerSocket::registerSession(
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_reactorStrand_sp;
         }
+
+        if (d_sessionStrand_sp) {
+            d_acceptQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_acceptQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
+        }
     }
     else {
         d_session_sp.reset();
@@ -2289,6 +2300,13 @@ ntsa::Error ListenerSocket::registerSessionCallback(
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_reactorStrand_sp;
         }
+
+        if (d_sessionStrand_sp) {
+            d_acceptQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_acceptQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
+        }
     }
     else {
         d_session_sp.reset();
@@ -2315,6 +2333,13 @@ ntsa::Error ListenerSocket::registerSessionCallback(
 
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_reactorStrand_sp;
+        }
+
+        if (d_sessionStrand_sp) {
+            d_acceptQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_acceptQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
         }
     }
     else {

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -4960,6 +4960,10 @@ StreamSocket::StreamSocket(
         d_sendGreedily = d_options.sendGreedily().value();
     }
 
+    if (reactor->maxThreads() > 1) {
+        d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+    }
+
     if (!d_options.readQueueLowWatermark().isNull()) {
         d_receiveQueue.setLowWatermark(
             d_options.readQueueLowWatermark().value());
@@ -6238,6 +6242,13 @@ ntsa::Error StreamSocket::registerSession(
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_reactorStrand_sp;
         }
+
+        if (d_sessionStrand_sp) {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
+        }
     }
     else {
         d_session_sp.reset();
@@ -6267,6 +6278,13 @@ ntsa::Error StreamSocket::registerSessionCallback(
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_reactorStrand_sp;
         }
+
+        if (d_sessionStrand_sp) {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
+        }
     }
     else {
         d_session_sp.reset();
@@ -6293,6 +6311,13 @@ ntsa::Error StreamSocket::registerSessionCallback(
 
         if (!d_sessionStrand_sp) {
             d_sessionStrand_sp = d_reactorStrand_sp;
+        }
+
+        if (d_sessionStrand_sp) {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_EDGE);
+        }
+        else {
+            d_receiveQueue.setTrigger(ntca::ReactorEventTrigger::e_LEVEL);
         }
     }
     else {


### PR DESCRIPTION
This PR adds separate level-triggered and edge-triggered semantics to `ntcq::AcceptQueue` and `ntcq::ReceiveQueue`. Level triggering is used when announcing the low and high watermarks to statically load balanced socket sessions when the session has no strand semantics. Otherwise, the queues operate in edge triggered mode. Edge triggered mode prevents spamming calls to, e.g., `ntci::ListenerSocketSession::processAcceptQueueLowWatermark` or `ntci::StreamSocketSession::processReadQueueLowWatermark` when the associated session has strand semantics, the alert must be processed asynchronously, and some function ahead in the strand ties up the strand by performing a lot of work. This defensive measure is not necessary for statically load balanced sockets, or when the socket session has no strand semantics; those alerts are always processed synchronously. For such configurations level triggering is used. The motivation of this change is to reduce the impact of a user erroneously failing to drain the accept queue or receive queue for any reason: with edge triggering failure to drain the queue down past the "edge" (i.e. low watermark) results in no other type of alert until the high watermark is announced; with level triggering a new alert is announced each time the level in the queue  increases. 