### PR TITLE
Fix[ntco_kqueue.cpp]: use allocator on shutdown

### DIFF
--- a/groups/ntc/ntco/ntco_kqueue.cpp
+++ b/groups/ntc/ntco/ntco_kqueue.cpp
@@ -2451,7 +2451,8 @@ void Kqueue::clearTimers()
 
 void Kqueue::clearSockets()
 {
-    bsl::vector<bsl::shared_ptr<ntcs::RegistryEntry> > entryList;
+    bsl::vector<bsl::shared_ptr<ntcs::RegistryEntry> > entryList(
+                                                           d_allocator_p);
     d_registry.clear(&entryList, d_controllerDescriptorHandle);
 
     for (bsl::vector<bsl::shared_ptr<ntcs::RegistryEntry> >::iterator it =
@@ -2470,7 +2471,8 @@ void Kqueue::clear()
 {
     d_chronology.clear();
 
-    bsl::vector<bsl::shared_ptr<ntcs::RegistryEntry> > entryList;
+    bsl::vector<bsl::shared_ptr<ntcs::RegistryEntry> > entryList(
+                                                           d_allocator_p);
     d_registry.clear(&entryList, d_controllerDescriptorHandle);
 
     for (bsl::vector<bsl::shared_ptr<ntcs::RegistryEntry> >::iterator it =


### PR DESCRIPTION
```
(0): BloombergLP::bmqtst::LoggingAllocator::allocate(unsigned long)+0x48 at 0x10334c3c0 in bmqimp_application.t
(1): BloombergLP::bslma::Allocator::do_allocate(unsigned long, unsigned long)+0x1c at 0x1032e0054 in bmqimp_application.t
(2): bsl::vector<bsl::shared_ptr<BloombergLP::ntcs::RegistryEntry>, bsl::allocator<bsl::shared_ptr<BloombergLP::ntcs::RegistryEntry>>>::reserve(unsigned long)+0x48 at 0x103229064 in bmqimp_application.t
(3): BloombergLP::ntco::Kqueue::clear()+0x168 at 0x10322724c in bmqimp_application.t
(4): BloombergLP::ntcr::Interface::~Interface()+0x1a0 at 0x1031c1350 in bmqimp_application.t
(5): BloombergLP::bslma::SharedPtrRep::releaseRef()+0x54 at 0x1032e15bc in bmqimp_application.t
(6): bsl::shared_ptr<BloombergLP::ntci::Interface>::reset()+0x38 at 0x102ed92c0 in bmqimp_application.t
(7): BloombergLP::bmqio::NtcChannelFactory::~NtcChannelFactory()+0xb8 at 0x102f0110c in bmqimp_application.t
(8): BloombergLP::bmqio::NtcChannelFactory::~NtcChannelFactory()+0x1c at 0x102f019e0 in bmqimp_application.t
(9): BloombergLP::bmqimp::Application::~Application()+0x1c4 at 0x102d01a78 in bmqimp_application.t
(10): BloombergLP::bmqimp::Application::~Application()+0x1c at 0x102d01c88 in bmqimp_application.t
(11): test3_startStopAsyncTest()+0x4e0 at 0x102cf5f10 in bmqimp_application.t
(12): main+0x4c0 at 0x102cf552c in bmqimp_application.t
```

We've caught an unhandled default allocator usage on `ntcr::Interface` destruction