### PR TITLE
Reduce capacity to stay within multi-pool allocator ceiling

### DIFF
--- a/groups/ntc/ntcs/ntcs_chronology.cpp
+++ b/groups/ntc/ntcs/ntcs_chronology.cpp
@@ -1441,7 +1441,10 @@ void Chronology::execute(const ntci::Executor::Functor& functor)
 
         bool wasEmpty = d_functorQueue.empty();
         if (wasEmpty) {
-            d_functorQueue.reserve(8 * 1024);
+            const size_t MIN_CAPACITY = 2 * 1024;
+            BSLS_ASSERT(MIN_CAPACITY * sizeof(FunctorQueue::value_type) <
+                        d_functorQueuePool.maxPooledBlockSize());
+            d_functorQueue.reserve(MIN_CAPACITY);
         }
         d_functorQueue.push_back(functor);
 


### PR DESCRIPTION
The deferred functor queue maintained by `Chronology` is swapped out with an empty container when it is drained by `announce()`. The next call to `execute()` re-reserves capacity for many functors. The intention was for the backing memory to come from the multi-pool allocator (making the pattern of reserve-swap-reserve-swap-... much cheaper). However, the chosen capacity was larger than the maximum size of the multi-pool, causing it to perform a true heap allocation/deallocation on each cycle, which was significantly more expensive.

I've changed the constant and added an assertion to insure against future regressions. I've verified the assertion fails while running the unit tests with the original constant. 

Note that on a 64-bit test machine, `sizeof(bsl::function<void()>)` is currently 80 bytes.

---

Empirical testing shows the following reduction in overhead:

Before: 118 samples, heap allocations
<img width="38" height="115" alt="image" src="https://github.com/user-attachments/assets/006ca840-e620-4d78-83c1-65a47669cd45" />

After: 108 samples, pool allocations

<img width="36" height="50" alt="image" src="https://github.com/user-attachments/assets/99a9e08d-79c3-43ce-b8b3-12c652096572" />