### PR TITLE
Perform X.509 subject alternative name comparison caselessly for domain names

### DIFF
--- a/groups/ntc/ntca/ntca_encryptioncertificate.cpp
+++ b/groups/ntc/ntca/ntca_encryptioncertificate.cpp
@@ -9571,7 +9571,7 @@ bool operator<(const EncryptionCertificate& lhs,
 bool EncryptionCertificateUtil::matches(const bsl::string& requested,
                                         const bsl::string& certified)
 {
-    if (requested == certified) {
+    if (bdlb::String::areEqualCaseless(requested, certified)) {
         return true;
     }
 
@@ -9638,7 +9638,9 @@ bool EncryptionCertificateUtil::matches(const bsl::string& requested,
             break;
         }
 
-        if (*requestedCurrent != *certifiedCurrent) {
+        if (!bdlb::String::areEqualCaseless(*requestedCurrent,
+                                            *certifiedCurrent))
+        {
             return false;
         }
 
@@ -9781,7 +9783,7 @@ bool EncryptionCertificateUtil::matches(const ntsa::Uri&   requested,
         if (!authority.host().isNull()) {
             const ntsa::Host& host = authority.host().value();
 
-            if (host.text() == certified) {
+            if (bdlb::String::areEqualCaseless(host.text(), certified)) {
                 return true;
             }
         }

--- a/groups/ntc/ntca/ntca_encryptioncertificate.t.cpp
+++ b/groups/ntc/ntca/ntca_encryptioncertificate.t.cpp
@@ -207,43 +207,83 @@ NTSCFG_TEST_FUNCTION(ntca::EncryptionCertificateTest::verifyMatchName)
     bool match;
 
     match = ntca::EncryptionCertificateUtil::matches(
-        "c.b.a", 
+        "c.b.a",
         "c.b.a");
     NTSCFG_TEST_TRUE(match);
 
     match = ntca::EncryptionCertificateUtil::matches(
-        "c.b.x", 
+        "C.B.A",
+        "c.b.a");
+    NTSCFG_TEST_TRUE(match);
+
+    match = ntca::EncryptionCertificateUtil::matches(
+        "c.b.x",
         "c.b.a");
     NTSCFG_TEST_FALSE(match);
 
     match = ntca::EncryptionCertificateUtil::matches(
-        "c.x.a", 
+        "C.B.X",
         "c.b.a");
     NTSCFG_TEST_FALSE(match);
 
     match = ntca::EncryptionCertificateUtil::matches(
-        "x.b.a", 
+        "c.x.a",
         "c.b.a");
     NTSCFG_TEST_FALSE(match);
 
     match = ntca::EncryptionCertificateUtil::matches(
-        "d.c.b.a", 
-            "c.b.a");
+        "C.X.A",
+        "c.b.a");
     NTSCFG_TEST_FALSE(match);
 
     match = ntca::EncryptionCertificateUtil::matches(
-            "c.b.a", 
+        "x.b.a",
+        "c.b.a");
+    NTSCFG_TEST_FALSE(match);
+
+    match = ntca::EncryptionCertificateUtil::matches(
+        "X.B.A",
+        "c.b.a");
+    NTSCFG_TEST_FALSE(match);
+
+    match = ntca::EncryptionCertificateUtil::matches(
+        "d.c.b.a",
+          "c.b.a");
+    NTSCFG_TEST_FALSE(match);
+
+    match = ntca::EncryptionCertificateUtil::matches(
+        "D.C.B.A",
+          "c.b.a");
+    NTSCFG_TEST_FALSE(match);
+
+    match = ntca::EncryptionCertificateUtil::matches(
+          "c.b.a",
         "d.c.b.a");
     NTSCFG_TEST_FALSE(match);
 
     match = ntca::EncryptionCertificateUtil::matches(
-        "d.c.b.a", 
+          "C.B.A",
+        "d.c.b.a");
+    NTSCFG_TEST_FALSE(match);
+
+    match = ntca::EncryptionCertificateUtil::matches(
+        "d.c.b.a",
         "*.c.b.a");
     NTSCFG_TEST_TRUE(match);
 
     match = ntca::EncryptionCertificateUtil::matches(
-        "e.d.c.b.a", 
-            "*.c.b.a");
+        "D.C.B.A",
+        "*.c.b.a");
+    NTSCFG_TEST_TRUE(match);
+
+    match = ntca::EncryptionCertificateUtil::matches(
+        "e.d.c.b.a",
+          "*.c.b.a");
+    NTSCFG_TEST_TRUE(match);
+
+    match = ntca::EncryptionCertificateUtil::matches(
+        "E.D.C.B.A",
+          "*.c.b.a");
     NTSCFG_TEST_TRUE(match);
 
     // clang-format on
@@ -309,7 +349,33 @@ NTSCFG_TEST_FUNCTION(ntca::EncryptionCertificateTest::verifyMatchAddress)
     {
         ntsa::Uri requestedUri;
         requestedUri.setScheme("http");
+        requestedUri.setHost("FOUND");
+        requestedUri.setPort(80);
+
+        bsl::string certifiedString = "found";
+
+        match = ntca::EncryptionCertificateUtil::matches(requestedUri,
+                                                         certifiedString);
+        NTSCFG_TEST_TRUE(match);
+    }
+
+    {
+        ntsa::Uri requestedUri;
+        requestedUri.setScheme("http");
         requestedUri.setHost("missing");
+        requestedUri.setPort(80);
+
+        bsl::string certifiedString = "found";
+
+        match = ntca::EncryptionCertificateUtil::matches(requestedUri,
+                                                         certifiedString);
+        NTSCFG_TEST_FALSE(match);
+    }
+
+    {
+        ntsa::Uri requestedUri;
+        requestedUri.setScheme("http");
+        requestedUri.setHost("MISSING");
         requestedUri.setPort(80);
 
         bsl::string certifiedString = "found";
@@ -356,7 +422,39 @@ NTSCFG_TEST_FUNCTION(ntca::EncryptionCertificateTest::verifyMatchAddress)
     {
         ntsa::Uri requestedUri;
         requestedUri.setScheme("http");
+        requestedUri.setHost("FOUND");
+        requestedUri.setPort(80);
+
+        ntsa::Uri certifiedUri;
+        certifiedUri.setScheme("https");  // intentional
+        certifiedUri.setHost("found");
+        certifiedUri.setPort(8080);  // intentional
+
+        match = ntca::EncryptionCertificateUtil::matches(requestedUri,
+                                                         certifiedUri);
+        NTSCFG_TEST_TRUE(match);
+    }
+
+    {
+        ntsa::Uri requestedUri;
+        requestedUri.setScheme("http");
         requestedUri.setHost("missing");
+        requestedUri.setPort(80);
+
+        ntsa::Uri certifiedUri;
+        certifiedUri.setScheme("https");  // intentional
+        certifiedUri.setHost("found");
+        certifiedUri.setPort(8080);  // intentional
+
+        match = ntca::EncryptionCertificateUtil::matches(requestedUri,
+                                                         certifiedUri);
+        NTSCFG_TEST_FALSE(match);
+    }
+
+    {
+        ntsa::Uri requestedUri;
+        requestedUri.setScheme("http");
+        requestedUri.setHost("MISSING");
         requestedUri.setPort(80);
 
         ntsa::Uri certifiedUri;
@@ -397,6 +495,10 @@ NTSCFG_TEST_FUNCTION(ntca::EncryptionCertificateTest::verifyFields)
     bool matchesSubjectDomainName =
         certificate.matchesSubjectDomainName("ntf.bloomberg.com");
     NTSCFG_TEST_TRUE(matchesSubjectDomainName);
+
+    bool matchesSubjectDomainNameCaseless =
+        certificate.matchesSubjectDomainName("NTF.Bloomberg.Com");
+    NTSCFG_TEST_TRUE(matchesSubjectDomainNameCaseless);
 
     bool isEllipticCurve = certificate.usesSubjectPublicKeyAlgorithm(
         ntca::EncryptionKeyAlgorithmIdentifierType::e_ELLIPTIC_CURVE);


### PR DESCRIPTION
The `ntca::EncryptionCertificate` is a value-semantic type that represents the X.509 certificate presented by a peer during a TLS handshake. This class provides access to the information provided in the certificate and provides certain convenience functions to assist the user in implementing application-specific certificate validation. One such function, `ntca::EncryptionCertificate::matchesSubjectDomainName(<domain-name>)`, allows the user to test whether the certificate identity indicates a particular domain name, either in the subject common name (CN) field, the subject domain name (DN) field, or in one of the subject alternative name extensions. This PR fixes a bug to compare domain names case-insensitively, as required by [RFC 4343](https://www.rfc-editor.org/rfc/rfc4343.txt).