### PR TITLE
Fix bug in ntci::ListenerSocket shutdown sequence deferencing an invalid ntsi::ListenerSocket

### DIFF
--- a/groups/ntc/ntccfg/ntccfg_platform.h
+++ b/groups/ntc/ntccfg/ntccfg_platform.h
@@ -281,6 +281,7 @@ public:
 };
 
 template <typename TYPE>
+NTCCFG_INLINE
 Safe<TYPE>::Safe(bslma::Allocator* basicAllocator)
 : d_mutex()
 , d_proxy(basicAllocator)
@@ -288,6 +289,7 @@ Safe<TYPE>::Safe(bslma::Allocator* basicAllocator)
 }
 
 template <typename TYPE>
+NTCCFG_INLINE
 Safe<TYPE>::Safe(const TYPE& value, bslma::Allocator* basicAllocator)
 : d_mutex()
 , d_proxy(basicAllocator)
@@ -296,6 +298,7 @@ Safe<TYPE>::Safe(const TYPE& value, bslma::Allocator* basicAllocator)
 }
 
 template <typename TYPE>
+NTCCFG_INLINE
 Safe<TYPE>::Safe(const Safe& original, bslma::Allocator* basicAllocator)
 : d_mutex()
 , d_proxy(basicAllocator)
@@ -304,11 +307,13 @@ Safe<TYPE>::Safe(const Safe& original, bslma::Allocator* basicAllocator)
 }
 
 template <typename TYPE>
+NTCCFG_INLINE
 Safe<TYPE>::~Safe()
 {
 }
 
 template <typename TYPE>
+NTCCFG_INLINE
 Safe<TYPE>& Safe<TYPE>::operator=(const Safe& other)
 {
     if (this != &other) {
@@ -319,6 +324,7 @@ Safe<TYPE>& Safe<TYPE>::operator=(const Safe& other)
 }
 
 template <typename TYPE>
+NTCCFG_INLINE
 Safe<TYPE>& Safe<TYPE>::operator=(const TYPE& value)
 {
     this->store(value);
@@ -326,6 +332,7 @@ Safe<TYPE>& Safe<TYPE>::operator=(const TYPE& value)
 }
 
 template <typename TYPE>
+NTCCFG_INLINE
 void Safe<TYPE>::reset()
 {
     ntccfg::LockGuard lock(&d_mutex);
@@ -333,6 +340,7 @@ void Safe<TYPE>::reset()
 }
 
 template <typename TYPE>
+NTCCFG_INLINE
 void Safe<TYPE>::store(const Safe& other)
 {
     if (&d_mutex < &other.d_mutex) {
@@ -348,6 +356,7 @@ void Safe<TYPE>::store(const Safe& other)
 }
 
 template <typename TYPE>
+NTCCFG_INLINE
 void Safe<TYPE>::store(const TYPE& value)
 {
     ntccfg::LockGuard lock(&d_mutex);
@@ -355,6 +364,7 @@ void Safe<TYPE>::store(const TYPE& value)
 }
 
 template <typename TYPE>
+NTCCFG_INLINE
 void Safe<TYPE>::load(TYPE* result) const
 {
     ntccfg::LockGuard lock(&d_mutex);

--- a/groups/ntc/ntcp/ntcp_datagramsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_datagramsocket.cpp
@@ -1058,12 +1058,12 @@ void DatagramSocket::privateShutdownSequence(
     }
 
     if (!asyncDetachInitiated) {
-        privateShutdownSequencePart2(self, context, defer);
+        privateShutdownSequenceComplete(self, context, defer);
     }
     else {
         BSLS_ASSERT(!d_deferredCall);
         d_deferredCall =
-            NTCCFG_BIND(&DatagramSocket::privateShutdownSequencePart2,
+            NTCCFG_BIND(&DatagramSocket::privateShutdownSequenceComplete,
                         this,
                         self,
                         context,
@@ -1071,7 +1071,7 @@ void DatagramSocket::privateShutdownSequence(
     }
 }
 
-void DatagramSocket::privateShutdownSequencePart2(
+void DatagramSocket::privateShutdownSequenceComplete(
     const bsl::shared_ptr<DatagramSocket>& self,
     const ntcs::ShutdownContext&           context,
     bool                                   defer)
@@ -1307,11 +1307,13 @@ void DatagramSocket::privateShutdownSequencePart2(
             }
         }
 
-        if (d_detachState.goal() == ntcs::DetachGoal::e_CLOSE) {
-            d_socket_sp->close();
-        }
-        else {
-            d_socket_sp->release();
+        if (d_socket_sp) {
+            if (d_detachState.goal() == ntcs::DetachGoal::e_CLOSE) {
+                d_socket_sp->close();
+            }
+            else {
+                d_socket_sp->release();
+            }
         }
 
         d_systemHandle = ntsa::k_INVALID_HANDLE;

--- a/groups/ntc/ntcp/ntcp_datagramsocket.h
+++ b/groups/ntc/ntcp/ntcp_datagramsocket.h
@@ -250,7 +250,7 @@ class DatagramSocket : public ntci::DatagramSocket,
 
     /// Execute the second part of shutdown sequence when the socket is
     /// detached. See also "privateShutdownSequence"
-    void privateShutdownSequencePart2(
+    void privateShutdownSequenceComplete(
         const bsl::shared_ptr<DatagramSocket>& self,
         const ntcs::ShutdownContext&           context,
         bool                                   defer);

--- a/groups/ntc/ntcp/ntcp_listenersocket.cpp
+++ b/groups/ntc/ntcp/ntcp_listenersocket.cpp
@@ -797,12 +797,12 @@ void ListenerSocket::privateShutdownSequence(
     }
 
     if (!asyncDetachmentStarted) {
-        privateShutdownSequencePart2(self, context, defer);
+        privateShutdownSequenceComplete(self, context, defer);
     }
     else {
         BSLS_ASSERT(!d_deferredCall);
         d_deferredCall =
-            NTCCFG_BIND(&ListenerSocket::privateShutdownSequencePart2,
+            NTCCFG_BIND(&ListenerSocket::privateShutdownSequenceComplete,
                         this,
                         self,
                         context,
@@ -810,7 +810,7 @@ void ListenerSocket::privateShutdownSequence(
     }
 }
 
-void ListenerSocket::privateShutdownSequencePart2(
+void ListenerSocket::privateShutdownSequenceComplete(
     const bsl::shared_ptr<ListenerSocket>& self,
     const ntcs::ShutdownContext&           context,
     bool                                   defer)
@@ -989,11 +989,13 @@ void ListenerSocket::privateShutdownSequencePart2(
             }
         }
 
-        if (d_detachState.goal() == ntcs::DetachGoal::e_CLOSE) {
-            d_socket_sp->close();
-        }
-        else {
-            d_socket_sp->release();
+        if (d_socket_sp) {
+            if (d_detachState.goal() == ntcs::DetachGoal::e_CLOSE) {
+                d_socket_sp->close();
+            }
+            else {
+                d_socket_sp->release();
+            }
         }
 
         d_systemHandle = ntsa::k_INVALID_HANDLE;

--- a/groups/ntc/ntcp/ntcp_listenersocket.h
+++ b/groups/ntc/ntcp/ntcp_listenersocket.h
@@ -204,7 +204,7 @@ class ListenerSocket : public ntci::ListenerSocket,
 
     /// Execute the second part of shutdown sequence when the socket is
     /// detached. See also "privateShutdownSequence"
-    void privateShutdownSequencePart2(
+    void privateShutdownSequenceComplete(
         const bsl::shared_ptr<ListenerSocket>& self,
         const ntcs::ShutdownContext&           context,
         bool                                   defer);

--- a/groups/ntc/ntcp/ntcp_streamsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.cpp
@@ -421,7 +421,7 @@ void StreamSocket::processConnectRetryTimer(
         if (d_connectInProgress) {
             if (d_connectAttempts > 0) {
                 d_retryConnect =
-                    true;  // privateRetryConnect will be called in privateFailConnectPart2
+                    true;  // privateRetryConnect will be called in privateFailConnectComplete
                 if (d_detachState.mode() !=
                     ntcs::DetachMode::e_INITIATED)
                 {
@@ -938,7 +938,7 @@ void StreamSocket::privateFailConnect(
                             ntcs::DetachMode::e_INITIATED);
                         BSLS_ASSERT(!d_deferredCall);
                         d_deferredCall =
-                            NTCCFG_BIND(&StreamSocket::privateFailConnectPart2,
+                            NTCCFG_BIND(&StreamSocket::privateFailConnectComplete,
                                         this,
                                         self,
                                         connectCallback,
@@ -969,7 +969,7 @@ void StreamSocket::privateFailConnect(
                         d_detachState.setMode(
                             ntcs::DetachMode::e_INITIATED);
                         d_deferredCall =
-                            NTCCFG_BIND(&StreamSocket::privateFailConnectPart2,
+                            NTCCFG_BIND(&StreamSocket::privateFailConnectComplete,
                                         this,
                                         self,
                                         connectCallback,
@@ -985,7 +985,7 @@ void StreamSocket::privateFailConnect(
         if (NTCCFG_UNLIKELY(d_detachState.mode() !=
                             ntcs::DetachMode::e_INITIATED))
         {
-            privateFailConnectPart2(self,
+            privateFailConnectComplete(self,
                                     connectCallback,
                                     connectEvent,
                                     defer);
@@ -999,7 +999,7 @@ void StreamSocket::privateFailConnect(
     }
 }
 
-void StreamSocket::privateFailConnectPart2(
+void StreamSocket::privateFailConnectComplete(
     const bsl::shared_ptr<StreamSocket>& self,
     const ntci::ConnectCallback&         connectCallback,
     const ntca::ConnectEvent&            connectEvent,
@@ -1951,12 +1951,12 @@ void StreamSocket::privateShutdownSequence(
     }
 
     if (!asyncDetachmentStarted) {
-        privateShutdownSequencePart2(self, context, defer);
+        privateShutdownSequenceComplete(self, context, defer);
     }
     else {
         BSLS_ASSERT(!d_deferredCall);
         d_deferredCall =
-            NTCCFG_BIND(&StreamSocket::privateShutdownSequencePart2,
+            NTCCFG_BIND(&StreamSocket::privateShutdownSequenceComplete,
                         this,
                         self,
                         context,
@@ -1964,7 +1964,7 @@ void StreamSocket::privateShutdownSequence(
     }
 }
 
-void StreamSocket::privateShutdownSequencePart2(
+void StreamSocket::privateShutdownSequenceComplete(
     const bsl::shared_ptr<StreamSocket>& self,
     const ntcs::ShutdownContext&         context,
     bool                                 defer)

--- a/groups/ntc/ntcp/ntcp_streamsocket.h
+++ b/groups/ntc/ntcp/ntcp_streamsocket.h
@@ -248,7 +248,7 @@ class StreamSocket : public ntci::StreamSocket,
 
     /// Execute the second part of connection failure processing when the
     /// socket is detached. See also "privateFailConnect"
-    void privateFailConnectPart2(const bsl::shared_ptr<StreamSocket>& self,
+    void privateFailConnectComplete(const bsl::shared_ptr<StreamSocket>& self,
                                  const ntci::ConnectCallback& connectCallback,
                                  const ntca::ConnectEvent&    connectEvent,
                                  bool                         defer);
@@ -342,7 +342,7 @@ class StreamSocket : public ntci::StreamSocket,
 
     /// Execute the second part of shutdown sequence when the socket is
     /// detached. See also "privateShutdownSequence"
-    void privateShutdownSequencePart2(
+    void privateShutdownSequenceComplete(
         const bsl::shared_ptr<StreamSocket>& self,
         const ntcs::ShutdownContext&         context,
         bool                                 defer);

--- a/groups/ntc/ntcr/ntcr_datagramsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.cpp
@@ -1597,11 +1597,13 @@ void DatagramSocket::privateShutdownSequenceComplete(
             }
         }
 
-        if (d_detachState.goal() == ntcs::DetachGoal::e_CLOSE) {
-            d_socket_sp->close();
-        }
-        else {
-            d_socket_sp->release();
+        if (d_socket_sp) {
+            if (d_detachState.goal() == ntcs::DetachGoal::e_CLOSE) {
+                d_socket_sp->close();
+            }
+            else {
+                d_socket_sp->release();
+            }
         }
 
         d_systemHandle = ntsa::k_INVALID_HANDLE;

--- a/groups/ntc/ntcr/ntcr_listenersocket.cpp
+++ b/groups/ntc/ntcr/ntcr_listenersocket.cpp
@@ -815,11 +815,13 @@ void ListenerSocket::privateShutdownSequenceComplete(
             }
         }
 
-        if (d_detachState.goal() == ntcs::DetachGoal::e_CLOSE) {
-            d_socket_sp->close();
-        }
-        else {
-            d_socket_sp->release();
+        if (d_socket_sp) {
+            if (d_detachState.goal() == ntcs::DetachGoal::e_CLOSE) {
+                d_socket_sp->close();
+            }
+            else {
+                d_socket_sp->release();
+            }
         }
 
         d_systemHandle = ntsa::k_INVALID_HANDLE;


### PR DESCRIPTION
The current test suite in `ntcf::SystemTest::verifyClose()` correctly tested various conditions in which an asynchronous `ntci::StreamSocket` should close properly, even if the underlying socket handle is invalid. However, this test case failed to excercise the same functionality under similar conditions for `ntci::DatagramSocket` and `ntci::ListenerSocket`. This allowed a regression introduced during the implementation of `ntci::ListenerSocket::release()` (to export the socket handle underlying the `ntci::ListenerSocket`). This regression deferenced a null pointer in the case when the automatic binding of the listener socket during `ntci::ListenerSocket::open()` fails (and also in some related "startup" failure cases.) 

This PR fixes this bug by guarding each of the sockets in `ntcr` and `ntcp` similar to how `ntcr::StreamSocket` and `ntcp::StreamSocket` guard against a never-successfully-created internal `ntsi` socket during their shutdown sequences. Additional cases have been added to `ntcf::SystemTest::verifyClose()` to excercise that the asynchronous shutdown sequence completes successful under a variety of "startup" failure cases, for all types of datagram, stream, and listener sockets.