### PR TITLE
Allow the TLS handshake callback to synchronously downgrade the socket

### DIFF
--- a/groups/ntc/ntcp/ntcp_streamsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.cpp
@@ -1292,6 +1292,10 @@ void StreamSocket::privateCompleteReceive(
                                0,
                                d_receiveBlob_sp->length());
 
+        if (!d_encryption_sp) {
+            return;
+        }
+
         if (!d_receiveInflater_sp) {
             while (NTCCFG_LIKELY(d_encryption_sp->hasIncomingPlainText())) {
                 error = d_encryption_sp->popIncomingPlainText(

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -3126,6 +3126,10 @@ ntsa::Error StreamSocket::privateDequeueReceiveBuffer(
             return error;
         }
 
+        if (!d_encryption_sp) {
+            return ntsa::Error();
+        }
+
         bdlbb::BlobUtil::erase(d_receiveBlob_sp.get(),
                                0,
                                d_receiveBlob_sp->length());


### PR DESCRIPTION
This PR makes the usage of `ntci::Encryption` by `ntcr::StreamSocket` and `ntcp::StreamSocket` more robust by allow the TLS handshake callback to synchronously downgrade the socket.