### PR TITLE
Fix[ntsb_resolver.cpp]: init `d_systemEnabled` using the correct field

### DIFF
--- a/groups/nts/ntsb/ntsb_resolver.cpp
+++ b/groups/nts/ntsb/ntsb_resolver.cpp
@@ -580,7 +580,7 @@ Resolver::Resolver(const ntsa::ResolverConfig& configuration,
 : d_overrides(basicAllocator)
 , d_overridesExist(false)
 , d_overridesEnabled(configuration.overridesEnabled().valueOr(true))
-, d_systemEnabled(configuration.overridesEnabled().valueOr(true))
+, d_systemEnabled(configuration.systemEnabled().valueOr(true))
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
 }


### PR DESCRIPTION
`d_systemEnabled` should be initialized from `configuration.systemEnabled()` value