### PR TITLE
Allow thread-safe reading of ntcr and ntcp source and remote endpoints independent of primary socket mutex

### DIFF
--- a/groups/ntc/ntccfg/ntccfg_platform.t.cpp
+++ b/groups/ntc/ntccfg/ntccfg_platform.t.cpp
@@ -30,10 +30,64 @@ class PlatformTest
 {
   public:
     // TODO
-    static void verify();
+    static void verifySafeInt();
+
+    // TODO
+    static void verifySafeString();
 };
 
-NTSCFG_TEST_FUNCTION(ntccfg::PlatformTest::verify)
+NTSCFG_TEST_FUNCTION(ntccfg::PlatformTest::verifySafeInt)
+{
+    // Default constructor.
+
+    {
+        ntccfg::Safe<int> s1(NTSCFG_TEST_ALLOCATOR);
+
+        int v1 = 1;
+        s1.load(&v1);
+        NTSCFG_TEST_EQ(v1, 0);
+    }
+
+    // Value constructor.
+
+    {
+        ntccfg::Safe<int> s1(1, NTSCFG_TEST_ALLOCATOR);
+        ntccfg::Safe<int> s2(2, NTSCFG_TEST_ALLOCATOR);
+
+        {
+            int v1 = 0;
+            s1.load(&v1);
+            NTSCFG_TEST_EQ(v1, 1);
+        }
+
+        {
+            int v2 = 0;
+            s2.load(&v2);
+            NTSCFG_TEST_EQ(v2, 2);
+        }
+    }
+
+    // Copy constructor.
+
+    {
+        ntccfg::Safe<int> s1(1, NTSCFG_TEST_ALLOCATOR);
+        ntccfg::Safe<int> s2(s1, NTSCFG_TEST_ALLOCATOR);
+
+        {
+            int v1 = 0;
+            s1.load(&v1);
+            NTSCFG_TEST_EQ(v1, 1);
+        }
+
+        {
+            int v2 = 0;
+            s2.load(&v2);
+            NTSCFG_TEST_EQ(v2, 1);
+        }
+    }
+}
+
+NTSCFG_TEST_FUNCTION(ntccfg::PlatformTest::verifySafeString)
 {
 }
 

--- a/groups/ntc/ntcp/ntcp_datagramsocket.h
+++ b/groups/ntc/ntcp/ntcp_datagramsocket.h
@@ -76,11 +76,13 @@ class DatagramSocket : public ntci::DatagramSocket,
 
     ntccfg::Object                               d_object;
     mutable Mutex                                d_mutex;
-    ntsa::Handle                                 d_systemHandle;
-    ntsa::Handle                                 d_publicHandle;
     ntsa::Transport::Value                       d_transport;
-    ntsa::Endpoint                               d_sourceEndpoint;
-    ntsa::Endpoint                               d_remoteEndpoint;
+    ntsa::Handle                                 d_systemHandle;
+    ntsa::Endpoint                               d_systemSourceEndpoint;
+    ntsa::Endpoint                               d_systemRemoteEndpoint;
+    ntsa::Handle                                 d_publicHandle;
+    ntccfg::Safe<ntsa::Endpoint>                 d_publicSourceEndpoint;
+    ntccfg::Safe<ntsa::Endpoint>                 d_publicRemoteEndpoint;
     bsl::shared_ptr<ntsi::DatagramSocket>        d_socket_sp;
     ntcs::Observer<ntci::Resolver>               d_resolver;
     ntcs::Observer<ntci::Proactor>               d_proactor;

--- a/groups/ntc/ntcp/ntcp_listenersocket.h
+++ b/groups/ntc/ntcp/ntcp_listenersocket.h
@@ -75,10 +75,11 @@ class ListenerSocket : public ntci::ListenerSocket,
 
     ntccfg::Object                               d_object;
     mutable Mutex                                d_mutex;
-    ntsa::Handle                                 d_systemHandle;
-    ntsa::Handle                                 d_publicHandle;
     ntsa::Transport::Value                       d_transport;
-    ntsa::Endpoint                               d_sourceEndpoint;
+    ntsa::Handle                                 d_systemHandle;
+    ntsa::Endpoint                               d_systemSourceEndpoint;
+    ntsa::Handle                                 d_publicHandle;
+    ntccfg::Safe<ntsa::Endpoint>                 d_publicSourceEndpoint;
     bsl::shared_ptr<ntsi::ListenerSocket>        d_socket_sp;
     ntcs::Observer<ntci::Resolver>               d_resolver;
     ntcs::Observer<ntci::Proactor>               d_proactor;

--- a/groups/ntc/ntcp/ntcp_streamsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.cpp
@@ -225,8 +225,8 @@ void StreamSocket::processSocketConnected(const ntsa::Error& error)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (error) {
         if (error != ntsa::Error::e_CANCELLED) {
@@ -256,8 +256,8 @@ void StreamSocket::processSocketReceived(const ntsa::Error&          error,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_receivePending = false;
 
@@ -295,8 +295,8 @@ void StreamSocket::processSocketSent(const ntsa::Error&       error,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_sendPending = false;
 
@@ -331,8 +331,8 @@ void StreamSocket::processSocketError(const ntsa::Error& error)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     this->privateFail(self, error);
 }
@@ -345,7 +345,7 @@ void StreamSocket::processSocketDetached()
 
     NTCI_LOG_CONTEXT();
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     BSLS_ASSERT(d_detachState.mode() == ntcs::DetachMode::e_INITIATED);
     d_detachState.setMode(ntcs::DetachMode::e_IDLE);
@@ -372,8 +372,8 @@ void StreamSocket::processConnectDeadlineTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         if (NTCCFG_UNLIKELY(d_detachState.mode() ==
@@ -414,8 +414,8 @@ void StreamSocket::processConnectRetryTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         if (d_connectInProgress) {
@@ -454,8 +454,8 @@ void StreamSocket::processUpgradeTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         // MRM: Log upgrade timeout
@@ -483,8 +483,8 @@ void StreamSocket::processSendRateTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCP_STREAMSOCKET_LOG_SEND_BUFFER_THROTTLE_RELAXED();
@@ -528,8 +528,8 @@ void StreamSocket::processSendDeadlineTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         ntci::SendCallback callback;
@@ -578,8 +578,8 @@ void StreamSocket::processReceiveRateTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCP_STREAMSOCKET_LOG_RECEIVE_BUFFER_THROTTLE_RELAXED();
@@ -623,8 +623,8 @@ void StreamSocket::processReceiveDeadlineTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         ntsa::Error error = d_receiveQueue.removeCallbackEntry(entry);
@@ -632,7 +632,7 @@ void StreamSocket::processReceiveDeadlineTimer(
             ntca::ReceiveContext receiveContext;
             receiveContext.setError(ntsa::Error(ntsa::Error::e_WOULD_BLOCK));
             receiveContext.setTransport(d_transport);
-            receiveContext.setEndpoint(d_remoteEndpoint);
+            receiveContext.setEndpoint(d_systemRemoteEndpoint);
 
             ntca::ReceiveEvent receiveEvent;
             receiveEvent.setType(ntca::ReceiveEventType::e_ERROR);
@@ -715,7 +715,7 @@ void StreamSocket::privateCompleteConnect(
         lastError = ntsa::Error::invalid();
     }
 
-    error = d_socket_sp->remoteEndpoint(&d_remoteEndpoint);
+    error = d_socket_sp->remoteEndpoint(&d_systemRemoteEndpoint);
     if (NTCCFG_UNLIKELY(error)) {
         NTCS_METRICS_UPDATE_CONNECT_FAILURE();
 
@@ -727,7 +727,9 @@ void StreamSocket::privateCompleteConnect(
         return;
     }
 
-    error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+    d_publicRemoteEndpoint = d_systemRemoteEndpoint;
+
+    error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
     if (NTCCFG_UNLIKELY(error)) {
         NTCS_METRICS_UPDATE_CONNECT_FAILURE();
 
@@ -738,6 +740,8 @@ void StreamSocket::privateCompleteConnect(
         this->privateFailConnect(self, lastError, false, false);
         return;
     }
+
+    d_publicSourceEndpoint = d_systemSourceEndpoint;
 
     {
         bsl::size_t sendBufferSize;
@@ -782,8 +786,8 @@ void StreamSocket::privateCompleteConnect(
 
     NTCS_METRICS_UPDATE_CONNECT_COMPLETE();
 
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     bsls::TimeInterval now = this->currentTime();
 
@@ -1379,7 +1383,7 @@ void StreamSocket::privateCompleteReceive(
 
         ntca::ReceiveContext receiveContext;
         receiveContext.setTransport(d_transport);
-        receiveContext.setEndpoint(d_remoteEndpoint);
+        receiveContext.setEndpoint(d_systemRemoteEndpoint);
 
         ntca::ReceiveEvent receiveEvent;
         receiveEvent.setType(ntca::ReceiveEventType::e_COMPLETE);
@@ -2155,7 +2159,7 @@ void StreamSocket::privateShutdownSequencePart2(
             ntca::ReceiveContext receiveContext;
             receiveContext.setError(ntsa::Error(ntsa::Error::e_EOF));
             receiveContext.setTransport(d_transport);
-            receiveContext.setEndpoint(d_remoteEndpoint);
+            receiveContext.setEndpoint(d_systemRemoteEndpoint);
 
             ntca::ReceiveEvent receiveEvent;
             receiveEvent.setType(ntca::ReceiveEventType::e_ERROR);
@@ -3136,24 +3140,26 @@ ntsa::Error StreamSocket::privateOpen(
         return ntsa::Error(ntsa::Error::e_LIMIT);
     }
 
-    d_systemHandle   = handle;
-    d_publicHandle   = handle;
-    d_transport      = transport;
-    d_sourceEndpoint = sourceEndpoint;
-    d_remoteEndpoint = remoteEndpoint;
-    d_socket_sp      = streamSocket;
-    d_acceptor_sp    = acceptor;
+    d_transport            = transport;
+    d_systemHandle         = handle;
+    d_systemSourceEndpoint = sourceEndpoint;
+    d_systemRemoteEndpoint = remoteEndpoint;
+    d_publicHandle         = handle;
+    d_publicSourceEndpoint = sourceEndpoint;
+    d_publicRemoteEndpoint = remoteEndpoint;
+    d_socket_sp            = streamSocket;
+    d_acceptor_sp          = acceptor;
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     NTCI_LOG_TRACE("Stream socket opened descriptor %d",
                    (int)(d_publicHandle));
 
     proactorRef->attachSocket(self);
 
-    if (!d_remoteEndpoint.isUndefined()) {
+    if (!d_systemRemoteEndpoint.isUndefined()) {
         d_openState.set(ntcs::OpenState::e_CONNECTED);
 
         ntcs::Dispatch::announceEstablished(d_manager_sp,
@@ -3215,13 +3221,14 @@ void StreamSocket::processSourceEndpointResolution(
     }
 
     if (!error) {
-        error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+        error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
+        d_publicSourceEndpoint = d_systemSourceEndpoint;
     }
 
     ntca::BindEvent bindEvent;
     if (!error) {
         bindEvent.setType(ntca::BindEventType::e_COMPLETE);
-        bindContext.setEndpoint(d_sourceEndpoint);
+        bindContext.setEndpoint(d_systemSourceEndpoint);
     }
     else {
         bindEvent.setType(ntca::BindEventType::e_ERROR);
@@ -3312,12 +3319,14 @@ void StreamSocket::processRemoteEndpointResolution(
 
     if (!error) {
         if (d_transport == ntsa::Transport::e_LOCAL_STREAM) {
-            if (d_sourceEndpoint.isImplicit()) {
+            if (d_systemSourceEndpoint.isImplicit()) {
                 error = d_socket_sp->bindAny(d_transport,
                                              d_options.reuseAddress());
 
                 if (!error) {
-                    error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+                    error = d_socket_sp->sourceEndpoint(
+                        &d_systemSourceEndpoint);
+                    d_publicSourceEndpoint = d_systemSourceEndpoint;
                 }
             }
         }
@@ -3335,7 +3344,8 @@ void StreamSocket::processRemoteEndpointResolution(
     }
 
     if (!error) {
-        error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+        error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
+        d_publicSourceEndpoint = d_systemSourceEndpoint;
     }
 
     if (error) {
@@ -3475,8 +3485,10 @@ void StreamSocket::privateRetryConnect(
         return;
     }
 
-    d_sourceEndpoint.reset();
-    d_remoteEndpoint.reset();
+    d_systemSourceEndpoint.reset();
+    d_systemRemoteEndpoint.reset();
+    d_publicSourceEndpoint.reset();
+    d_publicRemoteEndpoint.reset();
 
     d_flowControlState.reset();
     d_shutdownState.reset();
@@ -3562,17 +3574,19 @@ ntsa::Error StreamSocket::privateRetryConnectToEndpoint(
     }
 
     if (d_transport == ntsa::Transport::e_LOCAL_STREAM) {
-        if (d_sourceEndpoint.isImplicit()) {
+        if (d_systemSourceEndpoint.isImplicit()) {
             error =
                 d_socket_sp->bindAny(d_transport, d_options.reuseAddress());
             if (error) {
                 return error;
             }
 
-            error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+            error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
             if (error) {
                 return error;
             }
+
+            d_publicSourceEndpoint = d_systemSourceEndpoint;
         }
     }
 
@@ -3586,10 +3600,12 @@ ntsa::Error StreamSocket::privateRetryConnectToEndpoint(
         return error;
     }
 
-    error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+    error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
     if (error) {
         return error;
     }
+
+    d_publicSourceEndpoint = d_systemSourceEndpoint;
 
     return ntsa::Error();
 }
@@ -3600,8 +3616,8 @@ void StreamSocket::privateClose(const bsl::shared_ptr<StreamSocket>& self,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (d_detachState.mode() == ntcs::DetachMode::e_INITIATED) {
         d_deferredCalls.push_back(NTCCFG_BIND(
@@ -3640,11 +3656,13 @@ StreamSocket::StreamSocket(
     bslma::Allocator*                          basicAllocator)
 : d_object("ntcp::StreamSocket")
 , d_mutex()
-, d_systemHandle(ntsa::k_INVALID_HANDLE)
-, d_publicHandle(ntsa::k_INVALID_HANDLE)
 , d_transport(ntsa::Transport::e_UNDEFINED)
-, d_sourceEndpoint()
-, d_remoteEndpoint()
+, d_systemHandle(ntsa::k_INVALID_HANDLE)
+, d_systemSourceEndpoint()
+, d_systemRemoteEndpoint()
+, d_publicHandle(ntsa::k_INVALID_HANDLE)
+, d_publicSourceEndpoint()
+, d_publicRemoteEndpoint()
 , d_socket_sp()
 , d_acceptor_sp()
 , d_encryption_sp()
@@ -3896,14 +3914,16 @@ ntsa::Error StreamSocket::bind(const ntsa::Endpoint&     endpoint,
         return error;
     }
 
-    error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+    error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
     if (error) {
         return error;
     }
 
+    d_publicSourceEndpoint = d_systemSourceEndpoint;
+
     if (callback) {
         ntca::BindContext bindContext;
-        bindContext.setEndpoint(d_sourceEndpoint);
+        bindContext.setEndpoint(d_systemSourceEndpoint);
 
         ntca::BindEvent bindEvent;
         bindEvent.setType(ntca::BindEventType::e_COMPLETE);
@@ -4004,7 +4024,7 @@ ntsa::Error StreamSocket::connect(const ntsa::Endpoint&        endpoint,
         return ntsa::Error(ntsa::Error::e_INVALID);
     }
 
-    if (!d_remoteEndpoint.isUndefined()) {
+    if (!d_systemRemoteEndpoint.isUndefined()) {
         return ntsa::Error(ntsa::Error::e_INVALID);
     }
 
@@ -4141,7 +4161,7 @@ ntsa::Error StreamSocket::connect(const bsl::string&           name,
         return ntsa::Error(ntsa::Error::e_INVALID);
     }
 
-    if (!d_remoteEndpoint.isUndefined()) {
+    if (!d_systemRemoteEndpoint.isUndefined()) {
         return ntsa::Error(ntsa::Error::e_INVALID);
     }
 
@@ -4251,8 +4271,8 @@ ntsa::Error StreamSocket::upgrade(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -4408,8 +4428,8 @@ ntsa::Error StreamSocket::send(const bdlbb::Blob&        data,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -4525,8 +4545,8 @@ ntsa::Error StreamSocket::send(const ntsa::Data&         data,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -4633,8 +4653,8 @@ ntsa::Error StreamSocket::receive(ntca::ReceiveContext*       context,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -4693,7 +4713,7 @@ ntsa::Error StreamSocket::receive(ntca::ReceiveContext*       context,
         BSLS_ASSERT(numBytesDequeued <= options.maxSize());
 
         context->setTransport(d_transport);
-        context->setEndpoint(d_remoteEndpoint);
+        context->setEndpoint(d_systemRemoteEndpoint);
 
         ntcs::BlobUtil::append(data, d_receiveQueue.data(), numBytesDequeued);
 
@@ -4755,8 +4775,8 @@ ntsa::Error StreamSocket::receive(const ntca::ReceiveOptions&  options,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -4837,7 +4857,7 @@ ntsa::Error StreamSocket::receive(const ntca::ReceiveOptions&  options,
 
         ntca::ReceiveContext receiveContext;
         receiveContext.setTransport(d_transport);
-        receiveContext.setEndpoint(d_remoteEndpoint);
+        receiveContext.setEndpoint(d_systemRemoteEndpoint);
 
         ntca::ReceiveEvent receiveEvent;
         receiveEvent.setType(ntca::ReceiveEventType::e_COMPLETE);
@@ -5089,8 +5109,8 @@ ntsa::Error StreamSocket::setWriteRateLimiter(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_sendRateLimiter_sp = rateLimiter;
 
@@ -5118,8 +5138,8 @@ ntsa::Error StreamSocket::setWriteQueueLowWatermark(bsl::size_t lowWatermark)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_sendQueue.setLowWatermark(lowWatermark);
 
@@ -5157,8 +5177,8 @@ ntsa::Error StreamSocket::setWriteQueueHighWatermark(bsl::size_t highWatermark)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_sendQueue.setHighWatermark(highWatermark);
 
@@ -5197,8 +5217,8 @@ ntsa::Error StreamSocket::setWriteQueueWatermarks(bsl::size_t lowWatermark,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_sendQueue.setLowWatermark(lowWatermark);
     d_sendQueue.setHighWatermark(highWatermark);
@@ -5270,8 +5290,8 @@ ntsa::Error StreamSocket::setReadRateLimiter(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_receiveRateLimiter_sp = rateLimiter;
 
@@ -5299,8 +5319,8 @@ ntsa::Error StreamSocket::setReadQueueLowWatermark(bsl::size_t lowWatermark)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_receiveQueue.setLowWatermark(lowWatermark);
 
@@ -5340,8 +5360,8 @@ ntsa::Error StreamSocket::setReadQueueHighWatermark(bsl::size_t highWatermark)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_receiveQueue.setHighWatermark(highWatermark);
 
@@ -5366,8 +5386,8 @@ ntsa::Error StreamSocket::setReadQueueWatermarks(bsl::size_t lowWatermark,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_receiveQueue.setLowWatermark(lowWatermark);
     d_receiveQueue.setHighWatermark(highWatermark);
@@ -5400,8 +5420,8 @@ ntsa::Error StreamSocket::relaxFlowControl(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     return this->privateRelaxFlowControl(self, direction, true, true);
 }
@@ -5417,8 +5437,8 @@ ntsa::Error StreamSocket::applyFlowControl(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (direction == ntca::FlowControlType::e_SEND ||
         direction == ntca::FlowControlType::e_BOTH)
@@ -5459,8 +5479,8 @@ ntsa::Error StreamSocket::cancel(const ntca::ConnectToken& token)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (d_connectInProgress) {
         this->privateFailConnect(self,
@@ -5485,8 +5505,8 @@ ntsa::Error StreamSocket::cancel(const ntca::UpgradeToken& token)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (d_upgradeInProgress) {
         ntca::UpgradeContext upgradeContext;
@@ -5534,8 +5554,8 @@ ntsa::Error StreamSocket::cancel(const ntca::SendToken& token)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntci::SendCallback callback;
     ntca::SendContext  context;
@@ -5581,8 +5601,8 @@ ntsa::Error StreamSocket::cancel(const ntca::ReceiveToken& token)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     bsl::shared_ptr<ntcq::ReceiveCallbackQueueEntry> callbackEntry;
     ntsa::Error                                      error =
@@ -5591,7 +5611,7 @@ ntsa::Error StreamSocket::cancel(const ntca::ReceiveToken& token)
         ntca::ReceiveContext receiveContext;
         receiveContext.setError(ntsa::Error(ntsa::Error::e_CANCELLED));
         receiveContext.setTransport(d_transport);
-        receiveContext.setEndpoint(d_remoteEndpoint);
+        receiveContext.setEndpoint(d_systemRemoteEndpoint);
 
         ntca::ReceiveEvent receiveEvent;
         receiveEvent.setType(ntca::ReceiveEventType::e_ERROR);
@@ -5622,8 +5642,8 @@ ntsa::Error StreamSocket::downgrade()
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (!d_encryption_sp) {
         return ntsa::Error::invalid();
@@ -5713,8 +5733,8 @@ ntsa::Error StreamSocket::shutdown(ntsa::ShutdownType::Value direction,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (d_detachState.mode() == ntcs::DetachMode::e_INITIATED) {
         d_deferredCalls.push_back(
@@ -5915,13 +5935,13 @@ ntsa::Transport::Value StreamSocket::transport() const
 ntsa::Endpoint StreamSocket::sourceEndpoint() const
 {
     LockGuard lock(&d_mutex);
-    return d_sourceEndpoint;
+    return d_systemSourceEndpoint;
 }
 
 ntsa::Endpoint StreamSocket::remoteEndpoint() const
 {
     LockGuard lock(&d_mutex);
-    return d_remoteEndpoint;
+    return d_systemRemoteEndpoint;
 }
 
 bsl::shared_ptr<ntci::EncryptionCertificate> StreamSocket::sourceCertificate()

--- a/groups/ntc/ntcp/ntcp_streamsocket.h
+++ b/groups/ntc/ntcp/ntcp_streamsocket.h
@@ -89,11 +89,13 @@ class StreamSocket : public ntci::StreamSocket,
 
     ntccfg::Object                             d_object;
     mutable Mutex                              d_mutex;
-    ntsa::Handle                               d_systemHandle;
-    ntsa::Handle                               d_publicHandle;
     ntsa::Transport::Value                     d_transport;
-    ntsa::Endpoint                             d_sourceEndpoint;
-    ntsa::Endpoint                             d_remoteEndpoint;
+    ntsa::Handle                               d_systemHandle;
+    ntsa::Endpoint                             d_systemSourceEndpoint;
+    ntsa::Endpoint                             d_systemRemoteEndpoint;
+    ntsa::Handle                               d_publicHandle;
+    ntccfg::Safe<ntsa::Endpoint>               d_publicSourceEndpoint;
+    ntccfg::Safe<ntsa::Endpoint>               d_publicRemoteEndpoint;
     bsl::shared_ptr<ntsi::StreamSocket>        d_socket_sp;
     bsl::shared_ptr<ntci::ListenerSocket>      d_acceptor_sp;
     bsl::shared_ptr<ntci::Encryption>          d_encryption_sp;

--- a/groups/ntc/ntcr/ntcr_datagramsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.cpp
@@ -236,8 +236,8 @@ void DatagramSocket::processSocketReadable(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (NTCCFG_UNLIKELY(d_detachState.mode() ==
                         ntcs::DetachMode::e_INITIATED))
@@ -294,8 +294,8 @@ void DatagramSocket::processSocketWritable(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (NTCCFG_UNLIKELY(d_detachState.mode() ==
                         ntcs::DetachMode::e_INITIATED))
@@ -350,8 +350,8 @@ void DatagramSocket::processSocketError(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (NTCCFG_UNLIKELY(d_detachState.mode() ==
                         ntcs::DetachMode::e_INITIATED))
@@ -374,8 +374,8 @@ void DatagramSocket::processNotifications(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     typedef bsl::vector<ntsa::Notification>::const_iterator
         NotificationIterator;
@@ -408,8 +408,8 @@ ntsa::Error DatagramSocket::privateTimestampOutgoingData(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -497,8 +497,8 @@ ntsa::Error DatagramSocket::privateTimestampIncomingData(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -609,8 +609,8 @@ ntsa::Error DatagramSocket::privateZeroCopyEngage(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -711,8 +711,8 @@ void DatagramSocket::processSendRateTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCR_DATAGRAMSOCKET_LOG_SEND_BUFFER_THROTTLE_RELAXED();
@@ -756,8 +756,8 @@ void DatagramSocket::processSendDeadlineTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         ntci::SendCallback callback;
@@ -806,8 +806,8 @@ void DatagramSocket::processReceiveRateTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCR_DATAGRAMSOCKET_LOG_RECEIVE_BUFFER_THROTTLE_RELAXED();
@@ -851,8 +851,8 @@ void DatagramSocket::processReceiveDeadlineTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         ntsa::Error error = d_receiveQueue.removeCallbackEntry(entry);
@@ -938,7 +938,7 @@ ntsa::Error DatagramSocket::privateSocketReadableIteration(
                 receiveContext.setEndpoint(entry.endpoint().value());
             }
             else {
-                receiveContext.setEndpoint(d_remoteEndpoint);
+                receiveContext.setEndpoint(d_systemRemoteEndpoint);
             }
 
             if (entry.foreignHandle().has_value()) {
@@ -2322,7 +2322,7 @@ ntsa::Error DatagramSocket::privateEnqueueSendBuffer(
 
     ntsa::SendOptions options;
 
-    if (d_remoteEndpoint.isUndefined()) {
+    if (d_systemRemoteEndpoint.isUndefined()) {
         if (!endpoint.isNull()) {
             options.setEndpoint(endpoint.value());
         }
@@ -2330,7 +2330,7 @@ ntsa::Error DatagramSocket::privateEnqueueSendBuffer(
             return ntsa::Error(ntsa::Error::e_INVALID);
         }
     }
-    else if (!endpoint.isNull() && endpoint.value() != d_remoteEndpoint) {
+    else if (!endpoint.isNull() && endpoint.value() != d_systemRemoteEndpoint) {
         return ntsa::Error(ntsa::Error::e_INVALID);
     }
 
@@ -2372,11 +2372,13 @@ ntsa::Error DatagramSocket::privateEnqueueSendBuffer(
         ++d_timestampCounter;
     }
 
-    if (d_sourceEndpoint.isUndefined()) {
-        error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+    if (d_systemSourceEndpoint.isUndefined()) {
+        error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
         if (error) {
             return error;
         }
+
+        d_publicSourceEndpoint = d_systemSourceEndpoint;
     }
 
     if (NTCCFG_UNLIKELY(d_sendRateLimiter_sp)) {
@@ -2419,7 +2421,7 @@ ntsa::Error DatagramSocket::privateEnqueueSendBuffer(
 
     ntsa::SendOptions options;
 
-    if (d_remoteEndpoint.isUndefined()) {
+    if (d_systemRemoteEndpoint.isUndefined()) {
         if (!endpoint.isNull()) {
             options.setEndpoint(endpoint.value());
         }
@@ -2427,7 +2429,7 @@ ntsa::Error DatagramSocket::privateEnqueueSendBuffer(
             return ntsa::Error(ntsa::Error::e_INVALID);
         }
     }
-    else if (!endpoint.isNull() && endpoint.value() != d_remoteEndpoint) {
+    else if (!endpoint.isNull() && endpoint.value() != d_systemRemoteEndpoint) {
         return ntsa::Error(ntsa::Error::e_INVALID);
     }
 
@@ -2469,11 +2471,13 @@ ntsa::Error DatagramSocket::privateEnqueueSendBuffer(
         ++d_timestampCounter;
     }
 
-    if (d_sourceEndpoint.isUndefined()) {
-        error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+    if (d_systemSourceEndpoint.isUndefined()) {
+        error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
         if (error) {
             return error;
         }
+
+        d_publicSourceEndpoint = d_systemSourceEndpoint;
     }
 
     if (NTCCFG_UNLIKELY(d_sendRateLimiter_sp)) {
@@ -2604,7 +2608,7 @@ ntsa::Error DatagramSocket::privateDequeueReceiveBufferRaw(
     }
 
     if (context->endpoint().isNull()) {
-        context->setEndpoint(d_remoteEndpoint);
+        context->setEndpoint(d_systemRemoteEndpoint);
     }
 
     if (NTCCFG_UNLIKELY(d_receiveRateLimiter_sp)) {
@@ -2878,16 +2882,18 @@ ntsa::Error DatagramSocket::privateOpen(
         remoteEndpoint.reset();
     }
 
-    d_systemHandle   = handle;
-    d_publicHandle   = handle;
-    d_transport      = transport;
-    d_sourceEndpoint = sourceEndpoint;
-    d_remoteEndpoint = remoteEndpoint;
-    d_socket_sp      = datagramSocket;
+    d_transport            = transport;
+    d_systemHandle         = handle;
+    d_systemSourceEndpoint = sourceEndpoint;
+    d_systemRemoteEndpoint = remoteEndpoint;
+    d_publicHandle         = handle;
+    d_publicSourceEndpoint = sourceEndpoint;
+    d_publicRemoteEndpoint = remoteEndpoint;
+    d_socket_sp            = datagramSocket;
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     NTCI_LOG_TRACE("Datagram socket opened descriptor %d",
                    (int)(d_publicHandle));
@@ -2974,13 +2980,14 @@ void DatagramSocket::processSourceEndpointResolution(
     }
 
     if (!error) {
-        error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+        error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
+        d_publicSourceEndpoint = d_systemSourceEndpoint;
     }
 
     ntca::BindEvent bindEvent;
     if (!error) {
         bindEvent.setType(ntca::BindEventType::e_COMPLETE);
-        bindContext.setEndpoint(d_sourceEndpoint);
+        bindContext.setEndpoint(d_systemSourceEndpoint);
     }
     else {
         bindEvent.setType(ntca::BindEventType::e_ERROR);
@@ -3045,12 +3052,14 @@ void DatagramSocket::processRemoteEndpointResolution(
 
     if (!error) {
         if (d_transport == ntsa::Transport::e_LOCAL_DATAGRAM) {
-            if (d_sourceEndpoint.isImplicit()) {
+            if (d_systemSourceEndpoint.isImplicit()) {
                 error = d_socket_sp->bindAny(d_transport,
                                              d_options.reuseAddress());
 
                 if (!error) {
-                    error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+                    error = d_socket_sp->sourceEndpoint(
+                        &d_systemSourceEndpoint);
+                    d_publicSourceEndpoint = d_systemSourceEndpoint;
                 }
             }
         }
@@ -3061,17 +3070,19 @@ void DatagramSocket::processRemoteEndpointResolution(
     }
 
     if (!error) {
-        error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+        error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
+        d_publicSourceEndpoint = d_systemSourceEndpoint;
     }
 
     if (!error) {
-        error = d_socket_sp->remoteEndpoint(&d_remoteEndpoint);
+        error = d_socket_sp->remoteEndpoint(&d_systemRemoteEndpoint);
+        d_publicRemoteEndpoint = d_systemRemoteEndpoint;
     }
 
     ntca::ConnectEvent connectEvent;
     if (!error) {
         connectEvent.setType(ntca::ConnectEventType::e_COMPLETE);
-        connectContext.setEndpoint(d_sourceEndpoint);
+        connectContext.setEndpoint(d_systemSourceEndpoint);
     }
     else {
         connectEvent.setType(ntca::ConnectEventType::e_ERROR);
@@ -3099,7 +3110,7 @@ void DatagramSocket::privateClose(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     if (d_detachState.mode() == ntcs::DetachMode::e_INITIATED) {
         d_deferredCalls.push_back(NTCCFG_BIND(
@@ -3129,11 +3140,13 @@ DatagramSocket::DatagramSocket(
     bslma::Allocator*                         basicAllocator)
 : d_object("ntcr::DatagramSocket")
 , d_mutex()
-, d_systemHandle(ntsa::k_INVALID_HANDLE)
-, d_publicHandle(ntsa::k_INVALID_HANDLE)
 , d_transport(ntsa::Transport::e_UNDEFINED)
-, d_sourceEndpoint()
-, d_remoteEndpoint()
+, d_systemHandle(ntsa::k_INVALID_HANDLE)
+, d_systemSourceEndpoint()
+, d_systemRemoteEndpoint()
+, d_publicHandle(ntsa::k_INVALID_HANDLE)
+, d_publicSourceEndpoint()
+, d_publicRemoteEndpoint()
 , d_socket_sp()
 #if NTCR_DATAGRAMSOCKET_OBSERVE_BY_WEAK_PTR
 , d_resolver(bsl::weak_ptr<ntci::Resolver>(resolver))
@@ -3338,14 +3351,16 @@ ntsa::Error DatagramSocket::bind(const ntsa::Endpoint&     endpoint,
         return error;
     }
 
-    error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+    error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
     if (error) {
         return error;
     }
 
+    d_publicSourceEndpoint = d_systemSourceEndpoint;
+
     if (callback) {
         ntca::BindContext bindContext;
-        bindContext.setEndpoint(d_sourceEndpoint);
+        bindContext.setEndpoint(d_systemSourceEndpoint);
 
         ntca::BindEvent bindEvent;
         bindEvent.setType(ntca::BindEventType::e_COMPLETE);
@@ -3457,17 +3472,19 @@ ntsa::Error DatagramSocket::connect(const ntsa::Endpoint&        endpoint,
     }
 
     if (d_transport == ntsa::Transport::e_LOCAL_DATAGRAM) {
-        if (d_sourceEndpoint.isImplicit()) {
+        if (d_systemSourceEndpoint.isImplicit()) {
             error =
                 d_socket_sp->bindAny(d_transport, d_options.reuseAddress());
             if (error) {
                 return error;
             }
 
-            error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+            error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
             if (error) {
                 return error;
             }
+
+            d_publicSourceEndpoint = d_systemSourceEndpoint;
         }
     }
 
@@ -3476,21 +3493,25 @@ ntsa::Error DatagramSocket::connect(const ntsa::Endpoint&        endpoint,
         return error;
     }
 
-    error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+    error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
     if (error) {
         return error;
     }
 
-    error = d_socket_sp->remoteEndpoint(&d_remoteEndpoint);
+    d_publicSourceEndpoint = d_systemSourceEndpoint;
+
+    error = d_socket_sp->remoteEndpoint(&d_systemRemoteEndpoint);
     if (error) {
         return error;
     }
+
+    d_publicRemoteEndpoint = d_systemRemoteEndpoint;
 
     d_receiveOptions.hideEndpoint();
 
     if (callback) {
         ntca::ConnectContext connectContext;
-        connectContext.setEndpoint(d_remoteEndpoint);
+        connectContext.setEndpoint(d_systemRemoteEndpoint);
 
         ntca::ConnectEvent connectEvent;
         connectEvent.setType(ntca::ConnectEventType::e_COMPLETE);
@@ -3593,8 +3614,8 @@ ntsa::Error DatagramSocket::send(const bdlbb::Blob&        data,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntcq::SendState state;
     state.setCounter(d_sendCounter++);
@@ -3697,8 +3718,8 @@ ntsa::Error DatagramSocket::send(const ntsa::Data&         data,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntcq::SendState state;
     state.setCounter(d_sendCounter++);
@@ -3791,8 +3812,8 @@ ntsa::Error DatagramSocket::receive(ntca::ReceiveContext*       context,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -3855,7 +3876,7 @@ ntsa::Error DatagramSocket::receive(ntca::ReceiveContext*       context,
                 context->setEndpoint(receiveContext.endpoint().value());
             }
             else {
-                context->setEndpoint(d_remoteEndpoint);
+                context->setEndpoint(d_systemRemoteEndpoint);
             }
 
             if (receiveContext.foreignHandle().has_value()) {
@@ -3900,8 +3921,8 @@ ntsa::Error DatagramSocket::receive(const ntca::ReceiveOptions&  options,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -3940,7 +3961,7 @@ ntsa::Error DatagramSocket::receive(const ntca::ReceiveOptions&  options,
             receiveContext.setEndpoint(endpoint.value());
         }
         else {
-            receiveContext.setEndpoint(d_remoteEndpoint);
+            receiveContext.setEndpoint(d_systemRemoteEndpoint);
         }
 
         ntca::ReceiveEvent receiveEvent;
@@ -4022,7 +4043,7 @@ ntsa::Error DatagramSocket::receive(const ntca::ReceiveOptions&  options,
                 receiveContext.setEndpoint(receiveContext.endpoint().value());
             }
             else {
-                receiveContext.setEndpoint(d_remoteEndpoint);
+                receiveContext.setEndpoint(d_systemRemoteEndpoint);
             }
 
             if (receiveContext.foreignHandle().has_value()) {
@@ -4277,8 +4298,8 @@ ntsa::Error DatagramSocket::setWriteRateLimiter(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_sendRateLimiter_sp = rateLimiter;
 
@@ -4306,8 +4327,8 @@ ntsa::Error DatagramSocket::setWriteQueueLowWatermark(bsl::size_t lowWatermark)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_sendQueue.setLowWatermark(lowWatermark);
 
@@ -4342,8 +4363,8 @@ ntsa::Error DatagramSocket::setWriteQueueHighWatermark(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_sendQueue.setHighWatermark(highWatermark);
 
@@ -4378,8 +4399,8 @@ ntsa::Error DatagramSocket::setWriteQueueWatermarks(bsl::size_t lowWatermark,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_sendQueue.setLowWatermark(lowWatermark);
     d_sendQueue.setHighWatermark(highWatermark);
@@ -4443,8 +4464,8 @@ ntsa::Error DatagramSocket::setReadRateLimiter(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_receiveRateLimiter_sp = rateLimiter;
 
@@ -4472,8 +4493,8 @@ ntsa::Error DatagramSocket::setReadQueueLowWatermark(bsl::size_t lowWatermark)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_receiveQueue.setLowWatermark(lowWatermark);
 
@@ -4514,8 +4535,8 @@ ntsa::Error DatagramSocket::setReadQueueHighWatermark(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_receiveQueue.setHighWatermark(highWatermark);
 
@@ -4540,8 +4561,8 @@ ntsa::Error DatagramSocket::setReadQueueWatermarks(bsl::size_t lowWatermark,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_receiveQueue.setLowWatermark(lowWatermark);
     d_receiveQueue.setHighWatermark(highWatermark);
@@ -4656,8 +4677,8 @@ ntsa::Error DatagramSocket::relaxFlowControl(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     return this->privateRelaxFlowControl(self, direction, true, true);
 }
@@ -4673,8 +4694,8 @@ ntsa::Error DatagramSocket::applyFlowControl(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (direction == ntca::FlowControlType::e_SEND ||
         direction == ntca::FlowControlType::e_BOTH)
@@ -4720,8 +4741,8 @@ ntsa::Error DatagramSocket::cancel(const ntca::SendToken& token)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntci::SendCallback callback;
     ntca::SendContext  context;
@@ -4767,8 +4788,8 @@ ntsa::Error DatagramSocket::cancel(const ntca::ReceiveToken& token)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     bsl::shared_ptr<ntcq::ReceiveCallbackQueueEntry> callbackEntry;
     ntsa::Error                                      error =
@@ -4808,7 +4829,7 @@ ntsa::Error DatagramSocket::shutdown(ntsa::ShutdownType::Value direction,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     this->privateShutdown(self, direction, mode, true);
     return ntsa::Error();
@@ -4988,14 +5009,16 @@ ntsa::Transport::Value DatagramSocket::transport() const
 
 ntsa::Endpoint DatagramSocket::sourceEndpoint() const
 {
-    LockGuard lock(&d_mutex);
-    return d_sourceEndpoint;
+    ntsa::Endpoint result;
+    d_publicSourceEndpoint.load(&result);
+    return result;
 }
 
 ntsa::Endpoint DatagramSocket::remoteEndpoint() const
 {
-    LockGuard lock(&d_mutex);
-    return d_remoteEndpoint;
+    ntsa::Endpoint result;
+    d_publicRemoteEndpoint.load(&result);
+    return result;
 }
 
 const bsl::shared_ptr<ntci::Strand>& DatagramSocket::strand() const

--- a/groups/ntc/ntcr/ntcr_datagramsocket.h
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.h
@@ -82,11 +82,13 @@ class DatagramSocket : public ntci::DatagramSocket,
 
     ntccfg::Object                               d_object;
     mutable Mutex                                d_mutex;
-    ntsa::Handle                                 d_systemHandle;
-    ntsa::Handle                                 d_publicHandle;
     ntsa::Transport::Value                       d_transport;
-    ntsa::Endpoint                               d_sourceEndpoint;
-    ntsa::Endpoint                               d_remoteEndpoint;
+    ntsa::Handle                                 d_systemHandle;
+    ntsa::Endpoint                               d_systemSourceEndpoint;
+    ntsa::Endpoint                               d_systemRemoteEndpoint;
+    ntsa::Handle                                 d_publicHandle;
+    ntccfg::Safe<ntsa::Endpoint>                 d_publicSourceEndpoint;
+    ntccfg::Safe<ntsa::Endpoint>                 d_publicRemoteEndpoint;
     bsl::shared_ptr<ntsi::DatagramSocket>        d_socket_sp;
     ntcs::Observer<ntci::Resolver>               d_resolver;
     ntcs::Observer<ntci::Reactor>                d_reactor;

--- a/groups/ntc/ntcr/ntcr_listenersocket.cpp
+++ b/groups/ntc/ntcr/ntcr_listenersocket.cpp
@@ -160,7 +160,7 @@ void ListenerSocket::processSocketReadable(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     if (NTCCFG_UNLIKELY(d_detachState.mode() ==
                         ntcs::DetachMode::e_INITIATED))
@@ -220,7 +220,7 @@ void ListenerSocket::processSocketError(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     if (d_detachState.mode() == ntcs::DetachMode::e_INITIATED) {
         return;
@@ -250,7 +250,7 @@ void ListenerSocket::processAcceptRateTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCR_LISTENERSOCKET_LOG_BACKLOG_THROTTLE_RELAXED();
@@ -293,7 +293,7 @@ void ListenerSocket::processAcceptBackoffTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         this->privateRelaxFlowControl(self,
@@ -322,7 +322,7 @@ void ListenerSocket::processAcceptDeadlineTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         ntsa::Error error = d_acceptQueue.removeCallbackEntry(entry);
@@ -1470,13 +1470,14 @@ ntsa::Error ListenerSocket::privateOpen(
         sourceEndpoint.reset();
     }
 
-    d_systemHandle   = handle;
-    d_publicHandle   = handle;
-    d_transport      = transport;
-    d_sourceEndpoint = sourceEndpoint;
-    d_socket_sp      = listenerSocket;
+    d_transport            = transport;
+    d_systemHandle         = handle;
+    d_systemSourceEndpoint = sourceEndpoint;
+    d_publicHandle         = handle;
+    d_publicSourceEndpoint = sourceEndpoint; 
+    d_socket_sp            = listenerSocket;
 
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     NTCI_LOG_TRACE("Listener socket opened descriptor %d",
                    (int)(d_publicHandle));
@@ -1541,13 +1542,14 @@ void ListenerSocket::processSourceEndpointResolution(
     }
 
     if (!error) {
-        error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+        error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
+        d_publicSourceEndpoint = d_systemSourceEndpoint;
     }
 
     ntca::BindEvent bindEvent;
     if (!error) {
         bindEvent.setType(ntca::BindEventType::e_COMPLETE);
-        bindContext.setEndpoint(d_sourceEndpoint);
+        bindContext.setEndpoint(d_systemSourceEndpoint);
     }
     else {
         bindEvent.setType(ntca::BindEventType::e_ERROR);
@@ -1575,7 +1577,7 @@ void ListenerSocket::privateClose(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     if (d_detachState.mode() == ntcs::DetachMode::e_INITIATED) {
         d_deferredCalls.push_back(NTCCFG_BIND(
@@ -1632,10 +1634,11 @@ ListenerSocket::ListenerSocket(
     bslma::Allocator*                         basicAllocator)
 : d_object("ntcr::ListenerSocket")
 , d_mutex()
-, d_systemHandle(ntsa::k_INVALID_HANDLE)
-, d_publicHandle(ntsa::k_INVALID_HANDLE)
 , d_transport(ntsa::Transport::e_UNDEFINED)
-, d_sourceEndpoint()
+, d_systemHandle(ntsa::k_INVALID_HANDLE)
+, d_systemSourceEndpoint()
+, d_publicHandle(ntsa::k_INVALID_HANDLE)
+, d_publicSourceEndpoint()
 , d_socket_sp()
 #if NTCR_LISTENERSOCKET_OBSERVE_BY_WEAK_PTR
 , d_resolver(bsl::weak_ptr<ntci::Resolver>(resolver))
@@ -1804,14 +1807,16 @@ ntsa::Error ListenerSocket::bind(const ntsa::Endpoint&     endpoint,
         return error;
     }
 
-    error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+    error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
     if (error) {
         return error;
     }
 
+    d_publicSourceEndpoint = d_systemSourceEndpoint;
+
     if (callback) {
         ntca::BindContext bindContext;
-        bindContext.setEndpoint(d_sourceEndpoint);
+        bindContext.setEndpoint(d_systemSourceEndpoint);
 
         ntca::BindEvent bindEvent;
         bindEvent.setType(ntca::BindEventType::e_COMPLETE);
@@ -1909,10 +1914,12 @@ ntsa::Error ListenerSocket::listen(bsl::size_t backlog)
         return error;
     }
 
-    error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+    error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
     if (error) {
         return error;
     }
+
+    d_publicSourceEndpoint = d_systemSourceEndpoint;
 
     if (!this->getReactorContext()) {
         ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
@@ -1954,7 +1961,7 @@ ntsa::Error ListenerSocket::accept(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     ntsa::Error error;
 
@@ -2036,7 +2043,7 @@ ntsa::Error ListenerSocket::accept(const ntca::AcceptOptions&  options,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     ntsa::Error error;
 
@@ -2370,7 +2377,7 @@ ntsa::Error ListenerSocket::setAcceptRateLimiter(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     d_acceptRateLimiter_sp = rateLimiter;
 
@@ -2399,7 +2406,7 @@ ntsa::Error ListenerSocket::setAcceptQueueLowWatermark(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     d_acceptQueue.setLowWatermark(lowWatermark);
 
@@ -2440,7 +2447,7 @@ ntsa::Error ListenerSocket::setAcceptQueueHighWatermark(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     d_acceptQueue.setHighWatermark(highWatermark);
 
@@ -2465,7 +2472,7 @@ ntsa::Error ListenerSocket::setAcceptQueueWatermarks(bsl::size_t lowWatermark,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     d_acceptQueue.setLowWatermark(lowWatermark);
     d_acceptQueue.setHighWatermark(highWatermark);
@@ -2498,7 +2505,7 @@ ntsa::Error ListenerSocket::relaxFlowControl(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     return this->privateRelaxFlowControl(self, direction, true, true);
 }
@@ -2514,7 +2521,7 @@ ntsa::Error ListenerSocket::applyFlowControl(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     if (direction == ntca::FlowControlType::e_RECEIVE ||
         direction == ntca::FlowControlType::e_BOTH)
@@ -2544,7 +2551,7 @@ ntsa::Error ListenerSocket::cancel(const ntca::AcceptToken& token)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     bsl::shared_ptr<ntcq::AcceptCallbackQueueEntry> callbackEntry;
     ntsa::Error                                     error =
@@ -2582,7 +2589,7 @@ ntsa::Error ListenerSocket::shutdown()
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     this->privateShutdown(self,
                           ntsa::ShutdownType::e_BOTH,
@@ -2761,8 +2768,9 @@ ntsa::Transport::Value ListenerSocket::transport() const
 
 ntsa::Endpoint ListenerSocket::sourceEndpoint() const
 {
-    LockGuard lock(&d_mutex);
-    return d_sourceEndpoint;
+    ntsa::Endpoint result;
+    d_publicSourceEndpoint.load(&result);
+    return result;
 }
 
 const bsl::shared_ptr<ntci::Strand>& ListenerSocket::strand() const

--- a/groups/ntc/ntcr/ntcr_listenersocket.h
+++ b/groups/ntc/ntcr/ntcr_listenersocket.h
@@ -75,10 +75,11 @@ class ListenerSocket : public ntci::ListenerSocket,
 
     ntccfg::Object                               d_object;
     mutable Mutex                                d_mutex;
-    ntsa::Handle                                 d_systemHandle;
-    ntsa::Handle                                 d_publicHandle;
     ntsa::Transport::Value                       d_transport;
-    ntsa::Endpoint                               d_sourceEndpoint;
+    ntsa::Handle                                 d_systemHandle;
+    ntsa::Endpoint                               d_systemSourceEndpoint;
+    ntsa::Handle                                 d_publicHandle;
+    ntccfg::Safe<ntsa::Endpoint>                 d_publicSourceEndpoint;
     bsl::shared_ptr<ntsi::ListenerSocket>        d_socket_sp;
     ntcs::Observer<ntci::Resolver>               d_resolver;
     ntcs::Observer<ntci::Reactor>                d_reactor;

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -293,8 +293,8 @@ void StreamSocket::processSocketReadable(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (NTCCFG_UNLIKELY(d_detachState.mode() ==
                         ntcs::DetachMode::e_INITIATED))
@@ -351,8 +351,8 @@ void StreamSocket::processSocketWritable(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (NTCCFG_UNLIKELY(d_detachState.mode() ==
                         ntcs::DetachMode::e_INITIATED))
@@ -412,8 +412,8 @@ void StreamSocket::processSocketError(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (NTCCFG_UNLIKELY(d_detachState.mode() ==
                         ntcs::DetachMode::e_INITIATED))
@@ -444,7 +444,7 @@ void StreamSocket::processNotifications(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
 
     typedef bsl::vector<ntsa::Notification>::const_iterator
         NotificationIterator;
@@ -483,8 +483,8 @@ void StreamSocket::processConnectDeadlineTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         if (NTCCFG_UNLIKELY(d_detachState.mode() ==
@@ -525,8 +525,8 @@ void StreamSocket::processConnectRetryTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         if (d_connectInProgress) {
@@ -566,8 +566,8 @@ void StreamSocket::processUpgradeTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         if (d_upgradeInProgress) {
@@ -593,8 +593,8 @@ void StreamSocket::processSendRateTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCR_STREAMSOCKET_LOG_SEND_BUFFER_THROTTLE_RELAXED();
@@ -638,8 +638,8 @@ void StreamSocket::processSendDeadlineTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         ntci::SendCallback callback;
@@ -688,8 +688,8 @@ void StreamSocket::processReceiveRateTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         NTCR_STREAMSOCKET_LOG_RECEIVE_BUFFER_THROTTLE_RELAXED();
@@ -733,8 +733,8 @@ void StreamSocket::processReceiveDeadlineTimer(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         ntsa::Error error = d_receiveQueue.removeCallbackEntry(entry);
@@ -742,7 +742,7 @@ void StreamSocket::processReceiveDeadlineTimer(
             ntca::ReceiveContext receiveContext;
             receiveContext.setError(ntsa::Error(ntsa::Error::e_WOULD_BLOCK));
             receiveContext.setTransport(d_transport);
-            receiveContext.setEndpoint(d_remoteEndpoint);
+            receiveContext.setEndpoint(d_systemRemoteEndpoint);
 
             ntca::ReceiveEvent receiveEvent;
             receiveEvent.setType(ntca::ReceiveEventType::e_ERROR);
@@ -862,7 +862,7 @@ ntsa::Error StreamSocket::privateSocketReadableIteration(
 
         ntca::ReceiveContext receiveContext;
         receiveContext.setTransport(d_transport);
-        receiveContext.setEndpoint(d_remoteEndpoint);
+        receiveContext.setEndpoint(d_systemRemoteEndpoint);
 
         while (true) {
             ntcq::ReceiveQueueEntry& entry = d_receiveQueue.frontEntry();
@@ -1006,7 +1006,7 @@ ntsa::Error StreamSocket::privateSocketWritableConnection(
         lastError = ntsa::Error::invalid();
     }
 
-    error = d_socket_sp->remoteEndpoint(&d_remoteEndpoint);
+    error = d_socket_sp->remoteEndpoint(&d_systemRemoteEndpoint);
     if (NTCCFG_UNLIKELY(error)) {
         if (lastError == ntsa::Error::invalid()) {
             lastError = error;
@@ -1016,7 +1016,9 @@ ntsa::Error StreamSocket::privateSocketWritableConnection(
         return lastError;
     }
 
-    error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+    d_publicRemoteEndpoint = d_systemRemoteEndpoint;
+
+    error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
     if (NTCCFG_UNLIKELY(error)) {
         NTCS_METRICS_UPDATE_CONNECT_FAILURE();
 
@@ -1027,6 +1029,8 @@ ntsa::Error StreamSocket::privateSocketWritableConnection(
         this->privateFailConnect(self, lastError, false, false);
         return lastError;
     }
+
+    d_publicSourceEndpoint = d_systemSourceEndpoint;
 
     {
         bsl::size_t sendBufferSize;
@@ -1071,8 +1075,8 @@ ntsa::Error StreamSocket::privateSocketWritableConnection(
 
     NTCS_METRICS_UPDATE_CONNECT_COMPLETE();
 
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     bsls::TimeInterval now = this->currentTime();
 
@@ -2226,7 +2230,7 @@ void StreamSocket::privateShutdownSequenceComplete(
             ntca::ReceiveContext receiveContext;
             receiveContext.setError(ntsa::Error(ntsa::Error::e_EOF));
             receiveContext.setTransport(d_transport);
-            receiveContext.setEndpoint(d_remoteEndpoint);
+            receiveContext.setEndpoint(d_systemRemoteEndpoint);
 
             ntca::ReceiveEvent receiveEvent;
             receiveEvent.setType(ntca::ReceiveEventType::e_ERROR);
@@ -3988,22 +3992,24 @@ ntsa::Error StreamSocket::privateOpen(
         }
     }
 
-    d_systemHandle   = handle;
-    d_publicHandle   = handle;
-    d_transport      = transport;
-    d_sourceEndpoint = sourceEndpoint;
-    d_remoteEndpoint = remoteEndpoint;
-    d_socket_sp      = streamSocket;
-    d_acceptor_sp    = acceptor;
+    d_transport            = transport;
+    d_systemHandle         = handle;
+    d_systemSourceEndpoint = sourceEndpoint;
+    d_systemRemoteEndpoint = remoteEndpoint;
+    d_publicHandle         = handle;
+    d_publicSourceEndpoint = sourceEndpoint;
+    d_publicRemoteEndpoint = remoteEndpoint;
+    d_socket_sp            = streamSocket;
+    d_acceptor_sp          = acceptor;
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     NTCI_LOG_TRACE("Stream socket opened descriptor %d",
                    (int)(d_publicHandle));
 
-    if (!d_remoteEndpoint.isUndefined()) {
+    if (!d_systemRemoteEndpoint.isUndefined()) {
         ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
         if (!reactorRef) {
             return ntsa::Error(ntsa::Error::e_INVALID);
@@ -4085,13 +4091,15 @@ void StreamSocket::processSourceEndpointResolution(
     }
 
     if (!error) {
-        error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+        error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
     }
+
+    d_publicSourceEndpoint = d_systemSourceEndpoint;
 
     ntca::BindEvent bindEvent;
     if (!error) {
         bindEvent.setType(ntca::BindEventType::e_COMPLETE);
-        bindContext.setEndpoint(d_sourceEndpoint);
+        bindContext.setEndpoint(d_systemSourceEndpoint);
     }
     else {
         bindEvent.setType(ntca::BindEventType::e_ERROR);
@@ -4182,12 +4190,13 @@ void StreamSocket::processRemoteEndpointResolution(
 
     if (!error) {
         if (d_transport == ntsa::Transport::e_LOCAL_STREAM) {
-            if (d_sourceEndpoint.isImplicit()) {
+            if (d_systemSourceEndpoint.isImplicit()) {
                 error = d_socket_sp->bindAny(d_transport,
                                              d_options.reuseAddress());
 
                 if (!error) {
-                    error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+                    error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
+                    d_publicSourceEndpoint = d_systemSourceEndpoint;
                 }
             }
         }
@@ -4203,7 +4212,8 @@ void StreamSocket::processRemoteEndpointResolution(
     }
 
     if (!error) {
-        error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+        error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
+        d_publicSourceEndpoint = d_systemSourceEndpoint;
     }
 
     if (!error) {
@@ -4370,8 +4380,10 @@ void StreamSocket::privateRetryConnect(
         return;
     }
 
-    d_sourceEndpoint.reset();
-    d_remoteEndpoint.reset();
+    d_systemSourceEndpoint.reset();
+    d_systemRemoteEndpoint.reset();
+    d_publicSourceEndpoint.reset();
+    d_publicRemoteEndpoint.reset();
 
     d_flowControlState.reset();
     d_shutdownState.reset();
@@ -4456,17 +4468,19 @@ ntsa::Error StreamSocket::privateRetryConnectToEndpoint(
     }
 
     if (d_transport == ntsa::Transport::e_LOCAL_STREAM) {
-        if (d_sourceEndpoint.isImplicit()) {
+        if (d_systemSourceEndpoint.isImplicit()) {
             error =
                 d_socket_sp->bindAny(d_transport, d_options.reuseAddress());
             if (error) {
                 return error;
             }
 
-            error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+            error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
             if (error) {
                 return error;
             }
+
+            d_publicSourceEndpoint = d_systemSourceEndpoint;
         }
     }
 
@@ -4479,10 +4493,12 @@ ntsa::Error StreamSocket::privateRetryConnectToEndpoint(
         }
     }
 
-    error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+    error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
     if (error) {
         return error;
     }
+
+    d_publicSourceEndpoint = d_systemSourceEndpoint;
 
     ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
     if (!reactorRef) {
@@ -4511,8 +4527,8 @@ ntsa::Error StreamSocket::privateTimestampOutgoingData(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -4603,8 +4619,8 @@ ntsa::Error StreamSocket::privateTimestampIncomingData(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -4719,8 +4735,8 @@ ntsa::Error StreamSocket::privateZeroCopyEngage(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -4813,8 +4829,8 @@ void StreamSocket::privateClose(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (d_detachState.mode() == ntcs::DetachMode::e_INITIATED) {
         d_deferredCalls.push_back(NTCCFG_BIND(
@@ -4854,11 +4870,13 @@ StreamSocket::StreamSocket(
     bslma::Allocator*                         basicAllocator)
 : d_object("ntcr::StreamSocket")
 , d_mutex()
-, d_systemHandle(ntsa::k_INVALID_HANDLE)
-, d_publicHandle(ntsa::k_INVALID_HANDLE)
 , d_transport(ntsa::Transport::e_UNDEFINED)
-, d_sourceEndpoint()
-, d_remoteEndpoint()
+, d_systemHandle(ntsa::k_INVALID_HANDLE)
+, d_systemSourceEndpoint()
+, d_systemRemoteEndpoint()
+, d_publicHandle(ntsa::k_INVALID_HANDLE)
+, d_publicSourceEndpoint()
+, d_publicRemoteEndpoint()
 , d_socket_sp()
 , d_acceptor_sp()
 , d_encryption_sp()
@@ -5127,14 +5145,16 @@ ntsa::Error StreamSocket::bind(const ntsa::Endpoint&     endpoint,
         return error;
     }
 
-    error = d_socket_sp->sourceEndpoint(&d_sourceEndpoint);
+    error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
     if (error) {
         return error;
     }
 
+    d_publicSourceEndpoint = d_systemSourceEndpoint;
+
     if (callback) {
         ntca::BindContext bindContext;
-        bindContext.setEndpoint(d_sourceEndpoint);
+        bindContext.setEndpoint(d_systemSourceEndpoint);
 
         ntca::BindEvent bindEvent;
         bindEvent.setType(ntca::BindEventType::e_COMPLETE);
@@ -5235,7 +5255,7 @@ ntsa::Error StreamSocket::connect(const ntsa::Endpoint&        endpoint,
         return ntsa::Error(ntsa::Error::e_INVALID);
     }
 
-    if (!d_remoteEndpoint.isUndefined()) {
+    if (!d_systemRemoteEndpoint.isUndefined()) {
         return ntsa::Error(ntsa::Error::e_INVALID);
     }
 
@@ -5372,7 +5392,7 @@ ntsa::Error StreamSocket::connect(const bsl::string&           name,
         return ntsa::Error(ntsa::Error::e_INVALID);
     }
 
-    if (!d_remoteEndpoint.isUndefined()) {
+    if (!d_systemRemoteEndpoint.isUndefined()) {
         return ntsa::Error(ntsa::Error::e_INVALID);
     }
 
@@ -5482,8 +5502,8 @@ ntsa::Error StreamSocket::upgrade(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -5639,8 +5659,8 @@ ntsa::Error StreamSocket::send(const bdlbb::Blob&        data,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -5762,8 +5782,8 @@ ntsa::Error StreamSocket::send(const ntsa::Data&         data,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -5876,8 +5896,8 @@ ntsa::Error StreamSocket::receive(ntca::ReceiveContext*       context,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -5906,7 +5926,7 @@ ntsa::Error StreamSocket::receive(ntca::ReceiveContext*       context,
         bsl::size_t numBytesDequeued  = 0;
 
         context->setTransport(d_transport);
-        context->setEndpoint(d_remoteEndpoint);
+        context->setEndpoint(d_systemRemoteEndpoint);
 
         while (NTCCFG_LIKELY(d_receiveQueue.hasEntry())) {
             ntcq::ReceiveQueueEntry& entry = d_receiveQueue.frontEntry();
@@ -6012,8 +6032,8 @@ ntsa::Error StreamSocket::receive(const ntca::ReceiveOptions&  options,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntsa::Error error;
 
@@ -6047,7 +6067,7 @@ ntsa::Error StreamSocket::receive(const ntca::ReceiveOptions&  options,
 
         ntca::ReceiveContext receiveContext;
         receiveContext.setTransport(d_transport);
-        receiveContext.setEndpoint(d_remoteEndpoint);
+        receiveContext.setEndpoint(d_systemRemoteEndpoint);
 
         while (NTCCFG_LIKELY(d_receiveQueue.hasEntry())) {
             ntcq::ReceiveQueueEntry& entry = d_receiveQueue.frontEntry();
@@ -6366,8 +6386,8 @@ ntsa::Error StreamSocket::setWriteRateLimiter(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_sendRateLimiter_sp = rateLimiter;
 
@@ -6395,8 +6415,8 @@ ntsa::Error StreamSocket::setWriteQueueLowWatermark(bsl::size_t lowWatermark)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_sendQueue.setLowWatermark(lowWatermark);
 
@@ -6434,8 +6454,8 @@ ntsa::Error StreamSocket::setWriteQueueHighWatermark(bsl::size_t highWatermark)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_sendQueue.setHighWatermark(highWatermark);
 
@@ -6474,8 +6494,8 @@ ntsa::Error StreamSocket::setWriteQueueWatermarks(bsl::size_t lowWatermark,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_sendQueue.setLowWatermark(lowWatermark);
     d_sendQueue.setHighWatermark(highWatermark);
@@ -6547,8 +6567,8 @@ ntsa::Error StreamSocket::setReadRateLimiter(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_receiveRateLimiter_sp = rateLimiter;
 
@@ -6576,8 +6596,8 @@ ntsa::Error StreamSocket::setReadQueueLowWatermark(bsl::size_t lowWatermark)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_receiveQueue.setLowWatermark(lowWatermark);
 
@@ -6617,8 +6637,8 @@ ntsa::Error StreamSocket::setReadQueueHighWatermark(bsl::size_t highWatermark)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_receiveQueue.setHighWatermark(highWatermark);
 
@@ -6643,8 +6663,8 @@ ntsa::Error StreamSocket::setReadQueueWatermarks(bsl::size_t lowWatermark,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     d_receiveQueue.setLowWatermark(lowWatermark);
     d_receiveQueue.setHighWatermark(highWatermark);
@@ -6695,8 +6715,8 @@ ntsa::Error StreamSocket::relaxFlowControl(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     return this->privateRelaxFlowControl(self, direction, true, true);
 }
@@ -6712,8 +6732,8 @@ ntsa::Error StreamSocket::applyFlowControl(
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (direction == ntca::FlowControlType::e_SEND ||
         direction == ntca::FlowControlType::e_BOTH)
@@ -6754,8 +6774,8 @@ ntsa::Error StreamSocket::cancel(const ntca::ConnectToken& token)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (d_connectInProgress) {
         this->privateFailConnect(self,
@@ -6780,8 +6800,8 @@ ntsa::Error StreamSocket::cancel(const ntca::UpgradeToken& token)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (d_upgradeInProgress) {
         ntca::UpgradeContext upgradeContext;
@@ -6829,8 +6849,8 @@ ntsa::Error StreamSocket::cancel(const ntca::SendToken& token)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     ntci::SendCallback callback;
     ntca::SendContext  context;
@@ -6876,8 +6896,8 @@ ntsa::Error StreamSocket::cancel(const ntca::ReceiveToken& token)
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     bsl::shared_ptr<ntcq::ReceiveCallbackQueueEntry> callbackEntry;
     ntsa::Error                                      error =
@@ -6886,7 +6906,7 @@ ntsa::Error StreamSocket::cancel(const ntca::ReceiveToken& token)
         ntca::ReceiveContext receiveContext;
         receiveContext.setError(ntsa::Error(ntsa::Error::e_CANCELLED));
         receiveContext.setTransport(d_transport);
-        receiveContext.setEndpoint(d_remoteEndpoint);
+        receiveContext.setEndpoint(d_systemRemoteEndpoint);
 
         ntca::ReceiveEvent receiveEvent;
         receiveEvent.setType(ntca::ReceiveEventType::e_ERROR);
@@ -6917,8 +6937,8 @@ ntsa::Error StreamSocket::downgrade()
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (!d_encryption_sp) {
         return ntsa::Error::invalid();
@@ -7012,8 +7032,8 @@ ntsa::Error StreamSocket::shutdown(ntsa::ShutdownType::Value direction,
     NTCI_LOG_CONTEXT();
 
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
-    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
-    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_remoteEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
+    NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
     if (d_detachState.mode() == ntcs::DetachMode::e_INITIATED) {
         d_deferredCalls.push_back(
@@ -7213,14 +7233,16 @@ ntsa::Transport::Value StreamSocket::transport() const
 
 ntsa::Endpoint StreamSocket::sourceEndpoint() const
 {
-    LockGuard lock(&d_mutex);
-    return d_sourceEndpoint;
+    ntsa::Endpoint result;
+    d_publicSourceEndpoint.load(&result);
+    return result;
 }
 
 ntsa::Endpoint StreamSocket::remoteEndpoint() const
 {
-    LockGuard lock(&d_mutex);
-    return d_remoteEndpoint;
+    ntsa::Endpoint result;
+    d_publicRemoteEndpoint.load(&result);
+    return result;
 }
 
 bsl::shared_ptr<ntci::EncryptionCertificate> StreamSocket::sourceCertificate()

--- a/groups/ntc/ntcr/ntcr_streamsocket.h
+++ b/groups/ntc/ntcr/ntcr_streamsocket.h
@@ -92,11 +92,13 @@ class StreamSocket : public ntci::StreamSocket,
 
     ntccfg::Object                             d_object;
     mutable Mutex                              d_mutex;
-    ntsa::Handle                               d_systemHandle;
-    ntsa::Handle                               d_publicHandle;
     ntsa::Transport::Value                     d_transport;
-    ntsa::Endpoint                             d_sourceEndpoint;
-    ntsa::Endpoint                             d_remoteEndpoint;
+    ntsa::Handle                               d_systemHandle;
+    ntsa::Endpoint                             d_systemSourceEndpoint;
+    ntsa::Endpoint                             d_systemRemoteEndpoint;
+    ntsa::Handle                               d_publicHandle;
+    ntccfg::Safe<ntsa::Endpoint>               d_publicSourceEndpoint;
+    ntccfg::Safe<ntsa::Endpoint>               d_publicRemoteEndpoint;
     bsl::shared_ptr<ntsi::StreamSocket>        d_socket_sp;
     bsl::shared_ptr<ntci::ListenerSocket>      d_acceptor_sp;
     bsl::shared_ptr<ntci::Encryption>          d_encryption_sp;


### PR DESCRIPTION
Current, `ntci::StreamSocket::sourceEndpoint()` and `ntci::StreamSocket::remoteEndpoint()` require locking the same mutex that protects the other socket state. This causes threads to potentially wait unnecessarily. The source and remote endpoints rarely change over the lifetime of the socket object. This PR introduces specific mutexes for endpoint state so this source of contention in reduced.