### PR TITLE
Re-validate permission to continue connecting after announce a connection initiated event

### DIFF
--- a/groups/ntc/ntcp/ntcp_streamsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.cpp
@@ -3393,6 +3393,20 @@ void StreamSocket::processRemoteEndpointResolution(
             self,
             false,
             &d_mutex);
+
+        if (NTCCFG_UNLIKELY(d_detachState.mode() == 
+                            ntcs::DetachMode::e_INITIATED))
+        {
+            return;
+        }
+
+        if (!d_connectInProgress) {
+            return;
+        }
+
+        if (connectAttempts != d_connectAttempts) {
+            return;
+        }
     }
 
     if (error) {

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -4261,6 +4261,20 @@ void StreamSocket::processRemoteEndpointResolution(
                 self,
                 false,
                 &d_mutex);
+
+            if (NTCCFG_UNLIKELY(d_detachState.mode() == 
+                                ntcs::DetachMode::e_INITIATED))
+            {
+                return;
+            }
+
+            if (!d_connectInProgress) {
+                return;
+            }
+
+            if (connectAttempts != d_connectAttempts) {
+                return;
+            }
         }
     }
 

--- a/groups/nts/ntscfg/ntscfg_test.h
+++ b/groups/nts/ntscfg/ntscfg_test.h
@@ -87,6 +87,7 @@ BSLS_IDENT("$Id: $")
 #include <bsl_vector.h>
 #include <ball_log.h>
 #include <ball_loggermanager.h>
+#include <ball_recordstringformatter.h>
 #include <ball_severity.h>
 #include <ball_streamobserver.h>
 
@@ -447,6 +448,16 @@ inline TestLog::TestLog(int verbosity, bslma::Allocator* basicAllocator)
 
     bsl::shared_ptr<ball::StreamObserver> observer;
     observer.createInplace(d_allocator_p, &bsl::cout, d_allocator_p);
+
+    // clang-format off
+    observer->setRecordFormatFunctor(
+        ball::RecordStringFormatter(
+            //"----------------------------------------"
+            "\n"
+            "[ %O ][ %s ]"
+            "[ %T ][ %F:%l ][ %c ]"
+            ":\n%m %u\n"));
+    // clang-format on
 
     rc = d_manager_p->registerObserver(observer, "default");
     BSLS_ASSERT_OPT(rc == 0);


### PR DESCRIPTION
A recent PR added the announcement of a new event immediately after `connect` to alert the user that a connection attempt has been initiated. This announce must unlock mutexes such as `ntcr::StreamSocket::d_mutex`, which allows another thread to close the socket before the thread announcing the connection was initiated can resume. This PR adds a validation after the announcement of the connection initiated event, to defend against erroneously proceeding with the connection sequence after the user has closed the socket.
