### PR TITLE
Fix race calling 'getpeername() on a newly accepted socket to avoid completing accept operations with that socket

### DIFF
--- a/groups/ntc/ntcp/ntcp_streamsocket.cpp
+++ b/groups/ntc/ntcp/ntcp_streamsocket.cpp
@@ -3191,12 +3191,20 @@ ntsa::Error StreamSocket::privateOpen(
     ntsa::Endpoint sourceEndpoint;
     error = streamSocket->sourceEndpoint(&sourceEndpoint);
     if (error) {
+        if (acceptor) {
+            return error;
+        }
+
         sourceEndpoint.reset();
     }
 
     ntsa::Endpoint remoteEndpoint;
     error = streamSocket->remoteEndpoint(&remoteEndpoint);
     if (error) {
+        if (acceptor) {
+            return error;
+        }
+
         remoteEndpoint.reset();
     }
 

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -4054,12 +4054,20 @@ ntsa::Error StreamSocket::privateOpen(
     ntsa::Endpoint sourceEndpoint;
     error = streamSocket->sourceEndpoint(&sourceEndpoint);
     if (error) {
+        if (acceptor) {
+            return error;
+        }
+
         sourceEndpoint.reset();
     }
 
     ntsa::Endpoint remoteEndpoint;
     error = streamSocket->remoteEndpoint(&remoteEndpoint);
     if (error) {
+        if (acceptor) {
+            return error;
+        }
+
         remoteEndpoint.reset();
     }
 

--- a/groups/nts/ntsu/ntsu_socketutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.t.cpp
@@ -24,6 +24,7 @@ BSLS_IDENT_RCSID(ntsu_socketutil_t_cpp, "$Id$ $CSID$")
 #include <ntsu_socketoptionutil.h>
 #include <ntsu_socketutil.h>
 #include <ntsu_timestamputil.h>
+#include <ntsu_resolverutil.h>
 
 #if defined(BSLS_PLATFORM_OS_WINDOWS)
 #ifdef NTDDI_VERSION
@@ -1337,7 +1338,7 @@ void SocketUtilTest::testStreamSocketTransmissionWithControlMsgCoalesced(
 
     ntsa::Error error;
 
-    enum { 
+    enum {
         k_NUM_TRANSMISSIONS = 4,
         k_TRANSMISSION_SIZE = 10
     };
@@ -1347,11 +1348,11 @@ void SocketUtilTest::testStreamSocketTransmissionWithControlMsgCoalesced(
     for (bsl::size_t variation = 0; variation < 2; ++variation) {
         const bool exportHandles = (variation % 2 == 0);
 
-        NTSCFG_TEST_LOG_DEBUG << "Testing " 
+        NTSCFG_TEST_LOG_DEBUG << "Testing "
                               << transport
                               << ": writev/readv (blob) "
                               << "with ancillary data potentially coalesced "
-                              << "(export sockets: " << exportHandles << ")" 
+                              << "(export sockets: " << exportHandles << ")"
                               << NTSCFG_TEST_LOG_END;
 
         bsl::vector<ntsa::Handle> domesticSocketVector;
@@ -1390,8 +1391,8 @@ void SocketUtilTest::testStreamSocketTransmissionWithControlMsgCoalesced(
             s.append(k_TRANSMISSION_SIZE, '0' + (i % 10));
             NTSCFG_TEST_EQ(s.size(), k_TRANSMISSION_SIZE);
 
-            bsl::memcpy(sendBuffer + (k_TRANSMISSION_SIZE * i), 
-                        s.c_str(), 
+            bsl::memcpy(sendBuffer + (k_TRANSMISSION_SIZE * i),
+                        s.c_str(),
                         s.size());
         }
 
@@ -1404,7 +1405,7 @@ void SocketUtilTest::testStreamSocketTransmissionWithControlMsgCoalesced(
             }
 
             error = ntsu::SocketUtil::send(
-                &context, 
+                &context,
                 sendBuffer + (k_TRANSMISSION_SIZE * i),
                 k_TRANSMISSION_SIZE,
                 options,
@@ -1417,7 +1418,7 @@ void SocketUtilTest::testStreamSocketTransmissionWithControlMsgCoalesced(
 
         bslmt::ThreadUtil::sleep(bsls::TimeInterval(3));
 
-        const bsl::size_t numReceives = exportHandles ? 
+        const bsl::size_t numReceives = exportHandles ?
             (k_NUM_TRANSMISSIONS) : (k_NUM_TRANSMISSIONS / 2);
 
         bsl::size_t totalBytesReceived = 0;
@@ -1444,18 +1445,18 @@ void SocketUtilTest::testStreamSocketTransmissionWithControlMsgCoalesced(
                 NTSCFG_TEST_EQ(context.bytesReceived(), k_TRANSMISSION_SIZE);
                 NTSCFG_TEST_EQ(
                     bsl::memcmp(
-                        receiveBuffer, 
-                        sendBuffer + (k_TRANSMISSION_SIZE * i), 
-                        k_TRANSMISSION_SIZE), 
+                        receiveBuffer,
+                        sendBuffer + (k_TRANSMISSION_SIZE * i),
+                        k_TRANSMISSION_SIZE),
                     0);
             }
             else {
                 NTSCFG_TEST_EQ(context.bytesReceived(), sizeof receiveBuffer);
                 NTSCFG_TEST_EQ(
                     bsl::memcmp(
-                        receiveBuffer, 
-                        sendBuffer + (sizeof receiveBuffer * i), 
-                        sizeof receiveBuffer), 
+                        receiveBuffer,
+                        sendBuffer + (sizeof receiveBuffer * i),
+                        sizeof receiveBuffer),
                     0);
             }
 
@@ -1470,7 +1471,7 @@ void SocketUtilTest::testStreamSocketTransmissionWithControlMsgCoalesced(
                 error = ntsu::SocketUtil::sourceEndpoint(&foreignSourceEndpoint,
                                                         foreignSocket);
                 NTSCFG_TEST_OK(error);
-                NTSCFG_TEST_EQ(foreignSourceEndpoint, 
+                NTSCFG_TEST_EQ(foreignSourceEndpoint,
                             domesticSourceEndpointVector[i]);
             }
         }
@@ -1505,18 +1506,18 @@ void SocketUtilTest::testStreamSocketTransmissionWithControlMsgChunked(
 
     ntsa::Error error;
 
-    enum { 
+    enum {
         k_NUM_TRANSMISSIONS = 4,
         k_TRANSMISSION_SIZE = 10
     };
 
     BSLMF_ASSERT(k_NUM_TRANSMISSIONS % 2 == 0);
 
-    NTSCFG_TEST_LOG_DEBUG << "Testing " 
+    NTSCFG_TEST_LOG_DEBUG << "Testing "
                             << transport
                             << ": writev/readv (blob) "
                             << "with ancillary data potentially chunked "
-                            << "(export sockets: 1)" 
+                            << "(export sockets: 1)"
                             << NTSCFG_TEST_LOG_END;
 
     bsl::vector<ntsa::Handle> domesticSocketVector;
@@ -1553,8 +1554,8 @@ void SocketUtilTest::testStreamSocketTransmissionWithControlMsgChunked(
         s.append(k_TRANSMISSION_SIZE, '0' + (i % 10));
         NTSCFG_TEST_EQ(s.size(), k_TRANSMISSION_SIZE);
 
-        bsl::memcpy(sendBuffer + (k_TRANSMISSION_SIZE * i), 
-                    s.c_str(), 
+        bsl::memcpy(sendBuffer + (k_TRANSMISSION_SIZE * i),
+                    s.c_str(),
                     s.size());
     }
 
@@ -1565,7 +1566,7 @@ void SocketUtilTest::testStreamSocketTransmissionWithControlMsgChunked(
         options.setForeignHandle(domesticSocketVector[i]);
 
         error = ntsu::SocketUtil::send(
-            &context, 
+            &context,
             sendBuffer + (k_TRANSMISSION_SIZE * i),
             k_TRANSMISSION_SIZE,
             options,
@@ -1599,9 +1600,9 @@ void SocketUtilTest::testStreamSocketTransmissionWithControlMsgChunked(
         NTSCFG_TEST_EQ(context.bytesReceived(), k_TRANSMISSION_SIZE / 2);
         NTSCFG_TEST_EQ(
             bsl::memcmp(
-                receiveBuffer, 
-                sendBuffer + ((k_TRANSMISSION_SIZE / 2) * i), 
-                k_TRANSMISSION_SIZE / 2), 
+                receiveBuffer,
+                sendBuffer + ((k_TRANSMISSION_SIZE / 2) * i),
+                k_TRANSMISSION_SIZE / 2),
             0);
 
         totalBytesReceived += context.bytesReceived();
@@ -1615,7 +1616,7 @@ void SocketUtilTest::testStreamSocketTransmissionWithControlMsgChunked(
             error = ntsu::SocketUtil::sourceEndpoint(&foreignSourceEndpoint,
                                                      foreignSocket);
             NTSCFG_TEST_OK(error);
-            NTSCFG_TEST_EQ(foreignSourceEndpoint, 
+            NTSCFG_TEST_EQ(foreignSourceEndpoint,
                            domesticSourceEndpointVector[i / 2]);
         }
         else {
@@ -8715,127 +8716,223 @@ NTSCFG_TEST_FUNCTION(ntsu::SocketUtilTest::verifyCase34)
 
 NTSCFG_TEST_FUNCTION(ntsu::SocketUtilTest::verifyCase35)
 {
+    // Concern: If the peer shuts down or closes the socket after the
+    // connection is established but before the socket can be accepted from the
+    // listening socket's backlog, the '::accept()' function always succeeds
+    // and '::getpeername()' function succeeds unless the peer has performed an
+    // abortive close.
+
     BALL_LOG_SET_CATEGORY("NTSU.SOCKETUTIL.TEST");
 
     ntsa::Error error;
 
-    const bool abortiveClose   = false;
-    const bool shutdownSend    = true;
-    const bool shutdownReceive = true;
+    struct Data {
+        bool loopback;
+        bool shutdownSend;
+        bool shutdownReceive;
+        bool shutdownBoth;
+        bool abortiveClose;
+        bool success;
+    };
+
+    // clang-format off
+    const Data k_DATA[] = {
+        { true, false, false, false, false, true  },
+        { true, true,  false, false, false, true  },
+        { true, true,  true,  false, false, true  },
+        { true, false, false, true,  false, true  },
+        { true, false, false, false, true,  false }
+    };
+    // clang-format on
+
+    const bsl::size_t k_NUM_DATA =
+        sizeof(k_DATA) / sizeof(k_DATA[0]);
 
     const ntsa::Transport::Value transport =
         ntsa::Transport::e_TCP_IPV4_STREAM;
 
-    // Create a non-blocking socket for the listener.
+    ntsa::Ipv4Address localIpv4Address;
+    {
+        bsl::string localHostname;
+        error = ntsu::ResolverUtil::getHostname(&localHostname);
 
-    ntsa::Handle listener = ntsa::k_INVALID_HANDLE;
-    error = ntsu::SocketUtil::create(&listener, transport);
-    NTSCFG_TEST_OK(error);
+        BALL_LOG_DEBUG << "Local hostname = " << localHostname
+                       << BALL_LOG_END;
 
-    error = ntsu::SocketOptionUtil::setBlocking(listener, false);
-    NTSCFG_TEST_OK(error);
+        bsl::vector<ntsa::IpAddress> ipAddressList;
+        ntsa::IpAddressOptions       ipAddressOptions;
 
-    error = ntsu::SocketUtil::bind(
-        ntsa::Endpoint(ntsa::Ipv4Address::loopback(), 0),
-        false,
-        listener);
-    NTSCFG_TEST_OK(error);
+        ipAddressOptions.setIpAddressType(ntsa::IpAddressType::e_V4);
 
-    error = ntsu::SocketUtil::listen(1, listener);
-    NTSCFG_TEST_OK(error);
+        error = ntsu::ResolverUtil::getIpAddress(
+            &ipAddressList, localHostname, ipAddressOptions);
+        if (error) {
+            localIpv4Address = ntsa::Ipv4Address::loopback();
+        }
+        else {
+            NTSCFG_TEST_OK(error);
+            NTSCFG_TEST_GT(ipAddressList.size(), 0);
 
-    ntsa::Endpoint listenerEndpoint;
-    error = ntsu::SocketUtil::sourceEndpoint(&listenerEndpoint, listener);
-    NTSCFG_TEST_OK(error);
+            for (bsl::size_t i = 0; i < ipAddressList.size(); ++i) {
+                BALL_LOG_DEBUG << "Found IPv4 address = "
+                               << ipAddressList[i]
+                               << BALL_LOG_END;
+            }
 
-    // Create a blocking socket for the client, then connect that socket to
-    // the listener socket's local endpoint.
-
-    ntsa::Handle client = ntsa::k_INVALID_HANDLE;
-    error = ntsu::SocketUtil::create(&client, transport);
-    NTSCFG_TEST_OK(error);
-
-    error = ntsu::SocketOptionUtil::setBlocking(client, true);
-    NTSCFG_TEST_OK(error);
-
-    if (abortiveClose) {
-        error = ntsu::SocketOptionUtil::setLinger(client, 
-                                                  true, 
-                                                  bsls::TimeInterval(0));
-        NTSCFG_TEST_OK(error);
+            localIpv4Address = ipAddressList[0].v4();
+        }
     }
 
-    error = ntsu::SocketUtil::connect(listenerEndpoint, client);
-    NTSCFG_TEST_OK(error);
-
-    ntsa::Endpoint clientSourceEndpoint;
-    error = ntsu::SocketUtil::sourceEndpoint(&clientSourceEndpoint, client);
-    NTSCFG_TEST_OK(error);
-
-    ntsa::Endpoint clientRemoteEndpoint;
-    error = ntsu::SocketUtil::remoteEndpoint(&clientRemoteEndpoint, client);
-    NTSCFG_TEST_OK(error);
-
-    BALL_LOG_DEBUG << "Client sourceEndpoint = "
-                   << clientSourceEndpoint
-                   << ", remoteEndpoint = "
-                   << clientRemoteEndpoint
+    BALL_LOG_DEBUG << "Local IPv4 address = " << localIpv4Address
                    << BALL_LOG_END;
 
-    // Wait until the listener socket's backlog is non-empty.
+    for (bsl::size_t variation = 0; variation < k_NUM_DATA; ++variation) {
+        // Create a non-blocking socket for the listener.
 
-    error = ntsu::SocketUtil::waitUntilReadable(listener);
-    NTSCFG_TEST_OK(error);
-
-    if (shutdownSend) {
-        error = ntsu::SocketUtil::shutdown(
-            ntsa::ShutdownType::e_SEND, client);
+        ntsa::Handle listener = ntsa::k_INVALID_HANDLE;
+        error = ntsu::SocketUtil::create(&listener, transport);
         NTSCFG_TEST_OK(error);
-    }
 
-    if (shutdownReceive) {
-        error = ntsu::SocketUtil::shutdown(
-            ntsa::ShutdownType::e_RECEIVE, client);
+        error = ntsu::SocketOptionUtil::setBlocking(listener, false);
         NTSCFG_TEST_OK(error);
-    }
 
-    // Close the client socket.
+        if (k_DATA[variation].loopback) {
+            error = ntsu::SocketUtil::bind(
+                ntsa::Endpoint(ntsa::Ipv4Address::loopback(), 0),
+                false,
+                listener);
+            NTSCFG_TEST_OK(error);
+        }
+        else {
+            error = ntsu::SocketUtil::bind(
+                ntsa::Endpoint(localIpv4Address, 0),
+                false,
+                listener);
+            NTSCFG_TEST_OK(error);
+        }
 
-    error = ntsu::SocketUtil::close(client);
-    NTSCFG_TEST_OK(error);
+        error = ntsu::SocketUtil::listen(1, listener);
+        NTSCFG_TEST_OK(error);
 
-    bslmt::ThreadUtil::sleep(bsls::TimeInterval(1));
+        ntsa::Endpoint listenerEndpoint;
+        error = ntsu::SocketUtil::sourceEndpoint(&listenerEndpoint, listener);
+        NTSCFG_TEST_OK(error);
 
-    ntsa::Handle server = ntsa::k_INVALID_HANDLE;
-    error = ntsu::SocketUtil::accept(&server, listener);
-    NTSCFG_TEST_OK(error);
-    NTSCFG_TEST_NE(server, ntsa::k_INVALID_HANDLE);
+        // Create a blocking socket for the client, then connect that socket to
+        // the listener socket's local endpoint.
 
-    ntsa::Endpoint serverSourceEndpoint;
-    error = ntsu::SocketUtil::sourceEndpoint(&serverSourceEndpoint, server);
-    NTSCFG_TEST_OK(error);
+        ntsa::Handle client = ntsa::k_INVALID_HANDLE;
+        error = ntsu::SocketUtil::create(&client, transport);
+        NTSCFG_TEST_OK(error);
 
-    ntsa::Endpoint serverRemoteEndpoint;
-    error = ntsu::SocketUtil::remoteEndpoint(&serverRemoteEndpoint, server);
-    NTSCFG_TEST_OK(error);
+        error = ntsu::SocketOptionUtil::setBlocking(client, true);
+        NTSCFG_TEST_OK(error);
 
-    BALL_LOG_DEBUG << "Server sourceEndpoint = "
-                   << serverSourceEndpoint
-                   << ", remoteEndpoint = "
-                   << serverRemoteEndpoint
-                   << BALL_LOG_END;
+        if (k_DATA[variation].abortiveClose) {
+            error = ntsu::SocketOptionUtil::setLinger(client,
+                                                      true,
+                                                      bsls::TimeInterval(0));
+            NTSCFG_TEST_OK(error);
+        }
 
-    // Close the server socket.
+        ntsa::Endpoint connectEndpoint;
 
-    if (server != ntsa::k_INVALID_HANDLE) {
+        if (k_DATA[variation].loopback) {
+            connectEndpoint =
+                ntsa::Endpoint(
+                    ntsa::IpEndpoint(
+                        ntsa::Ipv4Address::loopback(),
+                        listenerEndpoint.ip().port()));
+        }
+        else {
+            connectEndpoint =
+                ntsa::Endpoint(
+                    ntsa::IpEndpoint(
+                        localIpv4Address,
+                        listenerEndpoint.ip().port()));
+        }
+
+        error = ntsu::SocketUtil::connect(connectEndpoint, client);
+        NTSCFG_TEST_OK(error);
+
+        ntsa::Endpoint clientSourceEndpoint;
+        error = ntsu::SocketUtil::sourceEndpoint(&clientSourceEndpoint, client);
+        NTSCFG_TEST_OK(error);
+
+        ntsa::Endpoint clientRemoteEndpoint;
+        error = ntsu::SocketUtil::remoteEndpoint(&clientRemoteEndpoint, client);
+        NTSCFG_TEST_OK(error);
+
+        BALL_LOG_DEBUG << "Client sourceEndpoint = "
+                       << clientSourceEndpoint
+                       << ", remoteEndpoint = "
+                       << clientRemoteEndpoint
+                       << BALL_LOG_END;
+
+        // Wait until the listener socket's backlog is non-empty.
+
+        error = ntsu::SocketUtil::waitUntilReadable(listener);
+        NTSCFG_TEST_OK(error);
+
+        if (k_DATA[variation].shutdownSend) {
+            error = ntsu::SocketUtil::shutdown(
+                ntsa::ShutdownType::e_SEND, client);
+            NTSCFG_TEST_OK(error);
+        }
+
+        if (k_DATA[variation].shutdownReceive) {
+            error = ntsu::SocketUtil::shutdown(
+                ntsa::ShutdownType::e_RECEIVE, client);
+            NTSCFG_TEST_OK(error);
+        }
+
+        if (k_DATA[variation].shutdownBoth) {
+            error = ntsu::SocketUtil::shutdown(
+                ntsa::ShutdownType::e_BOTH, client);
+            NTSCFG_TEST_OK(error);
+        }
+
+        // Close the client socket.
+
+        error = ntsu::SocketUtil::close(client);
+        NTSCFG_TEST_OK(error);
+
+        bslmt::ThreadUtil::sleep(bsls::TimeInterval(1));
+
+        ntsa::Handle server = ntsa::k_INVALID_HANDLE;
+        error = ntsu::SocketUtil::accept(&server, listener);
+        NTSCFG_TEST_OK(error);
+        NTSCFG_TEST_NE(server, ntsa::k_INVALID_HANDLE);
+
+        ntsa::Endpoint serverSourceEndpoint;
+        error = ntsu::SocketUtil::sourceEndpoint(&serverSourceEndpoint, server);
+        NTSCFG_TEST_OK(error);
+
+        ntsa::Endpoint serverRemoteEndpoint;
+        error = ntsu::SocketUtil::remoteEndpoint(&serverRemoteEndpoint, server);
+        if (k_DATA[variation].success) {
+            NTSCFG_TEST_OK(error);
+
+            BALL_LOG_DEBUG << "Server sourceEndpoint = "
+                           << serverSourceEndpoint
+                           << ", remoteEndpoint = "
+                           << serverRemoteEndpoint
+                           << BALL_LOG_END;
+        }
+        else {
+            BALL_LOG_ERROR << error << BALL_LOG_END;
+        }
+
+        // Close the server socket.
+
         error = ntsu::SocketUtil::close(server);
         NTSCFG_TEST_OK(error);
+
+        // Close the listener socket.
+
+        error = ntsu::SocketUtil::close(listener);
+        NTSCFG_TEST_OK(error);
     }
-
-    // Close the listener socket.
-
-    error = ntsu::SocketUtil::close(listener);
-    NTSCFG_TEST_OK(error);
 }
 
 }  // close namespace ntsu


### PR DESCRIPTION
On many operating systems, if the peer closes the connection before the socket can be accepted from a listening socket's backlog, the `::accept()` function might succeed but the `::getpeername()` function might fail (e.g. with ENOTCONN on Linux.) The current implementation has some defense for this: before completing an asynchronous accept operation or place a new `ntci::StreamSocket` on the accept queue, we first attempt to get the peer name of the newly accepted socket. If that fails, the socket is closed and user never sees it. This check is performed in `ntcr::ListenerSocket` and `ntcp::ListenerSocket`. 

However, this implementation has a race because the newly created `ntcr::StreamSocket` or `ntcp::StreamSocket` also calls `::getpeername()` to get the peer endpoint. This operation occurs in factored function that handles a bunch of cases: for new, unconnected sockets, for imported sockets, and for accepted sockets. Since for all cases other than known accepted sockets its likely or guaranteed that there is not yet any peer name associated with the socket this part of the implementation treats a failure of `getpeername()` as non-fatal to the opening of the new asynchronous socket object. This produces a race where the peer can close the socket after the first check in `ntcr::ListenerSocket::privateDequeueBacklog()` but before the second check in `ntcr::StreamSocket::privateOpen()`. If the peer closes the second in the middle of these two function calls, an accepted socket object is produced and potentially given to users with an "empty" remote endpoint. 

This PR fixes this race by treating `::getpeername()` failures as a failure to open newly accepted socket object.