### PR TITLE
Downgrade logging from timestamp correlation from WARN to TRACE

### DIFF
--- a/groups/ntc/ntcr/ntcr_datagramsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.cpp
@@ -184,10 +184,10 @@ BSLS_IDENT_RCSID(ntcr_datagramsocket_cpp, "$Id$ $CSID$")
                    "is shutting down transmission")
 
 #define NTCR_DATAGRAMSOCKET_LOG_TIMESTAMP_PROCESSING_ERROR()                  \
-    NTCI_LOG_WARN("Datagram socket timestamp processing error")
+    NTCI_LOG_TRACE("Datagram socket timestamp processing error")
 
 #define NTCR_DATAGRAMSOCKET_LOG_FAILED_TO_CORRELATE_TIMESTAMP(timestamp)      \
-    NTCI_LOG_WARN(                                                            \
+    NTCI_LOG_TRACE(                                                           \
         "Datagram socket failed to correlate timestamp ID %u type %s",        \
         timestamp.id(),                                                       \
         ntsa::TimestampType::toString(timestamp.type()));
@@ -763,8 +763,8 @@ void DatagramSocket::processSendDeadlineTimer(
         ntci::SendCallback callback;
         ntca::SendContext  context;
 
-        bool becameEmpty = d_sendQueue.removeEntryId(&callback, 
-                                                     &context, 
+        bool becameEmpty = d_sendQueue.removeEntryId(&callback,
+                                                     &context,
                                                      entryId);
         if (becameEmpty) {
             this->privateApplyFlowControl(self,
@@ -930,7 +930,7 @@ ntsa::Error DatagramSocket::privateSocketReadableIteration(
         receiveContext.setTransport(d_transport);
 
         bsl::shared_ptr<bdlbb::Blob> data;
-        
+
         {
             ntcq::ReceiveQueueEntry& entry = d_receiveQueue.frontEntry();
 
@@ -1035,7 +1035,7 @@ ntsa::Error DatagramSocket::privateSocketWritableIteration(
     ntcq::SendQueueEntry& entry = d_sendQueue.frontEntry();
 
     if (NTCCFG_LIKELY(entry.data())) {
-        ntsa::Handle foreignHandle = 
+        ntsa::Handle foreignHandle =
             entry.foreignHandle().value_or(ntsa::k_INVALID_HANDLE);
 
         ntsa::SendContext sendContext;
@@ -1284,12 +1284,12 @@ void DatagramSocket::privateShutdownSequence(
     // immeditiately by the reactor thread.
     //
     // TODO: Remove the 'defer' parameter and always defer the announcements.
-    // 
+    //
     // bool keepHalfOpen = NTCCFG_DEFAULT_DATAGRAM_SOCKET_KEEP_HALF_OPEN;
     // if (!d_options.keepHalfOpen().isNull()) {
     //     keepHalfOpen = d_options.keepHalfOpen().value();
     // }
-    // 
+    //
     // if (keepHalfOpen) {
     //     defer = true;
     // }
@@ -1399,7 +1399,7 @@ void DatagramSocket::privateShutdownSequenceComplete(
 
         NTCR_DATAGRAMSOCKET_LOG_SHUTDOWN_SEND();
 
-        typedef bsl::pair<ntca::SendContext, ntci::SendCallback> 
+        typedef bsl::pair<ntca::SendContext, ntci::SendCallback>
         SendContextCallback;
 
         bsl::vector<SendContextCallback> callbackVector;
@@ -1429,7 +1429,7 @@ void DatagramSocket::privateShutdownSequenceComplete(
                 announceWriteQueueDiscarded =
                     d_sendQueue.removeAll(&sendQueueEntryVector);
                 for (bsl::size_t i = 0; i < sendQueueEntryVector.size(); ++i) {
-                    const ntcq::SendQueueEntry& entry = 
+                    const ntcq::SendQueueEntry& entry =
                         sendQueueEntryVector[i];
                     if (entry.callback()) {
                         callbackVector.push_back(
@@ -2030,7 +2030,7 @@ ntsa::Error DatagramSocket::privateSend(
 
     ntsa::Error error;
 
-    ntsa::Handle foreignHandle = 
+    ntsa::Handle foreignHandle =
         options.foreignHandle().value_or(ntsa::k_INVALID_HANDLE);
 
     if (NTCCFG_LIKELY(!d_sendQueue.hasEntry())) {
@@ -2048,9 +2048,9 @@ ntsa::Error DatagramSocket::privateSend(
         else {
             if (sendContext.zeroCopy()) {
                 ntcq::ZeroCopyCounter zeroCopyCounter =
-                    d_zeroCopyQueue.push(state.counter(), 
-                                         data, 
-                                         setting, 
+                    d_zeroCopyQueue.push(state.counter(),
+                                         data,
+                                         setting,
                                          callback);
 
                 NTCCFG_WARNING_UNUSED(zeroCopyCounter);
@@ -2172,7 +2172,7 @@ ntsa::Error DatagramSocket::privateSend(
 
     ntsa::Error error;
 
-    ntsa::Handle foreignHandle = 
+    ntsa::Handle foreignHandle =
         options.foreignHandle().value_or(ntsa::k_INVALID_HANDLE);
 
     if (NTCCFG_LIKELY(!d_sendQueue.hasEntry())) {
@@ -2190,9 +2190,9 @@ ntsa::Error DatagramSocket::privateSend(
         else {
             if (sendContext.zeroCopy()) {
                 ntcq::ZeroCopyCounter zeroCopyCounter =
-                    d_zeroCopyQueue.push(state.counter(), 
-                                         data, 
-                                         setting, 
+                    d_zeroCopyQueue.push(state.counter(),
+                                         data,
+                                         setting,
                                          callback);
 
                 NTCCFG_WARNING_UNUSED(zeroCopyCounter);
@@ -2512,8 +2512,8 @@ ntsa::Error DatagramSocket::privateDequeueReceiveBuffer(
     }
     else {
         bsl::shared_ptr<bdlbb::Blob> deflatedData;
-        error = this->privateDequeueReceiveBufferRaw(self, 
-                                                     context, 
+        error = this->privateDequeueReceiveBufferRaw(self,
+                                                     context,
                                                      &deflatedData);
         if (error) {
             return error;
@@ -2526,16 +2526,16 @@ ntsa::Error DatagramSocket::privateDequeueReceiveBuffer(
             *data = d_dataPool_sp->createIncomingBlob();
         }
 
-        error = d_receiveInflater_sp->inflate(&inflateContext, 
-                                              data->get(), 
-                                              *deflatedData, 
+        error = d_receiveInflater_sp->inflate(&inflateContext,
+                                              data->get(),
+                                              *deflatedData,
                                               inflateOptions);
         if (error) {
             return error;
         }
 
         return ntsa::Error();
-    }  
+    }
 }
 
 ntsa::Error DatagramSocket::privateDequeueReceiveBufferRaw(
@@ -2829,9 +2829,9 @@ ntsa::Error DatagramSocket::privateOpen(
     }
 
     if (d_options.compressionConfig().has_value()) {
-        if (d_options.compressionConfig().value().type() != 
+        if (d_options.compressionConfig().value().type() !=
             ntca::CompressionType::e_UNDEFINED &&
-            d_options.compressionConfig().value().type() != 
+            d_options.compressionConfig().value().type() !=
             ntca::CompressionType::e_NONE)
         {
             bsl::shared_ptr<ntci::CompressionDriver> compressionDriver;
@@ -3677,9 +3677,9 @@ ntsa::Error DatagramSocket::send(const bdlbb::Blob&        data,
 
         bdlbb::Blob deflatedData(d_outgoingBufferFactory_sp.get());
 
-        error = d_sendDeflater_sp->deflate(&deflateContext, 
-                                           &deflatedData, 
-                                           data, 
+        error = d_sendDeflater_sp->deflate(&deflateContext,
+                                           &deflatedData,
+                                           data,
                                            deflateOptions);
         if (error) {
             return error;
@@ -3687,13 +3687,13 @@ ntsa::Error DatagramSocket::send(const bdlbb::Blob&        data,
 
         context.setCompressionType(deflateContext.compressionType());
         context.setCompressionRatio(
-            static_cast<double>(deflateContext.bytesWritten()) / 
+            static_cast<double>(deflateContext.bytesWritten()) /
             deflateContext.bytesRead());
 
-        return this->privateSend(self, 
-                                 deflatedData, 
-                                 state, 
-                                 options, 
+        return this->privateSend(self,
+                                 deflatedData,
+                                 state,
+                                 options,
                                  context,
                                  callback);
     }
@@ -3779,9 +3779,9 @@ ntsa::Error DatagramSocket::send(const ntsa::Data&         data,
 
         bdlbb::Blob deflatedData(d_outgoingBufferFactory_sp.get());
 
-        error = d_sendDeflater_sp->deflate(&deflateContext, 
-                                           &deflatedData, 
-                                           data, 
+        error = d_sendDeflater_sp->deflate(&deflateContext,
+                                           &deflatedData,
+                                           data,
                                            deflateOptions);
         if (error) {
             return error;
@@ -3789,13 +3789,13 @@ ntsa::Error DatagramSocket::send(const ntsa::Data&         data,
 
         context.setCompressionType(deflateContext.compressionType());
         context.setCompressionRatio(
-            static_cast<double>(deflateContext.bytesWritten()) / 
+            static_cast<double>(deflateContext.bytesWritten()) /
             deflateContext.bytesRead());
 
-        return this->privateSend(self, 
-                                 deflatedData, 
-                                 state, 
-                                 options, 
+        return this->privateSend(self,
+                                 deflatedData,
+                                 state,
+                                 options,
                                  context,
                                  callback);
     }
@@ -4749,8 +4749,8 @@ ntsa::Error DatagramSocket::cancel(const ntca::SendToken& token)
     ntci::SendCallback callback;
     ntca::SendContext  context;
 
-    bool becameEmpty = d_sendQueue.removeEntryToken(&callback, 
-                                                    &context, 
+    bool becameEmpty = d_sendQueue.removeEntryToken(&callback,
+                                                    &context,
                                                     token);
 
     if (becameEmpty) {
@@ -4842,7 +4842,7 @@ ntsa::Error DatagramSocket::release(ntsa::Handle* result)
     return this->release(result, ntci::CloseCallback());
 }
 
-ntsa::Error DatagramSocket::release(ntsa::Handle*              result, 
+ntsa::Error DatagramSocket::release(ntsa::Handle*              result,
                                     const ntci::CloseFunction& callback)
 {
     return this->release(
@@ -4853,7 +4853,7 @@ ntsa::Error DatagramSocket::release(ntsa::Handle*              result,
                                   const ntci::CloseCallback& callback)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
-    
+
     LockGuard lock(&d_mutex);
 
     *result = ntsa::k_INVALID_HANDLE;
@@ -4870,7 +4870,7 @@ ntsa::Error DatagramSocket::release(ntsa::Handle*              result,
 
     d_manager_sp.reset();
     d_session_sp.reset();
-    
+
     this->privateClose(self, callback);
 
     return ntsa::Error();

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -241,10 +241,10 @@ BSLS_IDENT_RCSID(ntcr_streamsocket_cpp, "$Id$ $CSID$")
                    "is shutting down transmission")
 
 #define NTCR_STREAMSOCKET_LOG_TIMESTAMP_PROCESSING_ERROR()                    \
-    NTCI_LOG_WARN("Stream socket timestamp processing error")
+    NTCI_LOG_TRACE("Stream socket timestamp processing error")
 
 #define NTCR_STREAMSOCKET_LOG_FAILED_TO_CORRELATE_TIMESTAMP(timestamp)        \
-    NTCI_LOG_WARN(                                                            \
+    NTCI_LOG_TRACE(                                                           \
         "Stream socket failed to correlate timestamp ID %u type %s",          \
         timestamp.id(),                                                       \
         ntsa::TimestampType::toString(timestamp.type()));
@@ -531,7 +531,7 @@ void StreamSocket::processConnectRetryTimer(
     if (event.type() == ntca::TimerEventType::e_DEADLINE) {
         if (d_connectInProgress) {
             if (d_connectAttempts > 0) {
-                d_retryConnect = true;  
+                d_retryConnect = true;
 
                 if (d_detachState.mode() !=
                     ntcs::DetachMode::e_INITIATED)
@@ -644,8 +644,8 @@ void StreamSocket::processSendDeadlineTimer(
         ntci::SendCallback callback;
         ntca::SendContext  context;
 
-        bool becameEmpty = d_sendQueue.removeEntryId(&callback, 
-                                                     &context, 
+        bool becameEmpty = d_sendQueue.removeEntryId(&callback,
+                                                     &context,
                                                      entryId);
         if (becameEmpty) {
             this->privateApplyFlowControl(self,
@@ -1208,9 +1208,9 @@ ntsa::Error StreamSocket::privateSocketWritableIterationBatch(
     ntsa::Error       error;
     ntsa::SendContext context;
 
-    error = this->privateEnqueueSendBuffer(self, 
-                                           &context, 
-                                           *d_sendData_sp, 
+    error = this->privateEnqueueSendBuffer(self,
+                                           &context,
+                                           *d_sendData_sp,
                                            ntsa::k_INVALID_HANDLE);
     if (NTCCFG_UNLIKELY(error)) {
         return error;
@@ -1218,7 +1218,7 @@ ntsa::Error StreamSocket::privateSocketWritableIterationBatch(
 
     bsl::size_t numBytesRemaining = context.bytesSent();
 
-    typedef bsl::pair<ntca::SendContext, ntci::SendCallback> 
+    typedef bsl::pair<ntca::SendContext, ntci::SendCallback>
     SendContextCallback;
 
     typedef bsl::vector<SendContextCallback>      SendCallbackVector;
@@ -1366,12 +1366,12 @@ ntsa::Error StreamSocket::privateSocketWritableIterationFront(
     ntcq::SendQueueEntry& entry = d_sendQueue.frontEntry();
 
     if (NTCCFG_LIKELY(entry.data())) {
-        ntsa::Handle foreignHandle = 
+        ntsa::Handle foreignHandle =
             entry.foreignHandle().value_or(ntsa::k_INVALID_HANDLE);
 
-        error = this->privateEnqueueSendBuffer(self, 
-                                               &context, 
-                                               *entry.data(), 
+        error = this->privateEnqueueSendBuffer(self,
+                                               &context,
+                                               *entry.data(),
                                                foreignHandle);
         if (NTCCFG_UNLIKELY(error)) {
             return error;
@@ -1409,7 +1409,7 @@ ntsa::Error StreamSocket::privateSocketWritableIterationFront(
 
         ntca::SendContext  setting;
         ntci::SendCallback callback;
-        
+
         if (context.bytesSent() == entry.length()) {
             NTCS_METRICS_UPDATE_WRITE_QUEUE_DELAY(entry.delay());
 
@@ -2096,7 +2096,7 @@ void StreamSocket::privateShutdownSequenceComplete(
 
         NTCR_STREAMSOCKET_LOG_SHUTDOWN_SEND();
 
-        typedef bsl::pair<ntca::SendContext, ntci::SendCallback> 
+        typedef bsl::pair<ntca::SendContext, ntci::SendCallback>
         SendContextCallback;
 
         bsl::vector<SendContextCallback> callbackVector;
@@ -2126,7 +2126,7 @@ void StreamSocket::privateShutdownSequenceComplete(
                 announceWriteQueueDiscarded =
                     d_sendQueue.removeAll(&sendQueueEntryVector);
                 for (bsl::size_t i = 0; i < sendQueueEntryVector.size(); ++i) {
-                    const ntcq::SendQueueEntry& entry = 
+                    const ntcq::SendQueueEntry& entry =
                         sendQueueEntryVector[i];
                     if (entry.callback()) {
                         callbackVector.push_back(
@@ -3148,9 +3148,9 @@ ntsa::Error StreamSocket::privateDequeueReceiveBuffer(
             }
 
             if (NTCCFG_UNLIKELY(
-                d_upgradeOptions.keepIncomingLeftovers().value_or(false))) 
+                d_upgradeOptions.keepIncomingLeftovers().value_or(false)))
             {
-                while (NTCCFG_LIKELY(d_encryption_sp->hasIncomingLeftovers())) 
+                while (NTCCFG_LIKELY(d_encryption_sp->hasIncomingLeftovers()))
                 {
                     downgradeAbortively = true;
 
@@ -3171,12 +3171,12 @@ ntsa::Error StreamSocket::privateDequeueReceiveBuffer(
             }
 
             if (NTCCFG_UNLIKELY(
-                d_upgradeOptions.keepIncomingLeftovers().value_or(false))) 
+                d_upgradeOptions.keepIncomingLeftovers().value_or(false)))
             {
-                while (NTCCFG_LIKELY(d_encryption_sp->hasIncomingLeftovers())) 
+                while (NTCCFG_LIKELY(d_encryption_sp->hasIncomingLeftovers()))
                 {
                     downgradeAbortively = true;
-                    
+
                     error = d_encryption_sp->popIncomingLeftovers(&plainText);
                     if (NTCCFG_UNLIKELY(error)) {
                         return error;
@@ -3290,7 +3290,7 @@ ntsa::Error StreamSocket::privateDequeueReceiveBuffer(
                 bdlbb::Blob cipherData(d_outgoingBufferFactory_sp.get());
 
                 while (NTCCFG_UNLIKELY(
-                    d_encryption_sp->hasOutgoingCipherText())) 
+                    d_encryption_sp->hasOutgoingCipherText()))
                 {
                     error = d_encryption_sp->popOutgoingCipherText(
                         &cipherData);
@@ -3502,13 +3502,13 @@ ntsa::Error StreamSocket::privateSendRaw(
     ntsa::Error       error;
     ntsa::SendContext context;
 
-    ntsa::Handle foreignHandle = 
+    ntsa::Handle foreignHandle =
         options.foreignHandle().value_or(ntsa::k_INVALID_HANDLE);
 
     if (NTCCFG_LIKELY(!d_sendQueue.hasEntry())) {
-        error = this->privateEnqueueSendBuffer(self, 
-                                               &context, 
-                                               data, 
+        error = this->privateEnqueueSendBuffer(self,
+                                               &context,
+                                               data,
                                                foreignHandle);
         if (NTCCFG_UNLIKELY(error)) {
             if (NTCCFG_UNLIKELY(error != ntsa::Error::e_WOULD_BLOCK)) {
@@ -3557,9 +3557,9 @@ ntsa::Error StreamSocket::privateSendRaw(
 
     if (context.zeroCopy()) {
         ntcq::ZeroCopyCounter zeroCopyCounter =
-            d_zeroCopyQueue.push(state.counter(), 
-                                 dataContainer, 
-                                 setting, 
+            d_zeroCopyQueue.push(state.counter(),
+                                 dataContainer,
+                                 setting,
                                  callback);
 
         NTCCFG_WARNING_UNUSED(zeroCopyCounter);
@@ -3638,12 +3638,12 @@ ntsa::Error StreamSocket::privateSendRaw(
     ntsa::Error       error;
     ntsa::SendContext context;
 
-    ntsa::Handle foreignHandle = 
+    ntsa::Handle foreignHandle =
         options.foreignHandle().value_or(ntsa::k_INVALID_HANDLE);
 
     if (NTCCFG_LIKELY(!d_sendQueue.hasEntry())) {
-        error = this->privateEnqueueSendBuffer(self, 
-                                               &context, 
+        error = this->privateEnqueueSendBuffer(self,
+                                               &context,
                                                data,
                                                foreignHandle);
         if (NTCCFG_UNLIKELY(error)) {
@@ -3696,9 +3696,9 @@ ntsa::Error StreamSocket::privateSendRaw(
 
     if (context.zeroCopy()) {
         ntcq::ZeroCopyCounter zeroCopyCounter =
-            d_zeroCopyQueue.push(state.counter(), 
-                                 dataContainer, 
-                                 setting, 
+            d_zeroCopyQueue.push(state.counter(),
+                                 dataContainer,
+                                 setting,
                                  callback);
 
         NTCCFG_WARNING_UNUSED(zeroCopyCounter);
@@ -3796,7 +3796,7 @@ ntsa::Error StreamSocket::privateSendEncrypted(
             return error;
         }
     }
-    else if (callback) {        
+    else if (callback) {
         ntca::SendEvent sendEvent;
         sendEvent.setType(ntca::SendEventType::e_COMPLETE);
         sendEvent.setContext(setting);
@@ -4011,9 +4011,9 @@ ntsa::Error StreamSocket::privateOpen(
     }
 
     if (d_options.compressionConfig().has_value()) {
-        if (d_options.compressionConfig().value().type() != 
+        if (d_options.compressionConfig().value().type() !=
             ntca::CompressionType::e_UNDEFINED &&
-            d_options.compressionConfig().value().type() != 
+            d_options.compressionConfig().value().type() !=
             ntca::CompressionType::e_NONE)
         {
             bsl::shared_ptr<ntci::CompressionDriver> compressionDriver;
@@ -4372,7 +4372,7 @@ void StreamSocket::processRemoteEndpointResolution(
                 false,
                 &d_mutex);
 
-            if (NTCCFG_UNLIKELY(d_detachState.mode() == 
+            if (NTCCFG_UNLIKELY(d_detachState.mode() ==
                                 ntcs::DetachMode::e_INITIATED))
             {
                 return;
@@ -4537,7 +4537,7 @@ ntsa::Error StreamSocket::privateDowngrade(
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
     NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
-    BSLS_ASSERT(downgradeOptions.abortive().isNull() || 
+    BSLS_ASSERT(downgradeOptions.abortive().isNull() ||
                 !downgradeOptions.abortive().value());
 
     if (!d_encryption_sp) {
@@ -4634,7 +4634,7 @@ ntsa::Error StreamSocket::privateDowngradeAbortively(
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
     NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
-    BSLS_ASSERT(downgradeOptions.abortive().has_value() && 
+    BSLS_ASSERT(downgradeOptions.abortive().has_value() &&
                 downgradeOptions.abortive().value());
 
     if (!d_encryption_sp) {
@@ -4654,8 +4654,8 @@ ntsa::Error StreamSocket::privateDowngradeAbortively(
         d_encryption_sp->popOutgoingCipherText(&data);
 
         NTCI_LOG_STREAM_WARN << "Failed to downgrade abortively: "
-                             << "pending outgoing ciphertext:\n" 
-                             << bdlbb::BlobUtilHexDumper(&data, 4096) 
+                             << "pending outgoing ciphertext:\n"
+                             << bdlbb::BlobUtilHexDumper(&data, 4096)
                              << NTCI_LOG_STREAM_END;
 
         return ntsa::Error::invalid();
@@ -6097,9 +6097,9 @@ ntsa::Error StreamSocket::send(const bdlbb::Blob&        data,
 
         bdlbb::Blob deflatedData(d_outgoingBufferFactory_sp.get());
 
-        error = d_sendDeflater_sp->deflate(&deflateContext, 
-                                           &deflatedData, 
-                                           data, 
+        error = d_sendDeflater_sp->deflate(&deflateContext,
+                                           &deflatedData,
+                                           data,
                                            deflateOptions);
         if (error) {
             return error;
@@ -6107,14 +6107,14 @@ ntsa::Error StreamSocket::send(const bdlbb::Blob&        data,
 
         context.setCompressionType(deflateContext.compressionType());
         context.setCompressionRatio(
-            static_cast<double>(deflateContext.bytesWritten()) / 
+            static_cast<double>(deflateContext.bytesWritten()) /
             deflateContext.bytesRead());
 
         if (NTCCFG_LIKELY(!d_encryption_sp)) {
-            return this->privateSendRaw(self, 
-                                        deflatedData, 
-                                        state, 
-                                        options, 
+            return this->privateSendRaw(self,
+                                        deflatedData,
+                                        state,
+                                        options,
                                         context,
                                         callback);
         }
@@ -6220,9 +6220,9 @@ ntsa::Error StreamSocket::send(const ntsa::Data&         data,
 
         bdlbb::Blob deflatedData(d_outgoingBufferFactory_sp.get());
 
-        error = d_sendDeflater_sp->deflate(&deflateContext, 
-                                           &deflatedData, 
-                                           data, 
+        error = d_sendDeflater_sp->deflate(&deflateContext,
+                                           &deflatedData,
+                                           data,
                                            deflateOptions);
         if (error) {
             return error;
@@ -6230,14 +6230,14 @@ ntsa::Error StreamSocket::send(const ntsa::Data&         data,
 
         context.setCompressionType(deflateContext.compressionType());
         context.setCompressionRatio(
-            static_cast<double>(deflateContext.bytesWritten()) / 
+            static_cast<double>(deflateContext.bytesWritten()) /
             deflateContext.bytesRead());
 
         if (NTCCFG_LIKELY(!d_encryption_sp)) {
-            return this->privateSendRaw(self, 
-                                        deflatedData, 
-                                        state, 
-                                        options, 
+            return this->privateSendRaw(self,
+                                        deflatedData,
+                                        state,
+                                        options,
                                         context,
                                         callback);
         }
@@ -7222,8 +7222,8 @@ ntsa::Error StreamSocket::cancel(const ntca::SendToken& token)
     ntci::SendCallback callback;
     ntca::SendContext  context;
 
-    bool becameEmpty = d_sendQueue.removeEntryToken(&callback, 
-                                                    &context, 
+    bool becameEmpty = d_sendQueue.removeEntryToken(&callback,
+                                                    &context,
                                                     token);
 
     if (becameEmpty) {
@@ -7360,7 +7360,7 @@ ntsa::Error StreamSocket::release(ntsa::Handle* result)
     return this->release(result, ntci::CloseCallback());
 }
 
-ntsa::Error StreamSocket::release(ntsa::Handle*              result, 
+ntsa::Error StreamSocket::release(ntsa::Handle*              result,
                                   const ntci::CloseFunction& callback)
 {
     return this->release(
@@ -7371,7 +7371,7 @@ ntsa::Error StreamSocket::release(ntsa::Handle*              result,
                                   const ntci::CloseCallback& callback)
 {
     bsl::shared_ptr<StreamSocket> self = this->getSelf(this);
-    
+
     LockGuard lock(&d_mutex);
 
     *result = ntsa::k_INVALID_HANDLE;


### PR DESCRIPTION
When timestamp information cannot be correlated because we've overflown our ring buffer this is an internal condition affecting quality of service, not an user error. Downgrade the log level from WARN to TRACE in these cases.
