### PR TITLE
Add support for coroutines in MSVC

### DIFF
--- a/configure.cmd
+++ b/configure.cmd
@@ -133,6 +133,10 @@ IF NOT DEFINED NTF_CONFIGURE_WITH_OPENSSL (
     set NTF_CONFIGURE_WITH_OPENSSL=1
 )
 
+IF NOT DEFINED NTF_CONFIGURE_WITH_COROUTINES (
+    set NTF_CONFIGURE_WITH_COROUTINES=0
+)
+
 IF NOT DEFINED NTF_CONFIGURE_WITH_TIMESTAMPING (
     set NTF_CONFIGURE_WITH_TIMESTAMPING=0
 )
@@ -374,6 +378,9 @@ if not "%1"=="" (
         set NTF_CONFIGURE_WITH_OPENSSL=1
     )
 
+    if "%1"=="--with-coroutines" (
+        set NTF_CONFIGURE_WITH_COROUTINES=1
+    )
     if "%1"=="--with-dynamic-load-balancing" (
         set NTF_CONFIGURE_WITH_DYNAMIC_LOAD_BALANCING=1
     )
@@ -516,6 +523,9 @@ if not "%1"=="" (
         set NTF_CONFIGURE_WITH_OPENSSL=0
     )
 
+    if "%1"=="--without-coroutines" (
+        set NTF_CONFIGURE_WITH_COROUTINES=0
+    )
     if "%1"=="--without-dynamic-load-balancing" (
         set NTF_CONFIGURE_WITH_DYNAMIC_LOAD_BALANCING=0
     )

--- a/groups/nts/ntsa/ntsa_coroutine.h
+++ b/groups/nts/ntsa/ntsa_coroutine.h
@@ -406,8 +406,8 @@ class Coroutine::FunctionMapAwaiter
     using AwaiterType =
         typename Compiler::AwaitableTraits<AWAITABLE&&>::AwaiterType;
 
-    FUNCTION&&  m_function;
-    AwaiterType m_awaiter;
+    FUNCTION&&  d_function;
+    AwaiterType d_awaiter;
 
   public:
     FunctionMapAwaiter(FUNCTION&& function, AWAITABLE&& awaitable) noexcept;
@@ -438,8 +438,8 @@ class Coroutine::FunctionMapAwaitable
     auto operator co_await() && noexcept;
 
   private:
-    FUNCTION  m_function;
-    AWAITABLE m_awaitable;
+    FUNCTION  d_function;
+    AWAITABLE d_awaitable;
 };
 
 /// @internal @brief TODO
@@ -1713,7 +1713,7 @@ class Coroutine::JoinAwaitable<std::tuple<TASKS...> >
 
   private:
     JoinCounter          d_counter;
-    std::tuple<TASKS...> m_tasks;
+    std::tuple<TASKS...> d_tasks;
 };
 
 /// @internal @brief
@@ -1762,7 +1762,7 @@ class Coroutine::JoinAwaitable
     bool ready() const noexcept;
 
     JoinCounter d_counter;
-    CONTAINER   m_tasks;
+    CONTAINER   d_tasks;
 };
 
 /// @internal @brief
@@ -1943,8 +1943,8 @@ class Coroutine::Join
 template <typename FUNCTION, typename AWAITABLE>
 NTSCFG_INLINE Coroutine::FunctionMapAwaiter<FUNCTION, AWAITABLE>::
     FunctionMapAwaiter(FUNCTION&& function, AWAITABLE&& awaitable) noexcept
-: m_function(static_cast<FUNCTION&&>(function)),
-  m_awaiter(Compiler::getAwaiter(static_cast<AWAITABLE&&>(awaitable)))
+: d_function(static_cast<FUNCTION&&>(function)),
+  d_awaiter(Compiler::getAwaiter(static_cast<AWAITABLE&&>(awaitable)))
 {
 }
 
@@ -1952,7 +1952,7 @@ template <typename FUNCTION, typename AWAITABLE>
 NTSCFG_INLINE decltype(auto)
     Coroutine::FunctionMapAwaiter<FUNCTION, AWAITABLE>::await_ready() noexcept
 {
-    return static_cast<AwaiterType&&>(m_awaiter).await_ready();
+    return static_cast<AwaiterType&&>(d_awaiter).await_ready();
 }
 
 template <typename FUNCTION, typename AWAITABLE>
@@ -1961,7 +1961,7 @@ NTSCFG_INLINE decltype(auto)
     Coroutine::FunctionMapAwaiter<FUNCTION, AWAITABLE>::await_suspend(
         std::coroutine_handle<PROMISE> coroutine) noexcept
 {
-    return static_cast<AwaiterType&&>(m_awaiter).await_suspend(
+    return static_cast<AwaiterType&&>(d_awaiter).await_suspend(
         std::move(coroutine));
 }
 
@@ -1972,13 +1972,13 @@ NTSCFG_INLINE decltype(auto)
     if constexpr (std::is_void_v<decltype(
                       std::declval<AwaiterType>().await_resume())>)
     {
-        static_cast<AwaiterType&&>(m_awaiter).await_resume();
-        return std::invoke(static_cast<FUNCTION&&>(m_function));
+        static_cast<AwaiterType&&>(d_awaiter).await_resume();
+        return std::invoke(static_cast<FUNCTION&&>(d_function));
     }
     else {
         return std::invoke(
-            static_cast<FUNCTION&&>(m_function),
-            static_cast<AwaiterType&&>(m_awaiter).await_resume());
+            static_cast<FUNCTION&&>(d_function),
+            static_cast<AwaiterType&&>(d_awaiter).await_resume());
     }
 }
 
@@ -1987,8 +1987,8 @@ template <typename FUNCTION_ARG, typename AWAITABLE_ARG>
 NTSCFG_INLINE Coroutine::FunctionMapAwaitable<FUNCTION, AWAITABLE>::
     FunctionMapAwaitable(FUNCTION_ARG&&  function,
                          AWAITABLE_ARG&& awaitable) noexcept
-: m_function(static_cast<FUNCTION_ARG&&>(function)),
-  m_awaitable(static_cast<AWAITABLE_ARG&&>(awaitable))
+: d_function(static_cast<FUNCTION_ARG&&>(function)),
+  d_awaitable(static_cast<AWAITABLE_ARG&&>(awaitable))
 {
 }
 
@@ -1996,8 +1996,8 @@ template <typename FUNCTION, typename AWAITABLE>
 NTSCFG_INLINE auto Coroutine::FunctionMapAwaitable<FUNCTION, AWAITABLE>::
 operator co_await() const& noexcept
 {
-    return FunctionMapAwaiter<const FUNCTION&, const AWAITABLE&>(m_function,
-                                                                 m_awaitable);
+    return FunctionMapAwaiter<const FUNCTION&, const AWAITABLE&>(d_function,
+                                                                 d_awaitable);
 }
 
 template <typename FUNCTION, typename AWAITABLE>
@@ -2005,7 +2005,7 @@ template <typename FUNCTION, typename AWAITABLE>
     operator co_await() &
     noexcept
 {
-    return FunctionMapAwaiter<FUNCTION&, AWAITABLE&>(m_function, m_awaitable);
+    return FunctionMapAwaiter<FUNCTION&, AWAITABLE&>(d_function, d_awaitable);
 }
 
 template <typename FUNCTION, typename AWAITABLE>
@@ -2014,8 +2014,8 @@ template <typename FUNCTION, typename AWAITABLE>
     noexcept
 {
     return FunctionMapAwaiter<FUNCTION&&, AWAITABLE&&>(
-        static_cast<FUNCTION&&>(m_function),
-        static_cast<AWAITABLE&&>(m_awaitable));
+        static_cast<FUNCTION&&>(d_function),
+        static_cast<AWAITABLE&&>(d_awaitable));
 }
 
 template <typename FUNCTION>
@@ -3079,7 +3079,7 @@ NTSCFG_INLINE Coroutine::JoinAwaitable<std::tuple<TASKS...> >::JoinAwaitable(
     TASKS&&... tasks)
     noexcept(std::conjunction_v<std::is_nothrow_move_constructible<TASKS>...>)
 : d_counter(sizeof...(TASKS))
-, m_tasks(std::move(tasks)...)
+, d_tasks(std::move(tasks)...)
 {
 }
 
@@ -3088,14 +3088,14 @@ NTSCFG_INLINE Coroutine::JoinAwaitable<std::tuple<TASKS...> >::JoinAwaitable(
     std::tuple<TASKS...>&& tasks)
     noexcept(std::is_nothrow_move_constructible_v<std::tuple<TASKS...> >)
 : d_counter(sizeof...(TASKS))
-, m_tasks(std::move(tasks))
+, d_tasks(std::move(tasks))
 {
 }
 
 template <typename... TASKS>
 NTSCFG_INLINE Coroutine::JoinAwaitable<std::tuple<TASKS...> >::JoinAwaitable(
     JoinAwaitable&& other) noexcept : d_counter(sizeof...(TASKS)),
-                                      m_tasks(std::move(other.m_tasks))
+                                      d_tasks(std::move(other.d_tasks))
 {
 }
 
@@ -3110,27 +3110,27 @@ template <typename... TASKS>
     noexcept
 {
     struct Awaiter {
-        Awaiter(JoinAwaitable& awaitable) noexcept : m_awaitable(awaitable)
+        Awaiter(JoinAwaitable& awaitable) noexcept : d_awaitable(awaitable)
         {
         }
 
         bool await_ready() const noexcept
         {
-            return m_awaitable.ready();
+            return d_awaitable.ready();
         }
 
         bool await_suspend(std::coroutine_handle<void> coroutine) noexcept
         {
-            return m_awaitable.suspend(coroutine);
+            return d_awaitable.suspend(coroutine);
         }
 
         std::tuple<TASKS...>& await_resume() noexcept
         {
-            return m_awaitable.m_tasks;
+            return d_awaitable.d_tasks;
         }
 
       private:
-        JoinAwaitable& m_awaitable;
+        JoinAwaitable& d_awaitable;
     };
 
     return Awaiter{*this};
@@ -3142,27 +3142,27 @@ template <typename... TASKS>
     noexcept
 {
     struct Awaiter {
-        Awaiter(JoinAwaitable& awaitable) noexcept : m_awaitable(awaitable)
+        Awaiter(JoinAwaitable& awaitable) noexcept : d_awaitable(awaitable)
         {
         }
 
         bool await_ready() const noexcept
         {
-            return m_awaitable.ready();
+            return d_awaitable.ready();
         }
 
         bool await_suspend(std::coroutine_handle<void> coroutine) noexcept
         {
-            return m_awaitable.suspend(coroutine);
+            return d_awaitable.suspend(coroutine);
         }
 
         std::tuple<TASKS...>&& await_resume() noexcept
         {
-            return std::move(m_awaitable.m_tasks);
+            return std::move(d_awaitable.d_tasks);
         }
 
       private:
-        JoinAwaitable& m_awaitable;
+        JoinAwaitable& d_awaitable;
     };
 
     return Awaiter{*this};
@@ -3183,7 +3183,7 @@ NTSCFG_INLINE void Coroutine::JoinAwaitable<std::tuple<TASKS...> >::startup(
     std::integer_sequence<std::size_t, INDICES...>) noexcept
 {
     (void)std::initializer_list<int>{
-        (std::get<INDICES>(m_tasks).start(&d_counter), 0)...};
+        (std::get<INDICES>(d_tasks).start(&d_counter), 0)...};
 }
 
 template <typename... TASKS>
@@ -3196,7 +3196,7 @@ NTSCFG_INLINE bool Coroutine::JoinAwaitable<std::tuple<TASKS...> >::ready()
 template <typename CONTAINER>
 NTSCFG_INLINE Coroutine::JoinAwaitable<CONTAINER>::JoinAwaitable(
     CONTAINER&& tasks) noexcept : d_counter(tasks.size()),
-                                  m_tasks(std::forward<CONTAINER>(tasks))
+                                  d_tasks(std::forward<CONTAINER>(tasks))
 {
 }
 
@@ -3204,8 +3204,8 @@ template <typename CONTAINER>
 NTSCFG_INLINE Coroutine::JoinAwaitable<CONTAINER>::JoinAwaitable(
     JoinAwaitable&& other)
     noexcept(std::is_nothrow_move_constructible_v<CONTAINER>)
-: d_counter(other.m_tasks.size())
-, m_tasks(std::move(other.m_tasks))
+: d_counter(other.d_tasks.size())
+, d_tasks(std::move(other.d_tasks))
 {
 }
 
@@ -3223,27 +3223,27 @@ template <typename CONTAINER>
     {
       public:
         Awaiter(JoinAwaitable& awaitable)
-        : m_awaitable(awaitable)
+        : d_awaitable(awaitable)
         {
         }
 
         bool await_ready() const noexcept
         {
-            return m_awaitable.ready();
+            return d_awaitable.ready();
         }
 
         bool await_suspend(std::coroutine_handle<void> coroutine) noexcept
         {
-            return m_awaitable.suspend(coroutine);
+            return d_awaitable.suspend(coroutine);
         }
 
         CONTAINER& await_resume() noexcept
         {
-            return m_awaitable.m_tasks;
+            return d_awaitable.d_tasks;
         }
 
       private:
-        JoinAwaitable& m_awaitable;
+        JoinAwaitable& d_awaitable;
     };
 
     return Awaiter{*this};
@@ -3258,27 +3258,27 @@ template <typename CONTAINER>
     {
       public:
         Awaiter(JoinAwaitable& awaitable)
-        : m_awaitable(awaitable)
+        : d_awaitable(awaitable)
         {
         }
 
         bool await_ready() const noexcept
         {
-            return m_awaitable.ready();
+            return d_awaitable.ready();
         }
 
         bool await_suspend(std::coroutine_handle<void> coroutine) noexcept
         {
-            return m_awaitable.suspend(coroutine);
+            return d_awaitable.suspend(coroutine);
         }
 
         CONTAINER&& await_resume() noexcept
         {
-            return std::move(m_awaitable.m_tasks);
+            return std::move(d_awaitable.d_tasks);
         }
 
       private:
-        JoinAwaitable& m_awaitable;
+        JoinAwaitable& d_awaitable;
     };
 
     return Awaiter{*this};
@@ -3296,7 +3296,7 @@ NTSCFG_INLINE bool Coroutine::JoinAwaitable<CONTAINER>::suspend(
 template <typename CONTAINER>
 NTSCFG_INLINE void Coroutine::JoinAwaitable<CONTAINER>::startup()
 {
-    for (auto&& task : m_tasks) {
+    for (auto&& task : d_tasks) {
         task.start(&d_counter);
     }
 }

--- a/groups/nts/ntsa/ntsa_coroutine.t.cpp
+++ b/groups/nts/ntsa/ntsa_coroutine.t.cpp
@@ -96,37 +96,17 @@ class CoroutineTest
     // Return a coroutine executing the specified 'function'.
     static ntsa::Task<void> coMain(CoroutineTestFunction testFunction);
 
-    // A variable with no meaning except that its address is returned by some
-    // of the `returnInt` functions.
-    static int globalInt;
-
-    // A variable with no meaning except that its address is returned by some
-    // of the `returnString` functions.
-    static String globalString;
-
     // Return void.
     static void returnVoid();
 
     // Return an integer by value.
     static int returnInt();
 
-    // Return a reference to an integer.
-    static int& returnIntReference();
-
-    // Return a reference to a movable integer.
-    static int&& returnIntReferenceMovable();
-
     // Return the specified integer 'value' by value.
     static int returnIntLiteral(int value);
 
     // Return a string by value.
     static String returnString();
-
-    // Return a reference to a string.
-    static String& returnStringReference();
-
-    // Return a reference to a movable string.
-    static String&& returnStringReferenceMovable();
 
     // Return the specified string 'value' by value.
     static String returnStringLiteral(const String& value);
@@ -143,12 +123,6 @@ class CoroutineTest
     // Return an awaitable with an integer result type.
     static ntsa::Task<int> coReturnInt();
 
-    // Return an awaitable with a reference to an integer result type.
-    static ntsa::Task<int&> coReturnIntReference();
-
-    // Return an awaitable with a reference to a movable integer result type.
-    static ntsa::Task<int&&> coReturnIntReferenceMovable();
-
     // Return an awaitable with an integer result type whose value is the
     // specified 'value'.
     static ntsa::Task<int> coReturnIntLiteral(int value);
@@ -159,12 +133,6 @@ class CoroutineTest
 
     // Return an awaitable with a string result type.
     static ntsa::Task<String> coReturnString();
-
-    // Return an awaitable with a reference to a string result type.
-    static ntsa::Task<String&> coReturnStringReference();
-
-    // Return an awaitable with a reference to a movable string result type.
-    static ntsa::Task<String&&> coReturnStringReferenceMovable();
 
     // Return an awaitable with a string result type whose value is the
     // specified 'value'.
@@ -1935,9 +1903,6 @@ ntsa::Error CoroutineTest::Mechanism::cancel(int token)
     return ntsa::Error();
 }
 
-int                         ntsa::CoroutineTest::globalInt;
-ntsa::CoroutineTest::String ntsa::CoroutineTest::globalString;
-
 void ntsa::CoroutineTest::main(CoroutineTestFunction testFunction)
 {
     ntsa::CoroutineTest::Scope function("main");
@@ -1963,16 +1928,6 @@ int ntsa::CoroutineTest::returnInt()
     return 1;
 }
 
-int& ntsa::CoroutineTest::returnIntReference()
-{
-    return globalInt;
-}
-
-int&& ntsa::CoroutineTest::returnIntReferenceMovable()
-{
-    return bsl::move(globalInt);
-}
-
 int ntsa::CoroutineTest::returnIntLiteral(int value)
 {
     return value;
@@ -1981,17 +1936,6 @@ int ntsa::CoroutineTest::returnIntLiteral(int value)
 ntsa::CoroutineTest::String ntsa::CoroutineTest::returnString()
 {
     return ntsa::CoroutineTest::String();
-}
-
-ntsa::CoroutineTest::String& ntsa::CoroutineTest::returnStringReference()
-{
-    return globalString;
-}
-
-ntsa::CoroutineTest::String&& ntsa::CoroutineTest::
-    returnStringReferenceMovable()
-{
-    return bsl::move(globalString);
 }
 
 ntsa::Generator<int> ntsa::CoroutineTest::coGenerateInt()
@@ -2047,16 +1991,6 @@ ntsa::Task<int> ntsa::CoroutineTest::coReturnInt()
     co_return returnInt();
 }
 
-ntsa::Task<int&> ntsa::CoroutineTest::coReturnIntReference()
-{
-    co_return returnIntReference();
-}
-
-ntsa::Task<int&&> ntsa::CoroutineTest::coReturnIntReferenceMovable()
-{
-    co_return returnIntReferenceMovable();
-}
-
 ntsa::Task<int> ntsa::CoroutineTest::coReturnIntLiteral(int value)
 {
     co_return returnIntLiteral(value);
@@ -2081,18 +2015,6 @@ ntsa::Task<int> ntsa::CoroutineTest::coReturnIntChain(int lhs, int rhs)
 ntsa::Task<ntsa::CoroutineTest::String> ntsa::CoroutineTest::coReturnString()
 {
     co_return returnString();
-}
-
-ntsa::Task<ntsa::CoroutineTest::String&> ntsa::CoroutineTest::
-    coReturnStringReference()
-{
-    co_return returnStringReference();
-}
-
-ntsa::Task<ntsa::CoroutineTest::String&&> ntsa::CoroutineTest::
-    coReturnStringReferenceMovable()
-{
-    co_return returnStringReferenceMovable();
 }
 
 ntsa::Task<ntsa::CoroutineTest::String> ntsa::CoroutineTest::
@@ -2171,9 +2093,6 @@ ntsa::Task<void> CoroutineTest::coVerifyReturnString()
 {
     ntsa::CoroutineTest::Scope function("coVerifyReturnString");
 
-    // MRM: The temporary passed to 'coReturnStringLiteral' seems to be
-    // destroyed.
-
 #if 0
     // This doesn't work (the parameter temporary is destroyed too early).
     ntsa::Task<ntsa::CoroutineTest::String> task =
@@ -2198,9 +2117,6 @@ ntsa::Task<void> CoroutineTest::coVerifyReturnString()
 ntsa::Task<void> CoroutineTest::coVerifyReturnStringChain()
 {
     ntsa::CoroutineTest::Scope function("coVerifyReturnStringChain");
-
-    // MRM: The temporary passed to 'coReturnStringLiteral' seems to be
-    // destroyed.
 
 #if 0
     // This doesn't work (the parameter temporary is destroyed too early).
@@ -2595,24 +2511,6 @@ NTSCFG_TEST_FUNCTION(ntsa::CoroutineTest::verifyBasic)
         int f = ntsa::Coroutine::synchronize(bsl::move(t));
 
         NTSCFG_TEST_EQ(e, f);
-    }
-
-    {
-        int&             e = returnIntReference();
-        ntsa::Task<int&> t = coReturnIntReference();
-
-        int& f = ntsa::Coroutine::synchronize(bsl::move(t));
-
-        NTSCFG_TEST_EQ(&e, &f);
-    }
-
-    {
-        int&&             e = returnIntReferenceMovable();
-        ntsa::Task<int&&> t = coReturnIntReferenceMovable();
-
-        int&& f = ntsa::Coroutine::synchronize(bsl::move(t));
-
-        NTSCFG_TEST_EQ(&e, &f);
     }
 }
 

--- a/groups/nts/ntsa/ntsa_coroutine.t.cpp
+++ b/groups/nts/ntsa/ntsa_coroutine.t.cpp
@@ -1845,13 +1845,15 @@ CoroutineTest::Mechanism::Awaiter CoroutineTest::Mechanism::schedule()
 
 ntsa::Task<void> CoroutineTest::Mechanism::hello()
 {
-    bsl::cout << "Scheduling on thread " << bslmt::ThreadUtil::selfIdAsUint64()
-              << bsl::endl;
+    BALL_LOG_INFO << "Scheduling on thread " 
+                  << bslmt::ThreadUtil::selfIdAsUint64()
+                  << BALL_LOG_END;
 
     co_await this->schedule();
 
-    bsl::cout << "Executing on thread " << bslmt::ThreadUtil::selfIdAsUint64()
-              << bsl::endl;
+    BALL_LOG_INFO << "Executing on thread " 
+                  << bslmt::ThreadUtil::selfIdAsUint64()
+                  << BALL_LOG_END;
 }
 
 ntsa::Error CoroutineTest::Mechanism::execute(Result*           result,


### PR DESCRIPTION
This PR adjusts the previously committed coroutine support so that the implementation is accepted by the Microsoft Visual Studio compiler. Namely, support for `ntsa::Task<T&>` and `ntsa::Task<T&&>` has been dropped until the proper syntax in the implementation can be determined.