### PR TITLE
Fix[ntcd::DataUtil::generateData]: out of bounds write with non-zero offset

### DIFF
--- a/groups/ntc/ntcd/ntcd_datautil.cpp
+++ b/groups/ntc/ntcd/ntcd_datautil.cpp
@@ -52,7 +52,7 @@ void DataUtil::generateData(bsl::string* result,
     result->clear();
     result->resize(size);
 
-    for (bsl::size_t i = offset; i < offset + size; ++i) {
+    for (bsl::size_t i = offset; i < size; ++i) {
         (*result)[i] = generateByte(offset + i, dataset);
     }
 }


### PR DESCRIPTION
Similar to `bdlbb::Blob* result` overload, resize exactly to `size` and do not write past the string size.