### PR TITLE
Add defensive checks to ntsb::Stream/DatagramSocket::acquire() to guard against importing socket handles of an unexpected socket type

### DIFF
--- a/groups/nts/ntsb/ntsb_datagramsocket.cpp
+++ b/groups/nts/ntsb/ntsb_datagramsocket.cpp
@@ -61,7 +61,19 @@ ntsa::Error DatagramSocket::open(ntsa::Transport::Value transport)
 
 ntsa::Error DatagramSocket::acquire(ntsa::Handle handle)
 {
+    ntsa::Error error;
+
     if (d_handle != ntsa::k_INVALID_HANDLE) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    bool isDatagram = false;
+    error           = ntsu::SocketOptionUtil::isDatagram(&isDatagram, handle);
+    if (error) {
+        return error;
+    }
+
+    if (!isDatagram) {
         return ntsa::Error(ntsa::Error::e_INVALID);
     }
 

--- a/groups/nts/ntsb/ntsb_streamsocket.cpp
+++ b/groups/nts/ntsb/ntsb_streamsocket.cpp
@@ -61,7 +61,19 @@ ntsa::Error StreamSocket::open(ntsa::Transport::Value transport)
 
 ntsa::Error StreamSocket::acquire(ntsa::Handle handle)
 {
+    ntsa::Error error;
+
     if (d_handle != ntsa::k_INVALID_HANDLE) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
+    }
+
+    bool isStream = false;
+    error         = ntsu::SocketOptionUtil::isStream(&isStream, handle);
+    if (error) {
+        return error;
+    }
+
+    if (!isStream) {
         return ntsa::Error(ntsa::Error::e_INVALID);
     }
 


### PR DESCRIPTION
This PR enhances the implementations of `ntsb::StreamSocket::acquire()` and `ntsb::DatagramSocket::acquire()` to guard against the user importing a socket of the wrong "type" (i.e. importing datagram socket handles into stream sockets or vice-versa.)