### PR TITLE
Fix: irreflexivity for STL compatible containers

### DIFF
--- a/groups/ntc/ntca/ntca_encryptionkey.cpp
+++ b/groups/ntc/ntca/ntca_encryptionkey.cpp
@@ -5197,7 +5197,7 @@ bool EncryptionKey::less(const EncryptionKey& other) const
         return d_info.object().less(other.d_info.object());
     }
 
-    return true;
+    return false;
 }
 
 bsl::ostream& EncryptionKey::print(bsl::ostream& stream,

--- a/groups/nts/ntsa/ntsa_endpoint.cpp
+++ b/groups/nts/ntsa/ntsa_endpoint.cpp
@@ -205,7 +205,7 @@ bool Endpoint::less(const Endpoint& other) const
     case ntsa::EndpointType::e_LOCAL:
         return d_local.object().less(other.d_local.object());
     default:
-        return true;
+        return false;
     }
 }
 

--- a/groups/nts/ntsa/ntsa_host.cpp
+++ b/groups/nts/ntsa/ntsa_host.cpp
@@ -325,7 +325,7 @@ bool Host::less(const Host& other) const
     case ntsa::HostType::e_LOCAL_NAME:
         return d_localName.object().less(other.d_localName.object());
     default:
-        return true;
+        return false;
     }
 }
 

--- a/groups/nts/ntsa/ntsa_ipaddress.cpp
+++ b/groups/nts/ntsa/ntsa_ipaddress.cpp
@@ -140,7 +140,7 @@ bool IpAddress::less(const IpAddress& other) const
     case ntsa::IpAddressType::e_V6:
         return d_v6.object().less(other.d_v6.object());
     default:
-        return true;
+        return false;
     }
 }
 

--- a/groups/nts/ntsa/ntsa_notification.cpp
+++ b/groups/nts/ntsa/ntsa_notification.cpp
@@ -91,7 +91,7 @@ bool Notification::less(const Notification& other) const
     case ntsa::NotificationType::e_ZERO_COPY:
         return d_zeroCopy.object() < other.d_zeroCopy.object();
     default:
-        return true;
+        return false;
     }
 }
 

--- a/groups/nts/ntsa/ntsa_socketoption.cpp
+++ b/groups/nts/ntsa/ntsa_socketoption.cpp
@@ -800,7 +800,7 @@ bool SocketOption::less(const SocketOption& other) const
         return d_tcpCongestionControl.object() <
                other.d_tcpCongestionControl.object();
     default:
-        return true;
+        return false;
     }
 }
 


### PR DESCRIPTION
Ensure strict weak ordering by making `less` operands return `false` (not `true`!) by default (if there is nothing to compare, or all fields are equal). This is required to make STL containers and algorithms work correctly.

The existing implementations violate irreflexivity, for example, with the existing implementation:

```
ntsa::Endpoint endpoint; // ntsa::EndpointType::e_UNDEFINED
endpoint.less(endpoint); // == true, should be false for irreflexivity
```