### PR TITLE
Announce connection initiated/complete datagram socket session events

### DIFF
--- a/groups/ntc/ntca/ntca_datagramsocketevent.h
+++ b/groups/ntc/ntca/ntca_datagramsocketevent.h
@@ -46,6 +46,7 @@ namespace ntca {
 class DatagramSocketEvent
 {
     union {
+        bsls::ObjectBuffer<ntca::ConnectEvent>    d_connectEvent;
         bsls::ObjectBuffer<ntca::ReadQueueEvent>  d_readQueueEvent;
         bsls::ObjectBuffer<ntca::WriteQueueEvent> d_writeQueueEvent;
         bsls::ObjectBuffer<ntca::DowngradeEvent>  d_downgradeEvent;
@@ -62,6 +63,13 @@ class DatagramSocketEvent
     /// 'basicAllocator' is 0, the currently installed default allocator is
     /// used.
     explicit DatagramSocketEvent(bslma::Allocator* basicAllocator = 0);
+
+    /// Create a new datagram socket have initially represented by the
+    /// specified 'connectEvent'. Optionally specify a 'basicAllocator'
+    /// used to supply memory. If 'basicAllocator' is 0, the currently
+    /// installed default allocator is used.
+    explicit DatagramSocketEvent(const ntca::ConnectEvent& connectEvent,
+                                 bslma::Allocator*         basicAllocator = 0);
 
     /// Create a new datagram socket have initially represented by the
     /// specified 'readQueueEvent'. Optionally specify a 'basicAllocator'
@@ -112,6 +120,11 @@ class DatagramSocketEvent
     /// Return a reference to this modifiable object.
     DatagramSocketEvent& operator=(const DatagramSocketEvent& other);
 
+    /// Make the representation of this object a connect event having the
+    /// same value as the specified 'other' object.  Return the reference
+    /// to this modifiable object.
+    DatagramSocketEvent& operator=(const ntca::ConnectEvent& other);
+
     /// Make the representation of this object a read queue event having the
     /// same value as the specified 'other' object.  Return the reference
     /// to this modifiable object.
@@ -143,6 +156,16 @@ class DatagramSocketEvent
 
     /// Make the representation of this object match the specified 'type'.
     void make(ntca::DatagramSocketEventType::Value type);
+
+    /// Make the representation of this object a connect event having a
+    /// default value.  Return the reference to the modifiable object
+    /// represented as a read queue event.
+    ntca::ConnectEvent& makeConnectEvent();
+
+    /// Make the representation of this object a read queue event having the
+    /// same value as the specified 'other' object.  Return the reference to
+    /// the modifiable object represented as a read queue event.
+    ntca::ConnectEvent& makeConnectEvent(const ntca::ConnectEvent& other);
 
     /// Make the representation of this object a read queue event having a
     /// default value.  Return the reference to the modifiable object
@@ -198,6 +221,11 @@ class DatagramSocketEvent
     /// the modifiable object represented as an error event.
     ntca::ErrorEvent& makeErrorEvent(const ntca::ErrorEvent& other);
 
+    /// Return the non-modifiable reference to the object represented as a
+    /// connect event. The behavior is undefined unless 'isConnectEvent()' is
+    /// true.
+    const ntca::ConnectEvent& connectEvent() const;
+
     /// Return the non-modifiable reference to the object represented as
     /// an read queue event. The behavior is undefined unless
     /// 'isReadQueueEvent()' is true.
@@ -229,6 +257,10 @@ class DatagramSocketEvent
     /// Return true if the datagram socket event type is undefined, otherwise
     /// return false.
     bool isUndefined() const;
+
+    /// Return true if the datagram socket event type is a connect event,
+    /// otherwise return false.
+    bool isConnectEvent() const;
 
     /// Return true if the datagram socket event type is a read queue event,
     /// otherwise return false.
@@ -345,7 +377,10 @@ void hashAppend(HASH_ALGORITHM& algorithm, const DatagramSocketEvent& value)
 {
     using bslh::hashAppend;
 
-    if (value.isReadQueueEvent()) {
+    if (value.isConnectEvent()) {
+        hashAppend(algorithm, value.connectEvent());
+    }
+    else if (value.isReadQueueEvent()) {
         hashAppend(algorithm, value.readQueueEvent());
     }
     else if (value.isWriteQueueEvent()) {

--- a/groups/ntc/ntca/ntca_datagramsocketeventtype.cpp
+++ b/groups/ntc/ntca/ntca_datagramsocketeventtype.cpp
@@ -30,8 +30,10 @@ int DatagramSocketEventType::fromInt(DatagramSocketEventType::Value* result,
 {
     switch (number) {
     case DatagramSocketEventType::e_UNDEFINED:
+    case DatagramSocketEventType::e_CONNECT:
     case DatagramSocketEventType::e_READ_QUEUE:
     case DatagramSocketEventType::e_WRITE_QUEUE:
+    case DatagramSocketEventType::e_DOWNGRADE:
     case DatagramSocketEventType::e_SHUTDOWN:
     case DatagramSocketEventType::e_ERROR:
         *result = static_cast<DatagramSocketEventType::Value>(number);
@@ -46,6 +48,10 @@ int DatagramSocketEventType::fromString(DatagramSocketEventType::Value* result,
 {
     if (bdlb::String::areEqualCaseless(string, "UNDEFINED")) {
         *result = e_UNDEFINED;
+        return 0;
+    }
+    if (bdlb::String::areEqualCaseless(string, "CONNECT")) {
+        *result = e_CONNECT;
         return 0;
     }
     if (bdlb::String::areEqualCaseless(string, "READ_QUEUE")) {
@@ -78,6 +84,9 @@ const char* DatagramSocketEventType::toString(
     switch (value) {
     case e_UNDEFINED: {
         return "UNDEFINED";
+    } break;
+    case e_CONNECT: {
+        return "CONNECT";
     } break;
     case e_READ_QUEUE: {
         return "READ_QUEUE";

--- a/groups/ntc/ntca/ntca_datagramsocketeventtype.h
+++ b/groups/ntc/ntca/ntca_datagramsocketeventtype.h
@@ -38,6 +38,9 @@ struct DatagramSocketEventType {
         // The datagram socket event type is undefined.
         e_UNDEFINED = 0,
 
+        /// The datagram socket event type is a connect event.
+        e_CONNECT = 6,
+
         // The datagram socket event type is a read queue event.
         e_READ_QUEUE = 1,
 

--- a/groups/ntc/ntca/ntca_streamsocketeventtype.cpp
+++ b/groups/ntc/ntca/ntca_streamsocketeventtype.cpp
@@ -30,6 +30,7 @@ int StreamSocketEventType::fromInt(StreamSocketEventType::Value* result,
 {
     switch (number) {
     case StreamSocketEventType::e_UNDEFINED:
+    case StreamSocketEventType::e_CONNECT:
     case StreamSocketEventType::e_READ_QUEUE:
     case StreamSocketEventType::e_WRITE_QUEUE:
     case StreamSocketEventType::e_DOWNGRADE:
@@ -47,6 +48,10 @@ int StreamSocketEventType::fromString(StreamSocketEventType::Value* result,
 {
     if (bdlb::String::areEqualCaseless(string, "UNDEFINED")) {
         *result = e_UNDEFINED;
+        return 0;
+    }
+    if (bdlb::String::areEqualCaseless(string, "CONNECT")) {
+        *result = e_CONNECT;
         return 0;
     }
     if (bdlb::String::areEqualCaseless(string, "READ_QUEUE")) {
@@ -78,6 +83,9 @@ const char* StreamSocketEventType::toString(StreamSocketEventType::Value value)
     switch (value) {
     case e_UNDEFINED: {
         return "UNDEFINED";
+    } break;
+    case e_CONNECT: {
+        return "CONNECT";
     } break;
     case e_READ_QUEUE: {
         return "READ_QUEUE";

--- a/groups/ntc/ntca/ntca_streamsocketeventtype.h
+++ b/groups/ntc/ntca/ntca_streamsocketeventtype.h
@@ -38,6 +38,9 @@ struct StreamSocketEventType {
         /// The stream socket event type is undefined.
         e_UNDEFINED = 0,
 
+        /// The stream socket event type is a connect event.
+        e_CONNECT = 6,
+
         /// The stream socket event type is a read queue event.
         e_READ_QUEUE = 1,
 

--- a/groups/ntc/ntci/ntci_datagramsocketsession.cpp
+++ b/groups/ntc/ntci/ntci_datagramsocketsession.cpp
@@ -27,6 +27,22 @@ DatagramSocketSession::~DatagramSocketSession()
 {
 }
 
+void DatagramSocketSession::processConnectInitiated(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::ConnectEvent&                    event)
+{
+    NTCCFG_WARNING_UNUSED(datagramSocket);
+    NTCCFG_WARNING_UNUSED(event);
+}
+
+void DatagramSocketSession::processConnectComplete(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::ConnectEvent&                    event)
+{
+    NTCCFG_WARNING_UNUSED(datagramSocket);
+    NTCCFG_WARNING_UNUSED(event);
+}
+
 void DatagramSocketSession::processReadQueueFlowControlRelaxed(
     const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
     const ntca::ReadQueueEvent&                  event)
@@ -134,6 +150,38 @@ void DatagramSocketSession::processWriteQueueRateLimitApplied(
 void DatagramSocketSession::processWriteQueueRateLimitRelaxed(
     const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
     const ntca::WriteQueueEvent&                 event)
+{
+    NTCCFG_WARNING_UNUSED(datagramSocket);
+    NTCCFG_WARNING_UNUSED(event);
+}
+
+void DatagramSocketSession::processDowngradeInitiated(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::DowngradeEvent&                  event)
+{
+    NTCCFG_WARNING_UNUSED(datagramSocket);
+    NTCCFG_WARNING_UNUSED(event);
+}
+
+void DatagramSocketSession::processDowngradeReceive(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::DowngradeEvent&                  event)
+{
+    NTCCFG_WARNING_UNUSED(datagramSocket);
+    NTCCFG_WARNING_UNUSED(event);
+}
+
+void DatagramSocketSession::processDowngradeSend(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::DowngradeEvent&                  event)
+{
+    NTCCFG_WARNING_UNUSED(datagramSocket);
+    NTCCFG_WARNING_UNUSED(event);
+}
+
+void DatagramSocketSession::processDowngradeComplete(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::DowngradeEvent&                  event)
 {
     NTCCFG_WARNING_UNUSED(datagramSocket);
     NTCCFG_WARNING_UNUSED(event);

--- a/groups/ntc/ntci/ntci_datagramsocketsession.h
+++ b/groups/ntc/ntci/ntci_datagramsocketsession.h
@@ -19,18 +19,24 @@
 #include <bsls_ident.h>
 BSLS_IDENT("$Id: $")
 
+#include <ntca_connectevent.h>
+#include <ntca_downgradeevent.h>
 #include <ntca_errorevent.h>
 #include <ntca_readqueueevent.h>
 #include <ntca_shutdownevent.h>
+#include <ntca_upgradeevent.h>
 #include <ntca_writequeueevent.h>
 #include <ntccfg_platform.h>
+#include <ntci_encryptioncertificate.h>
 #include <ntci_strand.h>
 #include <ntcscm_version.h>
 #include <ntsa_endpoint.h>
 #include <ntsa_error.h>
 #include <ntsa_shutdownorigin.h>
+#include <ntsa_shutdowntype.h>
 #include <bdlbb_blob.h>
 #include <bsl_memory.h>
+#include <bsl_string.h>
 
 namespace BloombergLP {
 namespace ntci {
@@ -50,6 +56,16 @@ class DatagramSocketSession
   public:
     /// Destroy this object.
     virtual ~DatagramSocketSession();
+
+    /// Process the condition that a connection is initiated.
+    virtual void processConnectInitiated(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::ConnectEvent&                    event);
+
+    /// Process the condition that a connection is complete.
+    virtual void processConnectComplete(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::ConnectEvent&                    event);
 
     /// Process the condition that read queue flow control has been relaxed:
     /// the socket receive buffer is being automatically copied to the read
@@ -145,6 +161,29 @@ class DatagramSocketSession
     virtual void processWriteQueueRateLimitRelaxed(
         const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
         const ntca::WriteQueueEvent&                 event);
+
+    /// Process the initiation of a downgrade from encrypted to unencrypted
+    /// communication.
+    virtual void processDowngradeInitiated(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::DowngradeEvent&                  event);
+
+    /// Process the socket being shut down for reading encryption
+    /// communication.
+    virtual void processDowngradeReceive(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::DowngradeEvent&                  event);
+
+    /// Process the socket being shut down for writing encrypted communication.
+    virtual void processDowngradeSend(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::DowngradeEvent&                  event);
+
+    /// Process the completion of a downgrade from encrypted to unencrypted
+    /// communication.
+    virtual void processDowngradeComplete(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::DowngradeEvent&                  event);
 
     /// Process the initiation of the shutdown sequence from the specified
     /// 'origin'.

--- a/groups/ntc/ntci/ntci_streamsocketsession.cpp
+++ b/groups/ntc/ntci/ntci_streamsocketsession.cpp
@@ -163,18 +163,17 @@ void StreamSocketSession::processDowngradeInitiated(
     NTCCFG_WARNING_UNUSED(event);
 }
 
-
 void StreamSocketSession::processDowngradeReceive(
-        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
-        const ntca::DowngradeEvent&                event)
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const ntca::DowngradeEvent&                event)
 {
     NTCCFG_WARNING_UNUSED(streamSocket);
     NTCCFG_WARNING_UNUSED(event);
 }
 
 void StreamSocketSession::processDowngradeSend(
-        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
-        const ntca::DowngradeEvent&                event)
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const ntca::DowngradeEvent&                event)
 {
     NTCCFG_WARNING_UNUSED(streamSocket);
     NTCCFG_WARNING_UNUSED(event);

--- a/groups/ntc/ntcp/ntcp_datagramsocket.h
+++ b/groups/ntc/ntcp/ntcp_datagramsocket.h
@@ -105,6 +105,7 @@ class DatagramSocket : public ntci::DatagramSocket,
     bool                                         d_sendPending;
     bool                                         d_sendGreedily;
     ntci::SendCallback                           d_sendComplete;
+    ntsa::ReceiveOptions                         d_receiveOptions;
     ntcq::ReceiveQueue                           d_receiveQueue;
     bsl::shared_ptr<ntci::Compression>           d_receiveInflater_sp;
     bsl::shared_ptr<ntci::RateLimiter>           d_receiveRateLimiter_sp;
@@ -842,9 +843,8 @@ class DatagramSocket : public ntci::DatagramSocket,
 
     /// Set the write deflater to the specified 'compression' technique. Return
     /// the error.
-    ntsa::Error setWriteDeflater(
-        const bsl::shared_ptr<ntci::Compression>& compression) 
-        BSLS_KEYWORD_OVERRIDE;
+    ntsa::Error setWriteDeflater(const bsl::shared_ptr<ntci::Compression>&
+                                     compression) BSLS_KEYWORD_OVERRIDE;
 
     /// Set the write queue low watermark to the specified 'lowWatermark'.
     /// Return the error.
@@ -869,9 +869,8 @@ class DatagramSocket : public ntci::DatagramSocket,
 
     /// Set the read inflater to the specified 'compression' technique. Return
     /// the error.
-    ntsa::Error setReadInflater(
-        const bsl::shared_ptr<ntci::Compression>& compression)
-        BSLS_KEYWORD_OVERRIDE;
+    ntsa::Error setReadInflater(const bsl::shared_ptr<ntci::Compression>&
+                                    compression) BSLS_KEYWORD_OVERRIDE;
 
     /// Set the read queue low watermark to the specified 'lowWatermark'.
     /// Return the error.
@@ -952,7 +951,7 @@ class DatagramSocket : public ntci::DatagramSocket,
     /// socket handle into the specified 'result', and close this object.
     /// Return the result. Note that the caller has the responsibility for
     /// closing '*result'. Also note that this function automatically closes
-    /// this object, but neither shuts down nor closes '*result'. 
+    /// this object, but neither shuts down nor closes '*result'.
     ntsa::Error release(ntsa::Handle* result) BSLS_KEYWORD_OVERRIDE;
 
     /// Release the underlying socket from ownership by this object, load the
@@ -964,9 +963,9 @@ class DatagramSocket : public ntci::DatagramSocket,
     /// '*result'. Also tote that callbacks created by this object will
     /// automatically be invoked on this object's strand unless an explicit
     /// strand is specified at the time the callback is created.
-    ntsa::Error release(ntsa::Handle*              result, 
-                        const ntci::CloseFunction& callback) 
-                        BSLS_KEYWORD_OVERRIDE;
+    ntsa::Error release(ntsa::Handle*              result,
+                        const ntci::CloseFunction& callback)
+        BSLS_KEYWORD_OVERRIDE;
 
     /// Release the underlying socket from ownership by this object, load the
     /// socket handle into the specified 'result', close this object, and
@@ -978,8 +977,8 @@ class DatagramSocket : public ntci::DatagramSocket,
     /// automatically be invoked on this object's strand unless an explicit
     /// strand is specified at the time the callback is created.
     ntsa::Error release(ntsa::Handle*              result,
-                        const ntci::CloseCallback& callback) 
-                        BSLS_KEYWORD_OVERRIDE;
+                        const ntci::CloseCallback& callback)
+        BSLS_KEYWORD_OVERRIDE;
 
     /// Close the datagram socket.
     void close() BSLS_KEYWORD_OVERRIDE;

--- a/groups/ntc/ntcr/ntcr_datagramsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.cpp
@@ -21,12 +21,12 @@ BSLS_IDENT_RCSID(ntcr_datagramsocket_cpp, "$Id$ $CSID$")
 #include <ntccfg_limits.h>
 #include <ntci_log.h>
 #include <ntci_monitorable.h>
-#include <ntcs_monitorable.h>
 #include <ntcs_async.h>
 #include <ntcs_blobbufferutil.h>
 #include <ntcs_blobutil.h>
 #include <ntcs_compat.h>
 #include <ntcs_dispatch.h>
+#include <ntcs_monitorable.h>
 #include <ntcs_plugin.h>
 #include <ntcu_datagramsocketsession.h>
 #include <ntcu_datagramsocketutil.h>
@@ -239,8 +239,7 @@ void DatagramSocket::processSocketReadable(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
     NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
-    if (NTCCFG_UNLIKELY(d_detachState.mode() ==
-                        ntcs::DetachMode::e_INITIATED))
+    if (NTCCFG_UNLIKELY(d_detachState.mode() == ntcs::DetachMode::e_INITIATED))
     {
         return;
     }
@@ -297,8 +296,7 @@ void DatagramSocket::processSocketWritable(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
     NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
-    if (NTCCFG_UNLIKELY(d_detachState.mode() ==
-                        ntcs::DetachMode::e_INITIATED))
+    if (NTCCFG_UNLIKELY(d_detachState.mode() == ntcs::DetachMode::e_INITIATED))
     {
         return;
     }
@@ -353,8 +351,7 @@ void DatagramSocket::processSocketError(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
     NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
-    if (NTCCFG_UNLIKELY(d_detachState.mode() ==
-                        ntcs::DetachMode::e_INITIATED))
+    if (NTCCFG_UNLIKELY(d_detachState.mode() == ntcs::DetachMode::e_INITIATED))
     {
         return;
     }
@@ -763,9 +760,8 @@ void DatagramSocket::processSendDeadlineTimer(
         ntci::SendCallback callback;
         ntca::SendContext  context;
 
-        bool becameEmpty = d_sendQueue.removeEntryId(&callback,
-                                                     &context,
-                                                     entryId);
+        bool becameEmpty =
+            d_sendQueue.removeEntryId(&callback, &context, entryId);
         if (becameEmpty) {
             this->privateApplyFlowControl(self,
                                           ntca::FlowControlType::e_SEND,
@@ -1347,8 +1343,7 @@ void DatagramSocket::privateShutdownSequenceComplete(
 
     if (lock) {
         d_mutex.lock();
-        BSLS_ASSERT(d_detachState.mode() ==
-                    ntcs::DetachMode::e_INITIATED);
+        BSLS_ASSERT(d_detachState.mode() == ntcs::DetachMode::e_INITIATED);
         d_detachState.setMode(ntcs::DetachMode::e_IDLE);
     }
     else {
@@ -1400,7 +1395,7 @@ void DatagramSocket::privateShutdownSequenceComplete(
         NTCR_DATAGRAMSOCKET_LOG_SHUTDOWN_SEND();
 
         typedef bsl::pair<ntca::SendContext, ntci::SendCallback>
-        SendContextCallback;
+            SendContextCallback;
 
         bsl::vector<SendContextCallback> callbackVector;
 
@@ -1418,8 +1413,8 @@ void DatagramSocket::privateShutdownSequenceComplete(
                     const ntcq::ZeroCopyEntry& entry = zeroCopyEntryVector[i];
                     if (entry.callback()) {
                         callbackVector.push_back(
-                            SendContextCallback(
-                                entry.context(), entry.callback()));
+                            SendContextCallback(entry.context(),
+                                                entry.callback()));
                     }
                 }
             }
@@ -1433,8 +1428,8 @@ void DatagramSocket::privateShutdownSequenceComplete(
                         sendQueueEntryVector[i];
                     if (entry.callback()) {
                         callbackVector.push_back(
-                            SendContextCallback(
-                                entry.context(), entry.callback()));
+                            SendContextCallback(entry.context(),
+                                                entry.callback()));
                     }
                 }
             }
@@ -1875,8 +1870,7 @@ bool DatagramSocket::privateCloseFlowControl(
     if (d_systemHandle != ntsa::k_INVALID_HANDLE) {
         ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
         if (reactorRef) {
-            BSLS_ASSERT(d_detachState.mode() !=
-                        ntcs::DetachMode::e_INITIATED);
+            BSLS_ASSERT(d_detachState.mode() != ntcs::DetachMode::e_INITIATED);
             const ntsa::Error error =
                 reactorRef->detachSocket(self, detachCallback);
             if (NTCCFG_UNLIKELY(error)) {
@@ -2332,7 +2326,8 @@ ntsa::Error DatagramSocket::privateEnqueueSendBuffer(
             return ntsa::Error(ntsa::Error::e_INVALID);
         }
     }
-    else if (!endpoint.isNull() && endpoint.value() != d_systemRemoteEndpoint) {
+    else if (!endpoint.isNull() && endpoint.value() != d_systemRemoteEndpoint)
+    {
         return ntsa::Error(ntsa::Error::e_INVALID);
     }
 
@@ -2431,7 +2426,8 @@ ntsa::Error DatagramSocket::privateEnqueueSendBuffer(
             return ntsa::Error(ntsa::Error::e_INVALID);
         }
     }
-    else if (!endpoint.isNull() && endpoint.value() != d_systemRemoteEndpoint) {
+    else if (!endpoint.isNull() && endpoint.value() != d_systemRemoteEndpoint)
+    {
         return ntsa::Error(ntsa::Error::e_INVALID);
     }
 
@@ -2512,9 +2508,8 @@ ntsa::Error DatagramSocket::privateDequeueReceiveBuffer(
     }
     else {
         bsl::shared_ptr<bdlbb::Blob> deflatedData;
-        error = this->privateDequeueReceiveBufferRaw(self,
-                                                     context,
-                                                     &deflatedData);
+        error =
+            this->privateDequeueReceiveBufferRaw(self, context, &deflatedData);
         if (error) {
             return error;
         }
@@ -2539,9 +2534,9 @@ ntsa::Error DatagramSocket::privateDequeueReceiveBuffer(
 }
 
 ntsa::Error DatagramSocket::privateDequeueReceiveBufferRaw(
-        const bsl::shared_ptr<DatagramSocket>& self,
-        ntsa::ReceiveContext*                  context,
-        bsl::shared_ptr<bdlbb::Blob>*          data)
+    const bsl::shared_ptr<DatagramSocket>& self,
+    ntsa::ReceiveContext*                  context,
+    bsl::shared_ptr<bdlbb::Blob>*          data)
 {
     NTCI_LOG_CONTEXT();
 
@@ -2830,9 +2825,9 @@ ntsa::Error DatagramSocket::privateOpen(
 
     if (d_options.compressionConfig().has_value()) {
         if (d_options.compressionConfig().value().type() !=
-            ntca::CompressionType::e_UNDEFINED &&
+                ntca::CompressionType::e_UNDEFINED &&
             d_options.compressionConfig().value().type() !=
-            ntca::CompressionType::e_NONE)
+                ntca::CompressionType::e_NONE)
         {
             bsl::shared_ptr<ntci::CompressionDriver> compressionDriver;
             error = ntcs::Plugin::lookupCompressionDriver(&compressionDriver);
@@ -2850,7 +2845,7 @@ ntsa::Error DatagramSocket::privateOpen(
                 return error;
             }
 
-            d_sendDeflater_sp = compression;
+            d_sendDeflater_sp    = compression;
             d_receiveInflater_sp = compression;
         }
     }
@@ -3031,6 +3026,7 @@ void DatagramSocket::processRemoteEndpointResolution(
     }
     else {
         connectContext.setName(getEndpointEvent.context().authority());
+        connectContext.setEndpoint(endpoint);
 
         if (getEndpointEvent.context().latency() != bsls::TimeInterval()) {
             connectContext.setLatency(getEndpointEvent.context().latency());
@@ -3059,8 +3055,8 @@ void DatagramSocket::processRemoteEndpointResolution(
                                              d_options.reuseAddress());
 
                 if (!error) {
-                    error = d_socket_sp->sourceEndpoint(
-                        &d_systemSourceEndpoint);
+                    error =
+                        d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
                     d_publicSourceEndpoint = d_systemSourceEndpoint;
                 }
             }
@@ -3081,10 +3077,30 @@ void DatagramSocket::processRemoteEndpointResolution(
         d_publicRemoteEndpoint = d_systemRemoteEndpoint;
     }
 
+    if (d_session_sp) {
+        ntca::ConnectEvent connectEvent;
+        connectEvent.setType(ntca::ConnectEventType::e_INITIATED);
+        connectEvent.setContext(connectContext);
+
+        const bool defer = !connectOptions.recurse();
+
+        ntcs::Dispatch::announceConnectInitiated(d_session_sp,
+                                                 self,
+                                                 connectEvent,
+                                                 d_sessionStrand_sp,
+                                                 ntci::Strand::unknown(),
+                                                 self,
+                                                 defer,
+                                                 &d_mutex);
+
+        if (d_shutdownState.initiated()) {
+            return;
+        }
+    }
+
     ntca::ConnectEvent connectEvent;
     if (!error) {
         connectEvent.setType(ntca::ConnectEventType::e_COMPLETE);
-        connectContext.setEndpoint(d_systemSourceEndpoint);
     }
     else {
         connectEvent.setType(ntca::ConnectEventType::e_ERROR);
@@ -3092,6 +3108,23 @@ void DatagramSocket::processRemoteEndpointResolution(
     }
 
     connectEvent.setContext(connectContext);
+
+    if (d_session_sp) {
+        const bool defer = !connectOptions.recurse();
+
+        ntcs::Dispatch::announceConnectComplete(d_session_sp,
+                                                self,
+                                                connectEvent,
+                                                d_sessionStrand_sp,
+                                                ntci::Strand::unknown(),
+                                                self,
+                                                defer,
+                                                &d_mutex);
+
+        if (d_shutdownState.initiated()) {
+            return;
+        }
+    }
 
     if (connectCallback) {
         const bool defer = !connectOptions.recurse();
@@ -3105,9 +3138,8 @@ void DatagramSocket::processRemoteEndpointResolution(
     }
 }
 
-void DatagramSocket::privateClose(
-    const bsl::shared_ptr<DatagramSocket>& self,
-    const ntci::CloseCallback&             callback)
+void DatagramSocket::privateClose(const bsl::shared_ptr<DatagramSocket>& self,
+                                  const ntci::CloseCallback& callback)
 {
     NTCI_LOG_CONTEXT();
 
@@ -3511,14 +3543,55 @@ ntsa::Error DatagramSocket::connect(const ntsa::Endpoint&        endpoint,
 
     d_receiveOptions.hideEndpoint();
 
-    if (callback) {
+    if (d_session_sp) {
         ntca::ConnectContext connectContext;
         connectContext.setEndpoint(d_systemRemoteEndpoint);
 
         ntca::ConnectEvent connectEvent;
-        connectEvent.setType(ntca::ConnectEventType::e_COMPLETE);
+        connectEvent.setType(ntca::ConnectEventType::e_INITIATED);
         connectEvent.setContext(connectContext);
 
+        const bool defer = !options.recurse();
+
+        ntcs::Dispatch::announceConnectInitiated(d_session_sp,
+                                                 self,
+                                                 connectEvent,
+                                                 d_sessionStrand_sp,
+                                                 ntci::Strand::unknown(),
+                                                 self,
+                                                 defer,
+                                                 &d_mutex);
+
+        if (d_shutdownState.initiated()) {
+            return ntsa::Error(ntsa::Error::e_CONNECTION_DEAD);
+        }
+    }
+
+    ntca::ConnectContext connectContext;
+    connectContext.setEndpoint(d_systemRemoteEndpoint);
+
+    ntca::ConnectEvent connectEvent;
+    connectEvent.setType(ntca::ConnectEventType::e_COMPLETE);
+    connectEvent.setContext(connectContext);
+
+    if (d_session_sp) {
+        const bool defer = !options.recurse();
+
+        ntcs::Dispatch::announceConnectComplete(d_session_sp,
+                                                self,
+                                                connectEvent,
+                                                d_sessionStrand_sp,
+                                                ntci::Strand::unknown(),
+                                                self,
+                                                defer,
+                                                &d_mutex);
+
+        if (d_shutdownState.initiated()) {
+            return ntsa::Error(ntsa::Error::e_CONNECTION_DEAD);
+        }
+    }
+
+    if (callback) {
         const bool defer = !options.recurse();
 
         callback.dispatch(self,
@@ -3668,8 +3741,8 @@ ntsa::Error DatagramSocket::send(const bdlbb::Blob&        data,
     }
 
     if (NTCCFG_LIKELY(!d_sendDeflater_sp)) {
-        return this->privateSend(
-            self, data, state, options, context, callback);
+        return this
+            ->privateSend(self, data, state, options, context, callback);
     }
     else {
         ntca::DeflateOptions deflateOptions;
@@ -3770,8 +3843,8 @@ ntsa::Error DatagramSocket::send(const ntsa::Data&         data,
     }
 
     if (NTCCFG_LIKELY(!d_sendDeflater_sp)) {
-        return this->privateSend(
-            self, data, state, options, context, callback);
+        return this
+            ->privateSend(self, data, state, options, context, callback);
     }
     else {
         ntca::DeflateOptions deflateOptions;
@@ -4281,7 +4354,7 @@ ntsa::Error DatagramSocket::setZeroCopyThreshold(bsl::size_t value)
 }
 
 ntsa::Error DatagramSocket::setWriteDeflater(
-        const bsl::shared_ptr<ntci::Compression>& compression)
+    const bsl::shared_ptr<ntci::Compression>& compression)
 {
     LockGuard lock(&d_mutex);
 
@@ -4447,7 +4520,7 @@ ntsa::Error DatagramSocket::setWriteQueueWatermarks(bsl::size_t lowWatermark,
 }
 
 ntsa::Error DatagramSocket::setReadInflater(
-        const bsl::shared_ptr<ntci::Compression>& compression)
+    const bsl::shared_ptr<ntci::Compression>& compression)
 {
     LockGuard lock(&d_mutex);
 
@@ -4749,9 +4822,8 @@ ntsa::Error DatagramSocket::cancel(const ntca::SendToken& token)
     ntci::SendCallback callback;
     ntca::SendContext  context;
 
-    bool becameEmpty = d_sendQueue.removeEntryToken(&callback,
-                                                    &context,
-                                                    token);
+    bool becameEmpty =
+        d_sendQueue.removeEntryToken(&callback, &context, token);
 
     if (becameEmpty) {
         this->privateApplyFlowControl(self,
@@ -4845,12 +4917,12 @@ ntsa::Error DatagramSocket::release(ntsa::Handle* result)
 ntsa::Error DatagramSocket::release(ntsa::Handle*              result,
                                     const ntci::CloseFunction& callback)
 {
-    return this->release(
-        result, this->createCloseCallback(callback, d_allocator_p));
+    return this->release(result,
+                         this->createCloseCallback(callback, d_allocator_p));
 }
 
 ntsa::Error DatagramSocket::release(ntsa::Handle*              result,
-                                  const ntci::CloseCallback& callback)
+                                    const ntci::CloseCallback& callback)
 {
     bsl::shared_ptr<DatagramSocket> self = this->getSelf(this);
 

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -23,12 +23,12 @@ BSLS_IDENT_RCSID(ntcr_streamsocket_cpp, "$Id$ $CSID$")
 #include <ntci_encryptioncertificate.h>
 #include <ntci_log.h>
 #include <ntci_monitorable.h>
-#include <ntcs_monitorable.h>
 #include <ntcs_async.h>
 #include <ntcs_blobbufferutil.h>
 #include <ntcs_blobutil.h>
 #include <ntcs_compat.h>
 #include <ntcs_dispatch.h>
+#include <ntcs_monitorable.h>
 #include <ntcs_plugin.h>
 #include <ntcu_streamsocketsession.h>
 #include <ntcu_streamsocketutil.h>
@@ -37,8 +37,8 @@ BSLS_IDENT_RCSID(ntcr_streamsocket_cpp, "$Id$ $CSID$")
 #include <ntsa_error.h>
 #include <ntsf_system.h>
 #include <ntsi_streamsocket.h>
-#include <ntsu_socketutil.h>
 #include <ntsu_socketoptionutil.h>
+#include <ntsu_socketutil.h>
 #include <ntsu_timestamputil.h>
 #include <bdlbb_blob.h>
 #include <bdlbb_blobutil.h>
@@ -296,8 +296,7 @@ void StreamSocket::processSocketReadable(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
     NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
-    if (NTCCFG_UNLIKELY(d_detachState.mode() ==
-                        ntcs::DetachMode::e_INITIATED))
+    if (NTCCFG_UNLIKELY(d_detachState.mode() == ntcs::DetachMode::e_INITIATED))
     {
         return;
     }
@@ -354,8 +353,7 @@ void StreamSocket::processSocketWritable(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
     NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
-    if (NTCCFG_UNLIKELY(d_detachState.mode() ==
-                        ntcs::DetachMode::e_INITIATED))
+    if (NTCCFG_UNLIKELY(d_detachState.mode() == ntcs::DetachMode::e_INITIATED))
     {
         return;
     }
@@ -415,8 +413,7 @@ void StreamSocket::processSocketError(const ntca::ReactorEvent& event)
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_systemSourceEndpoint);
     NTCI_LOG_CONTEXT_GUARD_REMOTE_ENDPOINT(d_systemRemoteEndpoint);
 
-    if (NTCCFG_UNLIKELY(d_detachState.mode() ==
-                        ntcs::DetachMode::e_INITIATED))
+    if (NTCCFG_UNLIKELY(d_detachState.mode() == ntcs::DetachMode::e_INITIATED))
     {
         return;
     }
@@ -533,9 +530,7 @@ void StreamSocket::processConnectRetryTimer(
             if (d_connectAttempts > 0) {
                 d_retryConnect = true;
 
-                if (d_detachState.mode() !=
-                    ntcs::DetachMode::e_INITIATED)
-                {
+                if (d_detachState.mode() != ntcs::DetachMode::e_INITIATED) {
                     this->privateFailConnect(
                         self,
                         ntsa::Error(ntsa::Error::e_CONNECTION_TIMEOUT),
@@ -644,9 +639,8 @@ void StreamSocket::processSendDeadlineTimer(
         ntci::SendCallback callback;
         ntca::SendContext  context;
 
-        bool becameEmpty = d_sendQueue.removeEntryId(&callback,
-                                                     &context,
-                                                     entryId);
+        bool becameEmpty =
+            d_sendQueue.removeEntryId(&callback, &context, entryId);
         if (becameEmpty) {
             this->privateApplyFlowControl(self,
                                           ntca::FlowControlType::e_SEND,
@@ -826,9 +820,9 @@ ntsa::Error StreamSocket::privateSocketReadableIteration(
         return error;
     }
 
-    BSLS_ASSERT(d_receiveQueue.size() ==
-   	            NTCCFG_WARNING_PROMOTE(bsl::size_t,
-   	                                   d_receiveQueue.data()->length()));
+    BSLS_ASSERT(
+        d_receiveQueue.size() ==
+        NTCCFG_WARNING_PROMOTE(bsl::size_t, d_receiveQueue.data()->length()));
 
     NTCR_STREAMSOCKET_LOG_READ_QUEUE_FILLED(d_receiveQueue.size());
 
@@ -1144,15 +1138,14 @@ ntsa::Error StreamSocket::privateSocketWritableConnection(
     NTCI_LOG_TRACE("Connection attempt succeeded");
 
     if (d_session_sp) {
-        ntcs::Dispatch::announceConnectComplete(
-            d_session_sp,
-            self,
-            connectEvent,
-            d_sessionStrand_sp,
-            ntci::Strand::unknown(),
-            self,
-            false,
-            &d_mutex);
+        ntcs::Dispatch::announceConnectComplete(d_session_sp,
+                                                self,
+                                                connectEvent,
+                                                d_sessionStrand_sp,
+                                                ntci::Strand::unknown(),
+                                                self,
+                                                false,
+                                                &d_mutex);
 
         if (d_openState.value() != ntcs::OpenState::e_CONNECTED) {
             return ntsa::Error(ntsa::Error::e_CONNECTION_DEAD);
@@ -1219,7 +1212,7 @@ ntsa::Error StreamSocket::privateSocketWritableIterationBatch(
     bsl::size_t numBytesRemaining = context.bytesSent();
 
     typedef bsl::pair<ntca::SendContext, ntci::SendCallback>
-    SendContextCallback;
+        SendContextCallback;
 
     typedef bsl::vector<SendContextCallback>      SendCallbackVector;
     typedef bdlma::LocalSequentialAllocator<1024> SendCallbackVectorAllocator;
@@ -1570,8 +1563,7 @@ void StreamSocket::privateFailConnect(
                     const ntsa::Error error =
                         reactorRef->detachSocket(self, detachCallback);
                     if (!error) {
-                        d_detachState.setMode(
-                            ntcs::DetachMode::e_INITIATED);
+                        d_detachState.setMode(ntcs::DetachMode::e_INITIATED);
                     }
                 }
             }
@@ -1605,8 +1597,7 @@ void StreamSocket::privateFailConnect(
                     const ntsa::Error error =
                         reactorRef->detachSocket(self, detachCallback);
                     if (!error) {
-                        d_detachState.setMode(
-                            ntcs::DetachMode::e_INITIATED);
+                        d_detachState.setMode(ntcs::DetachMode::e_INITIATED);
                     }
                 }
             }
@@ -1640,13 +1631,11 @@ void StreamSocket::privateFailConnectPart2(
 
     if (lock) {
         d_mutex.lock();
-        BSLS_ASSERT(d_detachState.mode() ==
-                    ntcs::DetachMode::e_INITIATED);
+        BSLS_ASSERT(d_detachState.mode() == ntcs::DetachMode::e_INITIATED);
         d_detachState.setMode(ntcs::DetachMode::e_IDLE);
     }
     else {
-        BSLS_ASSERT(d_detachState.mode() !=
-                    ntcs::DetachMode::e_INITIATED);
+        BSLS_ASSERT(d_detachState.mode() != ntcs::DetachMode::e_INITIATED);
     }
 
     if (d_systemHandle != ntsa::k_INVALID_HANDLE) {
@@ -1675,15 +1664,14 @@ void StreamSocket::privateFailConnectPart2(
     }
 
     if (d_session_sp) {
-        ntcs::Dispatch::announceConnectComplete(
-            d_session_sp,
-            self,
-            connectEvent,
-            d_sessionStrand_sp,
-            ntci::Strand::unknown(),
-            self,
-            defer,
-            &d_mutex);
+        ntcs::Dispatch::announceConnectComplete(d_session_sp,
+                                                self,
+                                                connectEvent,
+                                                d_sessionStrand_sp,
+                                                ntci::Strand::unknown(),
+                                                self,
+                                                defer,
+                                                &d_mutex);
     }
 
     if (connectCallback) {
@@ -2039,13 +2027,11 @@ void StreamSocket::privateShutdownSequenceComplete(
 
     if (lock) {
         d_mutex.lock();
-        BSLS_ASSERT(d_detachState.mode() ==
-                    ntcs::DetachMode::e_INITIATED);
+        BSLS_ASSERT(d_detachState.mode() == ntcs::DetachMode::e_INITIATED);
         d_detachState.setMode(ntcs::DetachMode::e_IDLE);
     }
     else {
-        BSLS_ASSERT(d_detachState.mode() !=
-                    ntcs::DetachMode::e_INITIATED);
+        BSLS_ASSERT(d_detachState.mode() != ntcs::DetachMode::e_INITIATED);
     }
 
     // Second, handle socket shutdown.
@@ -2097,7 +2083,7 @@ void StreamSocket::privateShutdownSequenceComplete(
         NTCR_STREAMSOCKET_LOG_SHUTDOWN_SEND();
 
         typedef bsl::pair<ntca::SendContext, ntci::SendCallback>
-        SendContextCallback;
+            SendContextCallback;
 
         bsl::vector<SendContextCallback> callbackVector;
 
@@ -2115,8 +2101,8 @@ void StreamSocket::privateShutdownSequenceComplete(
                     const ntcq::ZeroCopyEntry& entry = zeroCopyEntryVector[i];
                     if (entry.callback()) {
                         callbackVector.push_back(
-                            SendContextCallback(
-                                entry.context(), entry.callback()));
+                            SendContextCallback(entry.context(),
+                                                entry.callback()));
                     }
                 }
             }
@@ -2130,8 +2116,8 @@ void StreamSocket::privateShutdownSequenceComplete(
                         sendQueueEntryVector[i];
                     if (entry.callback()) {
                         callbackVector.push_back(
-                            SendContextCallback(
-                                entry.context(), entry.callback()));
+                            SendContextCallback(entry.context(),
+                                                entry.callback()));
                     }
                 }
             }
@@ -2616,8 +2602,7 @@ bool StreamSocket::privateCloseFlowControl(
     if (d_systemHandle != ntsa::k_INVALID_HANDLE) {
         ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
         if (reactorRef) {
-            BSLS_ASSERT(d_detachState.mode() !=
-                        ntcs::DetachMode::e_INITIATED);
+            BSLS_ASSERT(d_detachState.mode() != ntcs::DetachMode::e_INITIATED);
             const ntsa::Error error =
                 reactorRef->detachSocket(self, detachCallback);
             if (NTCCFG_UNLIKELY(error)) {
@@ -3148,7 +3133,7 @@ ntsa::Error StreamSocket::privateDequeueReceiveBuffer(
             }
 
             if (NTCCFG_UNLIKELY(
-                d_upgradeOptions.keepIncomingLeftovers().value_or(false)))
+                    d_upgradeOptions.keepIncomingLeftovers().value_or(false)))
             {
                 while (NTCCFG_LIKELY(d_encryption_sp->hasIncomingLeftovers()))
                 {
@@ -3171,7 +3156,7 @@ ntsa::Error StreamSocket::privateDequeueReceiveBuffer(
             }
 
             if (NTCCFG_UNLIKELY(
-                d_upgradeOptions.keepIncomingLeftovers().value_or(false)))
+                    d_upgradeOptions.keepIncomingLeftovers().value_or(false)))
             {
                 while (NTCCFG_LIKELY(d_encryption_sp->hasIncomingLeftovers()))
                 {
@@ -3247,15 +3232,14 @@ ntsa::Error StreamSocket::privateDequeueReceiveBuffer(
                 event.setType(ntca::DowngradeEventType::e_COMPLETE);
                 event.setContext(context);
 
-                ntcs::Dispatch::announceDowngradeComplete(
-                    d_session_sp,
-                    self,
-                    event,
-                    d_sessionStrand_sp,
-                    d_reactorStrand_sp,
-                    self,
-                    false,
-                    &d_mutex);
+                ntcs::Dispatch::announceDowngradeComplete(d_session_sp,
+                                                          self,
+                                                          event,
+                                                          d_sessionStrand_sp,
+                                                          d_reactorStrand_sp,
+                                                          self,
+                                                          false,
+                                                          &d_mutex);
             }
         }
         else {
@@ -3289,11 +3273,11 @@ ntsa::Error StreamSocket::privateDequeueReceiveBuffer(
             if (NTCCFG_UNLIKELY(d_encryption_sp->hasOutgoingCipherText())) {
                 bdlbb::Blob cipherData(d_outgoingBufferFactory_sp.get());
 
-                while (NTCCFG_UNLIKELY(
-                    d_encryption_sp->hasOutgoingCipherText()))
+                while (
+                    NTCCFG_UNLIKELY(d_encryption_sp->hasOutgoingCipherText()))
                 {
-                    error = d_encryption_sp->popOutgoingCipherText(
-                        &cipherData);
+                    error =
+                        d_encryption_sp->popOutgoingCipherText(&cipherData);
                     if (error) {
                         return error;
                     }
@@ -3789,9 +3773,12 @@ ntsa::Error StreamSocket::privateSendEncrypted(
     }
 
     if (cipherData.length() > 0) {
-        error =
-            this->privateSendRaw(
-                self, cipherData, state, options, setting, callback);
+        error = this->privateSendRaw(self,
+                                     cipherData,
+                                     state,
+                                     options,
+                                     setting,
+                                     callback);
         if (error) {
             return error;
         }
@@ -3839,9 +3826,12 @@ ntsa::Error StreamSocket::privateSendEncrypted(
     }
 
     if (cipherData.length() > 0) {
-        error =
-            this->privateSendRaw(
-                self, cipherData, state, options, setting, callback);
+        error = this->privateSendRaw(self,
+                                     cipherData,
+                                     state,
+                                     options,
+                                     setting,
+                                     callback);
         if (error) {
             return error;
         }
@@ -4012,13 +4002,12 @@ ntsa::Error StreamSocket::privateOpen(
 
     if (d_options.compressionConfig().has_value()) {
         if (d_options.compressionConfig().value().type() !=
-            ntca::CompressionType::e_UNDEFINED &&
+                ntca::CompressionType::e_UNDEFINED &&
             d_options.compressionConfig().value().type() !=
-            ntca::CompressionType::e_NONE)
+                ntca::CompressionType::e_NONE)
         {
             bsl::shared_ptr<ntci::CompressionDriver> compressionDriver;
-            error = ntcs::Plugin::lookupCompressionDriver(
-                &compressionDriver);
+            error = ntcs::Plugin::lookupCompressionDriver(&compressionDriver);
             if (error) {
                 return error;
             }
@@ -4033,7 +4022,7 @@ ntsa::Error StreamSocket::privateOpen(
                 return error;
             }
 
-            d_sendDeflater_sp = compression;
+            d_sendDeflater_sp    = compression;
             d_receiveInflater_sp = compression;
         }
     }
@@ -4271,8 +4260,7 @@ void StreamSocket::processRemoteEndpointResolution(
 
     LockGuard lock(&d_mutex);
 
-    if (NTCCFG_UNLIKELY(d_detachState.mode() ==
-                        ntcs::DetachMode::e_INITIATED))
+    if (NTCCFG_UNLIKELY(d_detachState.mode() == ntcs::DetachMode::e_INITIATED))
     {
         return;
     }
@@ -4332,7 +4320,8 @@ void StreamSocket::processRemoteEndpointResolution(
                                              d_options.reuseAddress());
 
                 if (!error) {
-                    error = d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
+                    error =
+                        d_socket_sp->sourceEndpoint(&d_systemSourceEndpoint);
                     d_publicSourceEndpoint = d_systemSourceEndpoint;
                 }
             }
@@ -4362,15 +4351,14 @@ void StreamSocket::processRemoteEndpointResolution(
             event.setType(ntca::ConnectEventType::e_INITIATED);
             event.setContext(d_connectContext);
 
-            ntcs::Dispatch::announceConnectInitiated(
-                d_session_sp,
-                self,
-                event,
-                d_sessionStrand_sp,
-                ntci::Strand::unknown(),
-                self,
-                false,
-                &d_mutex);
+            ntcs::Dispatch::announceConnectInitiated(d_session_sp,
+                                                     self,
+                                                     event,
+                                                     d_sessionStrand_sp,
+                                                     ntci::Strand::unknown(),
+                                                     self,
+                                                     false,
+                                                     &d_mutex);
 
             if (NTCCFG_UNLIKELY(d_detachState.mode() ==
                                 ntcs::DetachMode::e_INITIATED))
@@ -4856,15 +4844,14 @@ void StreamSocket::privateRetryConnectToEndpoint(
         event.setType(ntca::ConnectEventType::e_INITIATED);
         event.setContext(d_connectContext);
 
-        ntcs::Dispatch::announceConnectInitiated(
-            d_session_sp,
-            self,
-            event,
-            d_sessionStrand_sp,
-            ntci::Strand::unknown(),
-            self,
-            false,
-            &d_mutex);
+        ntcs::Dispatch::announceConnectInitiated(d_session_sp,
+                                                 self,
+                                                 event,
+                                                 d_sessionStrand_sp,
+                                                 ntci::Strand::unknown(),
+                                                 self,
+                                                 false,
+                                                 &d_mutex);
     }
 
     if (d_detachState.mode() == ntcs::DetachMode::e_INITIATED) {
@@ -4881,8 +4868,10 @@ void StreamSocket::privateRetryConnectToEndpoint(
 
     ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
     if (!reactorRef) {
-        this->privateFailConnect(
-            self, ntsa::Error(ntsa::Error::e_INVALID), false, false);
+        this->privateFailConnect(self,
+                                 ntsa::Error(ntsa::Error::e_INVALID),
+                                 false,
+                                 false);
         return;
     }
 
@@ -5203,9 +5192,8 @@ void StreamSocket::privateZeroCopyUpdate(
     }
 }
 
-void StreamSocket::privateClose(
-    const bsl::shared_ptr<StreamSocket>& self,
-    const ntci::CloseCallback&           callback)
+void StreamSocket::privateClose(const bsl::shared_ptr<StreamSocket>& self,
+                                const ntci::CloseCallback&           callback)
 {
     NTCI_LOG_CONTEXT();
 
@@ -6095,8 +6083,12 @@ ntsa::Error StreamSocket::send(const bdlbb::Blob&        data,
 
     if (NTCCFG_LIKELY(!d_sendDeflater_sp)) {
         if (NTCCFG_LIKELY(!d_encryption_sp)) {
-            return this->privateSendRaw(
-                self, data, state, options, context, callback);
+            return this->privateSendRaw(self,
+                                        data,
+                                        state,
+                                        options,
+                                        context,
+                                        callback);
         }
         else {
             return this->privateSendEncrypted(self,
@@ -6218,8 +6210,12 @@ ntsa::Error StreamSocket::send(const ntsa::Data&         data,
 
     if (NTCCFG_LIKELY(!d_sendDeflater_sp)) {
         if (NTCCFG_LIKELY(!d_encryption_sp)) {
-            return this->privateSendRaw(
-                self, data, state, options, context, callback);
+            return this->privateSendRaw(self,
+                                        data,
+                                        state,
+                                        options,
+                                        context,
+                                        callback);
         }
         else {
             return this->privateSendEncrypted(self,
@@ -6330,8 +6326,7 @@ ntsa::Error StreamSocket::receive(ntca::ReceiveContext*       context,
                     ntsu::SocketUtil::close(entry.foreignHandle().value());
                 }
                 else {
-                    context->setForeignHandle(
-                        entry.foreignHandle().value());
+                    context->setForeignHandle(entry.foreignHandle().value());
                 }
             }
 
@@ -6750,7 +6745,7 @@ ntsa::Error StreamSocket::setZeroCopyThreshold(bsl::size_t value)
 }
 
 ntsa::Error StreamSocket::setWriteDeflater(
-        const bsl::shared_ptr<ntci::Compression>& compression)
+    const bsl::shared_ptr<ntci::Compression>& compression)
 {
     LockGuard lock(&d_mutex);
 
@@ -6931,7 +6926,7 @@ ntsa::Error StreamSocket::setWriteQueueWatermarks(bsl::size_t lowWatermark,
 }
 
 ntsa::Error StreamSocket::setReadInflater(
-        const bsl::shared_ptr<ntci::Compression>& compression)
+    const bsl::shared_ptr<ntci::Compression>& compression)
 {
     LockGuard lock(&d_mutex);
 
@@ -7238,9 +7233,8 @@ ntsa::Error StreamSocket::cancel(const ntca::SendToken& token)
     ntci::SendCallback callback;
     ntca::SendContext  context;
 
-    bool becameEmpty = d_sendQueue.removeEntryToken(&callback,
-                                                    &context,
-                                                    token);
+    bool becameEmpty =
+        d_sendQueue.removeEntryToken(&callback, &context, token);
 
     if (becameEmpty) {
         this->privateApplyFlowControl(self,
@@ -7379,8 +7373,8 @@ ntsa::Error StreamSocket::release(ntsa::Handle* result)
 ntsa::Error StreamSocket::release(ntsa::Handle*              result,
                                   const ntci::CloseFunction& callback)
 {
-    return this->release(
-        result, this->createCloseCallback(callback, d_allocator_p));
+    return this->release(result,
+                         this->createCloseCallback(callback, d_allocator_p));
 }
 
 ntsa::Error StreamSocket::release(ntsa::Handle*              result,

--- a/groups/ntc/ntcs/ntcs_dispatch.cpp
+++ b/groups/ntc/ntcs/ntcs_dispatch.cpp
@@ -99,6 +99,80 @@ void Dispatch::announceClosed(
     }
 }
 
+void Dispatch::announceConnectInitiated(
+    const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
+    const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
+    const ntca::ConnectEvent&                           event,
+    const bsl::shared_ptr<ntci::Strand>&                destination,
+    const bsl::shared_ptr<ntci::Strand>&                source,
+    const bsl::shared_ptr<ntci::Executor>&              executor,
+    bool                                                defer,
+    ntccfg::Mutex*                                      mutex)
+{
+    if (!session) {
+        return;
+    }
+
+    if (NTCCFG_LIKELY(!defer &&
+                      ntci::Strand::passthrough(destination, source)))
+    {
+        bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
+        ntccfg::UnLockGuard                          guard(mutex);
+        sessionGuard->processConnectInitiated(socket, event);
+    }
+    else if (destination) {
+        destination->execute(
+            NTCCFG_BIND(&ntci::DatagramSocketSession::processConnectInitiated,
+                        session,
+                        socket,
+                        event));
+    }
+    else {
+        executor->execute(
+            NTCCFG_BIND(&ntci::DatagramSocketSession::processConnectInitiated,
+                        session,
+                        socket,
+                        event));
+    }
+}
+
+void Dispatch::announceConnectComplete(
+    const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
+    const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
+    const ntca::ConnectEvent&                           event,
+    const bsl::shared_ptr<ntci::Strand>&                destination,
+    const bsl::shared_ptr<ntci::Strand>&                source,
+    const bsl::shared_ptr<ntci::Executor>&              executor,
+    bool                                                defer,
+    ntccfg::Mutex*                                      mutex)
+{
+    if (!session) {
+        return;
+    }
+
+    if (NTCCFG_LIKELY(!defer &&
+                      ntci::Strand::passthrough(destination, source)))
+    {
+        bsl::shared_ptr<ntci::DatagramSocketSession> sessionGuard = session;
+        ntccfg::UnLockGuard                          guard(mutex);
+        sessionGuard->processConnectComplete(socket, event);
+    }
+    else if (destination) {
+        destination->execute(
+            NTCCFG_BIND(&ntci::DatagramSocketSession::processConnectComplete,
+                        session,
+                        socket,
+                        event));
+    }
+    else {
+        executor->execute(
+            NTCCFG_BIND(&ntci::DatagramSocketSession::processConnectComplete,
+                        session,
+                        socket,
+                        event));
+    }
+}
+
 void Dispatch::announceReadQueueFlowControlRelaxed(
     const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
     const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
@@ -1442,18 +1516,18 @@ void Dispatch::announceConnectInitiated(
         sessionGuard->processConnectInitiated(socket, event);
     }
     else if (destination) {
-        destination->execute(NTCCFG_BIND(
-            &ntci::StreamSocketSession::processConnectInitiated,
-            session,
-            socket,
-            event));
+        destination->execute(
+            NTCCFG_BIND(&ntci::StreamSocketSession::processConnectInitiated,
+                        session,
+                        socket,
+                        event));
     }
     else {
-        executor->execute(NTCCFG_BIND(
-            &ntci::StreamSocketSession::processConnectInitiated,
-            session,
-            socket,
-            event));
+        executor->execute(
+            NTCCFG_BIND(&ntci::StreamSocketSession::processConnectInitiated,
+                        session,
+                        socket,
+                        event));
     }
 }
 
@@ -1479,18 +1553,18 @@ void Dispatch::announceConnectComplete(
         sessionGuard->processConnectComplete(socket, event);
     }
     else if (destination) {
-        destination->execute(NTCCFG_BIND(
-            &ntci::StreamSocketSession::processConnectComplete,
-            session,
-            socket,
-            event));
+        destination->execute(
+            NTCCFG_BIND(&ntci::StreamSocketSession::processConnectComplete,
+                        session,
+                        socket,
+                        event));
     }
     else {
-        executor->execute(NTCCFG_BIND(
-            &ntci::StreamSocketSession::processConnectComplete,
-            session,
-            socket,
-            event));
+        executor->execute(
+            NTCCFG_BIND(&ntci::StreamSocketSession::processConnectComplete,
+                        session,
+                        socket,
+                        event));
     }
 }
 

--- a/groups/ntc/ntcs/ntcs_dispatch.h
+++ b/groups/ntc/ntcs/ntcs_dispatch.h
@@ -101,6 +101,51 @@ struct Dispatch {
         bool                                                defer,
         ntccfg::Mutex*                                      mutex);
 
+    /// Announce to the specified 'session' the condition that a connection
+    /// sequence has been initiated. If the specified 'defer' flag is
+    /// false and the requirements of the specified 'destination' strand
+    /// permits the announcement to be executed immediately by the specified
+    /// 'source' strand, unlock the specified 'mutex', execute the
+    /// announcement, then relock the 'mutex'. Otherwise, enqueue the
+    /// announcement to be executed on the 'destination' strand, if not
+    /// null, or by the specified 'executor' otherwise. The behavior is
+    /// undefined if 'mutex' is null or not locked. The behavior is *not*
+    /// undefined if either the 'destination' strand is null or the 'source'
+    /// strand is null; a null 'destination' strand indicates the
+    /// announcement may be invoked on any strand by any thread; a null
+    /// 'source' strand indicates the source strand is unknown.
+    static void announceConnectInitiated(
+        const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
+        const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
+        const ntca::ConnectEvent&                           event,
+        const bsl::shared_ptr<ntci::Strand>&                destination,
+        const bsl::shared_ptr<ntci::Strand>&                source,
+        const bsl::shared_ptr<ntci::Executor>&              executor,
+        bool                                                defer,
+        ntccfg::Mutex*                                      mutex);
+
+    /// Announce to the specified 'session' the condition that a connection
+    /// sequence is complete. If the specified 'defer' flag is false and the
+    /// requirements of the specified 'destination' strand permits the
+    /// announcement to be executed immediately by the specified 'source'
+    /// strand, unlock the specified 'mutex', execute the announcement, then
+    /// relock the 'mutex'. Otherwise, enqueue the announcement to be executed
+    /// on the 'destination' strand, if not null, or by the specified
+    /// 'executor' otherwise. The behavior is undefined if 'mutex' is null or
+    /// not locked. The behavior is *not* undefined if either the 'destination'
+    /// strand is null or the 'source' strand is null; a null 'destination'
+    /// strand indicates the announcement may be invoked on any strand by any
+    /// thread; a null 'source' strand indicates the source strand is unknown.
+    static void announceConnectComplete(
+        const bsl::shared_ptr<ntci::DatagramSocketSession>& session,
+        const bsl::shared_ptr<ntci::DatagramSocket>&        socket,
+        const ntca::ConnectEvent&                           event,
+        const bsl::shared_ptr<ntci::Strand>&                destination,
+        const bsl::shared_ptr<ntci::Strand>&                source,
+        const bsl::shared_ptr<ntci::Executor>&              executor,
+        bool                                                defer,
+        ntccfg::Mutex*                                      mutex);
+
     /// Announce to the specified 'session' the condition that read queue
     /// flow control has been relaxed. If the specified 'defer' flag is
     /// false and the requirements of the specified 'destination' strand

--- a/groups/ntc/ntcu/ntcu_datagramsocketsession.cpp
+++ b/groups/ntc/ntcu/ntcu_datagramsocketsession.cpp
@@ -39,6 +39,22 @@ DatagramSocketSession::~DatagramSocketSession()
 {
 }
 
+void DatagramSocketSession::processConnectInitiated(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::ConnectEvent&                    event)
+{
+    BSLS_ASSERT(event.type() == ntca::ConnectEventType::e_INITIATED);
+    d_callback(datagramSocket, ntca::DatagramSocketEvent(event));
+}
+
+void DatagramSocketSession::processConnectComplete(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::ConnectEvent&                    event)
+{
+    BSLS_ASSERT(event.type() == ntca::ConnectEventType::e_COMPLETE);
+    d_callback(datagramSocket, ntca::DatagramSocketEvent(event));
+}
+
 void DatagramSocketSession::processReadQueueFlowControlRelaxed(
     const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
     const ntca::ReadQueueEvent&                  event)
@@ -120,6 +136,22 @@ void DatagramSocketSession::processWriteQueueDiscarded(
     const ntca::WriteQueueEvent&                 event)
 {
     BSLS_ASSERT(event.type() == ntca::WriteQueueEventType::e_DISCARDED);
+    d_callback(datagramSocket, ntca::DatagramSocketEvent(event));
+}
+
+void DatagramSocketSession::processDowngradeInitiated(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::DowngradeEvent&                  event)
+{
+    BSLS_ASSERT(event.type() == ntca::DowngradeEventType::e_INITIATED);
+    d_callback(datagramSocket, ntca::DatagramSocketEvent(event));
+}
+
+void DatagramSocketSession::processDowngradeComplete(
+    const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+    const ntca::DowngradeEvent&                  event)
+{
+    BSLS_ASSERT(event.type() == ntca::DowngradeEventType::e_COMPLETE);
     d_callback(datagramSocket, ntca::DatagramSocketEvent(event));
 }
 

--- a/groups/ntc/ntcu/ntcu_datagramsocketsession.h
+++ b/groups/ntc/ntcu/ntcu_datagramsocketsession.h
@@ -67,6 +67,16 @@ class DatagramSocketSession : public ntci::DatagramSocketSession
     /// Destroy this object.
     ~DatagramSocketSession() BSLS_KEYWORD_OVERRIDE;
 
+    /// Process the condition that a connection is initiated.
+    void processConnectInitiated(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::ConnectEvent& event) BSLS_KEYWORD_OVERRIDE;
+
+    /// Process the condition that a connection is complete.
+    void processConnectComplete(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::ConnectEvent& event) BSLS_KEYWORD_OVERRIDE;
+
     /// Process the condition that read queue flow control has been relaxed:
     /// the socket receive buffer is being automatically copied to the read
     /// queue.
@@ -137,6 +147,18 @@ class DatagramSocketSession : public ntci::DatagramSocketSession
     void processWriteQueueDiscarded(
         const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
         const ntca::WriteQueueEvent& event) BSLS_KEYWORD_OVERRIDE;
+
+    /// Process the initiation of a downgrade from encrypted to unencrypted
+    /// communication.
+    void processDowngradeInitiated(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::DowngradeEvent& event) BSLS_KEYWORD_OVERRIDE;
+
+    /// Process the completion of a downgrade from encrypted to unencrypted
+    /// communication.
+    void processDowngradeComplete(
+        const bsl::shared_ptr<ntci::DatagramSocket>& datagramSocket,
+        const ntca::DowngradeEvent& event) BSLS_KEYWORD_OVERRIDE;
 
     /// Process the initiation of the shutdown sequence from the specified
     /// 'origin'.

--- a/groups/ntc/ntcu/ntcu_streamsocketeventqueue.h
+++ b/groups/ntc/ntcu/ntcu_streamsocketeventqueue.h
@@ -57,7 +57,7 @@ class StreamSocketEventQueue : public ntci::StreamSocketSession,
         // This enumeration defines the constants used by this class.
 
         /// The total number of stream socket event types.
-        k_NUM_EVENT_TYPES = 6
+        k_NUM_EVENT_TYPES = 7
     };
 
     ntccfg::ConditionMutex        d_mutex;
@@ -82,9 +82,18 @@ class StreamSocketEventQueue : public ntci::StreamSocketSession,
         BSLS_KEYWORD_OVERRIDE;
 
     /// Process the closure of the specified 'streamSocket'.
-    void processStreamSocketClosed(
-        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket)
-        BSLS_KEYWORD_OVERRIDE;
+    void processStreamSocketClosed(const bsl::shared_ptr<ntci::StreamSocket>&
+                                       streamSocket) BSLS_KEYWORD_OVERRIDE;
+
+    /// Process the condition that a connection is initiated.
+    void processConnectInitiated(
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const ntca::ConnectEvent& event) BSLS_KEYWORD_OVERRIDE;
+
+    /// Process the condition that a connection is complete.
+    void processConnectComplete(
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const ntca::ConnectEvent& event) BSLS_KEYWORD_OVERRIDE;
 
     /// Process the condition that read queue flow control has been relaxed:
     /// the socket receive buffer is being automatically copied to the read
@@ -199,6 +208,10 @@ class StreamSocketEventQueue : public ntci::StreamSocketSession,
 
     /// Return true if the user is interested in events of the specified
     /// 'type', otherwise return false.
+    bool want(ntca::ConnectEventType::Value type) const;
+
+    /// Return true if the user is interested in events of the specified
+    /// 'type', otherwise return false.
     bool want(ntca::ReadQueueEventType::Value type) const;
 
     /// Return true if the user is interested in events of the specified
@@ -233,6 +246,9 @@ class StreamSocketEventQueue : public ntci::StreamSocketSession,
     void show(ntca::StreamSocketEventType::Value type);
 
     /// Gain interest in events of the specified 'type'.
+    void show(ntca::ConnectEventType::Value type);
+
+    /// Gain interest in events of the specified 'type'.
     void show(ntca::ReadQueueEventType::Value type);
 
     /// Gain interest in events of the specified 'type'.
@@ -252,6 +268,9 @@ class StreamSocketEventQueue : public ntci::StreamSocketSession,
 
     /// Lose interest in all events of the specified 'type'.
     void hide(ntca::StreamSocketEventType::Value type);
+
+    /// Lose interest in events of the specified 'type'.
+    void hide(ntca::ConnectEventType::Value type);
 
     /// Lose interest in events of the specified 'type'.
     void hide(ntca::ReadQueueEventType::Value type);
@@ -277,6 +296,27 @@ class StreamSocketEventQueue : public ntci::StreamSocketSession,
     /// the error.
     ntsa::Error wait(ntca::StreamSocketEvent*  result,
                      const bsls::TimeInterval& timeout);
+
+    /// Wait for any connect event to occur and load the result into the
+    /// specified 'result'. Return the error.
+    ntsa::Error wait(ntca::ConnectEvent* result);
+
+    /// Wait for any connect event to occur or until the specified 'timeout',
+    /// in absolute time since the Unix epoch, elapses. Return the error.
+    ntsa::Error wait(ntca::ConnectEvent*       result,
+                     const bsls::TimeInterval& timeout);
+
+    /// Wait for a connect event of the specified 'type' to occur and load the
+    /// result into the specified 'result'. Return the error.
+    ntsa::Error wait(ntca::ConnectEvent*           result,
+                     ntca::ConnectEventType::Value type);
+
+    /// Wait for a connect event of the specified 'type' to occur or until the
+    /// specified 'timeout', in absolute time since the Unix epoch, elapses.
+    /// Return the error.
+    ntsa::Error wait(ntca::ConnectEvent*           result,
+                     ntca::ConnectEventType::Value type,
+                     const bsls::TimeInterval&     timeout);
 
     /// Wait for any read queue event to occur and load the result into
     /// the specified 'result'. Return the error.

--- a/groups/ntc/ntcu/ntcu_streamsocketsession.cpp
+++ b/groups/ntc/ntcu/ntcu_streamsocketsession.cpp
@@ -39,22 +39,38 @@ StreamSocketSession::~StreamSocketSession()
 {
 }
 
+void StreamSocketSession::processConnectInitiated(
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const ntca::ConnectEvent&                  event)
+{
+    BSLS_ASSERT(event.type() == ntca::ConnectEventType::e_INITIATED);
+    d_callback(streamSocket, ntca::StreamSocketEvent(event));
+}
+
+void StreamSocketSession::processConnectComplete(
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+    const ntca::ConnectEvent&                  event)
+{
+    BSLS_ASSERT(event.type() == ntca::ConnectEventType::e_COMPLETE);
+    d_callback(streamSocket, ntca::StreamSocketEvent(event));
+}
+
 void StreamSocketSession::processReadQueueFlowControlRelaxed(
-    const bsl::shared_ptr<ntci::StreamSocket>& datagramSocket,
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
     const ntca::ReadQueueEvent&                event)
 {
     BSLS_ASSERT(event.type() ==
                 ntca::ReadQueueEventType::e_FLOW_CONTROL_RELAXED);
-    d_callback(datagramSocket, ntca::StreamSocketEvent(event));
+    d_callback(streamSocket, ntca::StreamSocketEvent(event));
 }
 
 void StreamSocketSession::processReadQueueFlowControlApplied(
-    const bsl::shared_ptr<ntci::StreamSocket>& datagramSocket,
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
     const ntca::ReadQueueEvent&                event)
 {
     BSLS_ASSERT(event.type() ==
                 ntca::ReadQueueEventType::e_FLOW_CONTROL_APPLIED);
-    d_callback(datagramSocket, ntca::StreamSocketEvent(event));
+    d_callback(streamSocket, ntca::StreamSocketEvent(event));
 }
 
 void StreamSocketSession::processReadQueueLowWatermark(
@@ -82,21 +98,21 @@ void StreamSocketSession::processReadQueueDiscarded(
 }
 
 void StreamSocketSession::processWriteQueueFlowControlRelaxed(
-    const bsl::shared_ptr<ntci::StreamSocket>& datagramSocket,
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
     const ntca::WriteQueueEvent&               event)
 {
     BSLS_ASSERT(event.type() ==
                 ntca::WriteQueueEventType::e_FLOW_CONTROL_RELAXED);
-    d_callback(datagramSocket, ntca::StreamSocketEvent(event));
+    d_callback(streamSocket, ntca::StreamSocketEvent(event));
 }
 
 void StreamSocketSession::processWriteQueueFlowControlApplied(
-    const bsl::shared_ptr<ntci::StreamSocket>& datagramSocket,
+    const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
     const ntca::WriteQueueEvent&               event)
 {
     BSLS_ASSERT(event.type() ==
                 ntca::WriteQueueEventType::e_FLOW_CONTROL_APPLIED);
-    d_callback(datagramSocket, ntca::StreamSocketEvent(event));
+    d_callback(streamSocket, ntca::StreamSocketEvent(event));
 }
 
 void StreamSocketSession::processWriteQueueLowWatermark(

--- a/groups/ntc/ntcu/ntcu_streamsocketsession.h
+++ b/groups/ntc/ntcu/ntcu_streamsocketsession.h
@@ -66,6 +66,16 @@ class StreamSocketSession : public ntci::StreamSocketSession
     /// Destroy this object.
     ~StreamSocketSession() BSLS_KEYWORD_OVERRIDE;
 
+    /// Process the condition that a connection is initiated.
+    void processConnectInitiated(
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const ntca::ConnectEvent& event) BSLS_KEYWORD_OVERRIDE;
+
+    /// Process the condition that a connection is complete.
+    void processConnectComplete(
+        const bsl::shared_ptr<ntci::StreamSocket>& streamSocket,
+        const ntca::ConnectEvent& event) BSLS_KEYWORD_OVERRIDE;
+
     /// Process the condition that read queue flow control has been relaxed:
     /// the socket receive buffer is being automatically copied to the read
     /// queue.


### PR DESCRIPTION
This PR adds a two new passive events, `ntci::DatagramSocketSession::processConnectInitiated` and `ntci::DatagramSocketSession::processConnectInitiated`, similar to those passive events already present in `ntci::StreamSocketSession`.