### PR TITLE
Fix[ntcs_async.cpp]: lost wakeup on `execute`

### DIFF
--- a/groups/ntc/ntcs/ntcs_async.cpp
+++ b/groups/ntc/ntcs/ntcs_async.cpp
@@ -318,10 +318,10 @@ void* Async::State::run(Async::State* state)
     }
 
     while (state->d_runState == k_RUN_STATE_STARTED) {
+        ntccfg::ConditionMutexGuard guard(&state->d_runMutex);
+
         bdlb::NullableValue<bsls::TimeInterval> deadline =
             state->d_chronology_sp->earliest();
-
-        ntccfg::ConditionMutexGuard guard(&state->d_runMutex);
 
         if (deadline.isNull()) {
             state->d_runCondition.wait(&state->d_runMutex);


### PR DESCRIPTION
# Description

The real time point annotations t0-t4 show the exact sequence of events that causes a lost wakeup of executor.

Thread 1 (`ntcs::Async::State::run`):
```cpp
    while (state->d_runState == k_RUN_STATE_STARTED) {
        bdlb::NullableValue<bsls::TimeInterval> deadline =
            state->d_chronology_sp->earliest();  // t0 - deadline is NULL

        ntccfg::ConditionMutexGuard guard(&state->d_runMutex); // t3 - thread un-sleeps and locks the mutex

        if (deadline.isNull()) {
            state->d_runCondition.wait(&state->d_runMutex); // t4 - thread waits for signal (forever, if there are no more functors enqueued)
        }
        else {
            state->d_runCondition.timedWait(&state->d_runMutex,
                                            deadline.value());
        }

        while (state->d_chronology_sp->hasAnyScheduledOrDeferred()) {
            state->d_chronology_sp->announce(state->d_dynamic);
        }
    }
```

Thread 2 (`ntcs::Chronology::execute`):

```cpp
void Chronology::execute(const ntci::Executor::Functor& functor)
{
    {
        LockGuard lock(&d_mutex);

        bool wasEmpty = d_functorQueue.empty();
        if (wasEmpty) {
            d_functorQueue.reserve(8 * 1024);
        }
        d_functorQueue.push_back(functor);  // t1 - functor is enqueued

        if (wasEmpty) {
            d_functorQueueEmpty = false;
        }
    }

    d_interruptor_sp->interruptAll();  // t2 - mutex is locked and signal is sent
}
```

Simply, the runner thread might miss a signal from `interruptAll`.


# UT

Causes the following UT failure:

```
 500/1012 Test  #500: ntc ntcs::AsyncTest::verifyFunction .................................................***Timeout 600.01 sec


99% tests passed, 1 tests failed out of 500

Total Test time (real) = 624.04 sec

The following tests FAILED:
	500 - ntc ntcs::AsyncTest::verifyFunction (Timeout)
Errors while running CTest
FAILED: CMakeFiles/test.util 
cd /workspace/ntf-core/build && /usr/local/bin/ctest --force-new-ctest-process --stop-on-failure --output-on-failure --output-junit Testing/Temporary/Test.xml
ninja: build stopped: subcommand failed.
```