### PR TITLE
Perf[ntsa_domainname.h]: improve CPU cache locality

### DIFF
--- a/groups/nts/ntsa/ntsa_domainname.h
+++ b/groups/nts/ntsa/ntsa_domainname.h
@@ -98,8 +98,8 @@ class DomainName
   private:
     enum { BUFFER_SIZE = 256 };
 
-    char          d_buffer[BUFFER_SIZE];
     bsl::uint32_t d_size;
+    char          d_buffer[BUFFER_SIZE];
 
     // Provide a private implementation.
     class Impl;


### PR DESCRIPTION
Place domain name size before buffer to improve CPU cache locality.

With short domain names (less than 60 bytes), the accessed data fits into just 1 CPU cache line that is 64 bytes.
The existing implementation guarantees that 2 cache lines will be used, because we have to access the data in the beginning of `d_buffer` and access `d_size` that are 256 bytes apart from each other.