### PR TITLE
Fix incorrect mapping of cpp03 to CMAKE_CXX_STANDARD

### DIFF
--- a/toolchain.cmake
+++ b/toolchain.cmake
@@ -180,7 +180,11 @@ endif()
 
 string(REGEX MATCH "cpp([0-9][0-9])" ufid_standard "${NTF_TOOLCHAIN_UFID}")
 if (ufid_standard)
-    set(CMAKE_CXX_STANDARD "${CMAKE_MATCH_1}${CMAKE_MATCH_2}" CACHE STRING "" FORCE)
+    if (CMAKE_MATCH_1 STREQUAL "03")
+        set(CMAKE_CXX_STANDARD "98" CACHE STRING "" FORCE)
+    else ()
+        set(CMAKE_CXX_STANDARD "${CMAKE_MATCH_1}" CACHE STRING "" FORCE)
+    endif ()
 endif()
 unset(ufid_standard)
 


### PR DESCRIPTION
CMake does not recognize "03" as valid. Map to 98.

Fixes #375

*Issue number of the reported bug or feature request: #375*

**Describe your changes**
Added a if else statement which checks if CMAKE_MATCH_1 has 03 in it. If yes std set to 98 else std is set to the value stored in CMAKE_MATCH_1

**Testing performed**
when ./configure --standard 03 used its sets std to 98

**Additional context**
None
